### PR TITLE
Add signal APIs and reactive OpenLayers updates

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -60,10 +60,31 @@ Known init-only or rebuild-backed inputs:
 | Geometry                   | Coordinates, geometry collections, point coordinates, circle center/radius, and coordinate SRID transforms are synced.                                                                                                                                                                                                    | Geometry layout options and base geometry SRID are init-only unless the child coordinate component performs the transform.                                                                                                                                                                                                            |
 | `aol-feature`              | `id` and `properties` are synced.                                                                                                                                                                                                                                                                                         | Changing the `feature` input replaces the wrapped OL feature instance.                                                                                                                                                                                                                                                                |
 
+## Instance timing
+
+Every wrapper exposes the underlying OpenLayers object through `instance` and `instanceSignal`. Version 22 keeps both APIs.
+
+Most wrappers create their OpenLayers instance during `ngOnInit`, after Angular inputs are available. Components that need projected child components, such as child tile grids, child formats, raster child sources, or child styles, create their instance during content initialization instead.
+
+`instanceSignal()` is `undefined` until the wrapper has enough inputs and child content to create a valid OpenLayers instance. It is updated whenever ngx-ol intentionally replaces the underlying OL instance, for example when changing a constructor-only input that has a documented rebuild path.
+
+Use `instanceSignal()` when code needs to wait until the OpenLayers object is ready:
+
+```ts
+protected readonly mapComponent = viewChild.required(MapComponent);
+
+protected rotate(): void {
+  this.mapComponent().instanceSignal()?.getView().animate({
+    rotation: Math.PI / 8,
+  });
+}
+```
+
 ## Table of contents
 
 - [v22 output name changes](#v22-output-name-changes)
 - [Input reactivity notes](#input-reactivity-notes)
+- [Instance timing](#instance-timing)
 - [Modules](#modules)
 - [Map setup](#map-setup)
 - [Layer groups](#layer-groups)

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -8,26 +8,62 @@ Version 22 normalizes output names. The `ol` prefix is only used where the unpre
 
 Migration table:
 
-| Before | After |
-| --- | --- |
+| Before                 | After                |
+| ---------------------- | -------------------- |
 | `(olChangeLayerGroup)` | `(changeLayerGroup)` |
-| `(olChangeSize)` | `(changeSize)` |
-| `(olChangeTarget)` | `(changeTarget)` |
-| `(olChangeView)` | `(changeView)` |
-| `(olPostCompose)` | `(postCompose)` |
-| `(olPreCompose)` | `(preCompose)` |
-| `(olPropertyChange)` | `(propertyChange)` |
-| `(olChangeActive)` | `(changeActive)` |
-| `(olDrawAbort)` | `(drawAbort)` |
-| `(olModifyStart)` | `(modifyStart)` |
-| `(olModifyEnd)` | `(modifyEnd)` |
-| `(olSnap)` | `(snap)` |
+| `(olChangeSize)`       | `(changeSize)`       |
+| `(olChangeTarget)`     | `(changeTarget)`     |
+| `(olChangeView)`       | `(changeView)`       |
+| `(olPostCompose)`      | `(postCompose)`      |
+| `(olPreCompose)`       | `(preCompose)`       |
+| `(olPropertyChange)`   | `(propertyChange)`   |
+| `(olChangeActive)`     | `(changeActive)`     |
+| `(olDrawAbort)`        | `(drawAbort)`        |
+| `(olModifyStart)`      | `(modifyStart)`      |
+| `(olModifyEnd)`        | `(modifyEnd)`        |
+| `(olSnap)`             | `(snap)`             |
 
 `olPostRender` has been removed. Use `(postRender)`.
+
+## Input reactivity notes
+
+Most inputs are forwarded to OpenLayers with the matching setter when OpenLayers exposes one. Some OpenLayers options are constructor-only, so changing the Angular input after the component has created its OL instance will not change the existing OL object. For those inputs, recreate the wrapper component with Angular control flow if the value needs to change.
+
+Example:
+
+```html
+@if (tileJsonTheme() === 'light') {
+<aol-source-tilejson url="/tile-json/carto-light.json"></aol-source-tilejson>
+} @else {
+<aol-source-tilejson url="/tile-json/carto-dark.json"></aol-source-tilejson>
+}
+```
+
+Known init-only or rebuild-backed inputs:
+
+| Component area             | Setter-backed/live inputs                                                                                                                                                                                                                                                                                                 | Init-only or rebuild-backed inputs                                                                                                                                                                                                                                                                                                    |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aol-map`                  | `width`, `height` update map size.                                                                                                                                                                                                                                                                                        | `pixelRatio`, `keyboardEventTarget`, `maxTilesLoading`, `moveTolerance`, and `runOutsideAngular` are used when the `ol/Map` is created.                                                                                                                                                                                               |
+| `aol-view`                 | `center`, `zoom`, `maxZoom`, `minZoom`, `resolution`, `rotation`, and `constrainResolution` use OL setters. `zoomAnimation` affects future `zoom` changes.                                                                                                                                                                | `projection` recreates the `ol/View`. `constrainRotation`, `enableRotation`, `extent`, `maxResolution`, `minResolution`, `resolutions`, `zoomFactor`, `constrainOnlyCenter`, `smoothExtentConstraint`, `smoothResolutionConstraint`, `showFullExtent`, `multiWorld`, and `padding` are constructor-only unless the view is recreated. |
+| Base layers                | `extent`, `maxResolution`, `minResolution`, `maxZoom`, `minZoom`, `opacity`, `visible`, `zIndex`, `properties`, `prerender`, and `postrender` are synced.                                                                                                                                                                 | `className` and `render` are constructor-only.                                                                                                                                                                                                                                                                                        |
+| Vector layers              | `style`, `renderOrder`, and `source` are synced where supported. Heatmap `gradient`, `radius`, `blur`, and `source` are synced. Tile layer `preload`, `useInterimTilesOnError`, and `source` are synced. WebGL tile `style` and `source` are synced.                                                                      | Vector layer constructor options such as `renderBuffer`, `declutter`, `background`, `updateWhileAnimating`, `updateWhileInteracting`, `imageRatio`, `renderMode`, `weight`, `cacheSize`, `sources`, `map`, and WebGL `useInterimTilesOnError` are init-only unless the layer is recreated.                                            |
+| Tiled sources              | `aol-source-osm` syncs `url` and `tileLoadFunction`. `aol-source-xyz` syncs `url`, `urls`, `tileLoadFunction`, and `tileUrlFunction`. `aol-source-tilewms` and `aol-source-tilearcgisrest` sync `url`, `urls`, `tileLoadFunction`, and `params`; removed param keys recreate the source.                                  | Other tile source constructor options such as cache, projection, tile grid, tile size, interpolation, transition, wrap, z direction, HiDPI, gutter, server type, tile class, and reprojection settings are init-only unless the source is recreated.                                                                                  |
+| `aol-source-tilejson`      | None after init.                                                                                                                                                                                                                                                                                                          | `url`, `tileJSON`, and all other TileJSON options are init-only. Recreate the component to load a different TileJSON document.                                                                                                                                                                                                        |
+| `aol-source-tilewmts`      | `dimensions` updates with `updateDimensions()` when keys are added or changed.                                                                                                                                                                                                                                            | `url` changes and removed dimension keys recreate the source. Other WMTS options, including `layer`, `style`, `matrixSet`, `format`, `tileGrid`, request encoding, tile class, projection, and tile pixel ratio, are init-only unless the source is recreated.                                                                        |
+| Image sources              | `aol-source-imagewms` and `aol-source-imagearcgisrest` sync `url`, `imageLoadFunction`, `resolutions`, and `params`; removed param keys recreate the source.                                                                                                                                                              | `crossOrigin`, `hidpi`, `interpolate`, `projection`, `ratio`, and WMS server type are init-only. `aol-source-imagestatic` recreates the source when its inputs change.                                                                                                                                                                |
+| Vector and cluster sources | Vector source `loader` and `url` are synced. Cluster source `distance` and `minDistance` are synced.                                                                                                                                                                                                                      | Vector `features`, `format`, `strategy`, spatial index, overlaps, and wrap settings are init-only. Cluster `geometryFunction`, `wrapX`, and `createCluster` are init-only.                                                                                                                                                            |
+| Init-only source families  |                                                                                                                                                                                                                                                                                                                           | `aol-source-bingmaps`, `aol-source-geojson`, `aol-source-iiif`, `aol-source-ogcmaptile`, `aol-source-ogcvectortile`, `aol-source-utfgrid`, `aol-source-vectortile`, and `aol-source-zoomify` use their inputs when the source is created.                                                                                             |
+| Formats                    |                                                                                                                                                                                                                                                                                                                           | `aol-format-geojson` and `aol-format-mvt` inputs are init-only.                                                                                                                                                                                                                                                                       |
+| Controls                   | Attribution `collapsed`/`collapsible`, fullscreen/rotate/zoom/zoomslider/zoomtoextent `target`, mouse position `coordinateFormat`/`projection`, overview `collapsed`/`collapsible`/`rotateWithView`, and scale line `units`/`dpi` are synced.                                                                             | Default controls and most control display options such as labels, CSS class names, render callbacks, durations, source, keys, overview layers/view, scale bar options, and zoom deltas are init-only.                                                                                                                                 |
+| Interactions               | Draw `trace`, extent `extent`, mouse wheel zoom `useAnchor`, select `hitTolerance`, and translate `hitTolerance` are synced. Draw recreates the interaction for other input changes.                                                                                                                                      | Default interactions and most interaction constructor options are init-only: predicates/conditions, durations, deltas, kinetic settings, feature collections, layers, filters, styles, sources, format constructors, history/link params, snap options, and modify options.                                                           |
+| Styles                     | Fill/stroke/text/style setters are synced where OpenLayers exposes setters. Circle style syncs radius, displacement, scale, rotation, rotate-with-view, fill, and stroke. Icon syncs anchor, displacement, opacity, rotate-with-view, rotation, scale, and recreates for `src`. Regular shape syncs fill/stroke directly. | Icon image construction options such as anchor units/origin, color, crossOrigin, `img`, offset/origin, width, height, size, and declutter mode are init-only. Regular shape structural options such as points, radius, radius2, angle, displacement, rotation, rotate-with-view, scale, and declutter mode recreate the style image.  |
+| Geometry                   | Coordinates, geometry collections, point coordinates, circle center/radius, and coordinate SRID transforms are synced.                                                                                                                                                                                                    | Geometry layout options and base geometry SRID are init-only unless the child coordinate component performs the transform.                                                                                                                                                                                                            |
+| `aol-feature`              | `id` and `properties` are synced.                                                                                                                                                                                                                                                                                         | Changing the `feature` input replaces the wrapped OL feature instance.                                                                                                                                                                                                                                                                |
 
 ## Table of contents
 
 - [v22 output name changes](#v22-output-name-changes)
+- [Input reactivity notes](#input-reactivity-notes)
 - [Modules](#modules)
 - [Map setup](#map-setup)
 - [Layer groups](#layer-groups)
@@ -502,7 +538,8 @@ Inputs:
 <aol-layer-image>
   <aol-source-imagewms
     [url]="'https://example.com/geoserver/wms'"
-    [params]="{ LAYERS: 'workspace:layer' }">
+    [params]="{ LAYERS: 'workspace:layer' }"
+  >
   </aol-source-imagewms>
 </aol-layer-image>
 ```
@@ -1338,9 +1375,7 @@ Inputs:
 ```html
 <aol-overlay [position]="[-907904, 7065770]">
   <aol-content>
-    <div class="my-overlay-class">
-      Overlay content
-    </div>
+    <div class="my-overlay-class">Overlay content</div>
   </aol-content>
 </aol-overlay>
 ```

--- a/projects/ngx-ol/src/lib/attribution.component.spec.ts
+++ b/projects/ngx-ol/src/lib/attribution.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../public-api';
@@ -10,8 +10,7 @@ import { AttributionComponent } from './attribution.component';
   imports: [AngularOpenlayersModule],
 })
 class AttributionHostComponent {
-  @ViewChild(AttributionComponent)
-  attribution!: AttributionComponent;
+  readonly attribution = viewChild.required<AttributionComponent>(AttributionComponent);
 }
 
 describe('AttributionComponent', () => {
@@ -31,6 +30,6 @@ describe('AttributionComponent', () => {
   });
 
   it('captures its projected markup as the attribution label', () => {
-    expect(fixture.componentInstance.attribution.label).toBe('Data Provider');
+    expect(fixture.componentInstance.attribution().label).toBe('Data Provider');
   });
 });

--- a/projects/ngx-ol/src/lib/attribution.component.ts
+++ b/projects/ngx-ol/src/lib/attribution.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, inject } from '@angular/core';
 
 @Component({
   selector: 'aol-attribution',
@@ -7,7 +7,7 @@ import { Component, ElementRef, OnInit } from '@angular/core';
 export class AttributionComponent implements OnInit {
   label: string;
 
-  constructor(private elementRef: ElementRef) {}
+  private readonly elementRef = inject(ElementRef);
 
   ngOnInit() {
     this.label = this.elementRef.nativeElement.innerHTML;

--- a/projects/ngx-ol/src/lib/attributions.component.spec.ts
+++ b/projects/ngx-ol/src/lib/attributions.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../public-api';
@@ -27,11 +27,9 @@ class AttributionsHostComponent {
   zoom = 2;
   url = 'https://example.com/{z}/{x}/{y}.png';
 
-  @ViewChild(AttributionsComponent)
-  attributions!: AttributionsComponent;
+  readonly attributions = viewChild.required<AttributionsComponent>(AttributionsComponent);
 
-  @ViewChild(SourceXYZComponent)
-  source!: SourceXYZComponent;
+  readonly source = viewChild.required<SourceXYZComponent>(SourceXYZComponent);
 }
 
 describe('AttributionsComponent', () => {
@@ -51,8 +49,8 @@ describe('AttributionsComponent', () => {
   });
 
   it('collects child attribution labels and applies them to the source', () => {
-    expect(fixture.componentInstance.attributions.instance).toEqual(['First', 'Second']);
-    expect(fixture.componentInstance.source.instance.getAttributions()?.({} as any)).toEqual([
+    expect(fixture.componentInstance.attributions().instance).toEqual(['First', 'Second']);
+    expect(fixture.componentInstance.source().instance.getAttributions()?.({} as any)).toEqual([
       'First',
       'Second',
     ]);

--- a/projects/ngx-ol/src/lib/attributions.component.ts
+++ b/projects/ngx-ol/src/lib/attributions.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ContentChildren, Host, QueryList, signal } from '@angular/core';
+import { AfterViewInit, Component, Host, contentChildren, signal } from '@angular/core';
 import { SourceComponent } from './sources/source.component';
 import { AttributionComponent } from './attribution.component';
 
@@ -7,8 +7,7 @@ import { AttributionComponent } from './attribution.component';
   template: '<ng-content></ng-content>',
 })
 export class AttributionsComponent implements AfterViewInit {
-  @ContentChildren(AttributionComponent)
-  attributions: QueryList<AttributionComponent>;
+  protected readonly attributions = contentChildren(AttributionComponent);
 
   instance: Array<string>;
 
@@ -27,8 +26,10 @@ export class AttributionsComponent implements AfterViewInit {
 
   /* we can do this at the very end */
   ngAfterViewInit() {
-    if (this.attributions.length) {
-      this.setInstance(this.attributions.map((cmp) => cmp.label));
+    const attributions = this.attributions();
+
+    if (attributions.length) {
+      this.setInstance(attributions.map((cmp) => cmp.label));
       // console.log('setting attributions:', this.instance);
       this.source.instance.setAttributions(this.instance);
     }

--- a/projects/ngx-ol/src/lib/attributions.component.ts
+++ b/projects/ngx-ol/src/lib/attributions.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ContentChildren, Host, QueryList } from '@angular/core';
+import { AfterViewInit, Component, ContentChildren, Host, QueryList, signal } from '@angular/core';
 import { SourceComponent } from './sources/source.component';
 import { AttributionComponent } from './attribution.component';
 
@@ -12,12 +12,23 @@ export class AttributionsComponent implements AfterViewInit {
 
   instance: Array<string>;
 
+  protected readonly _instanceSignal = signal<Array<string> | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Array<string>): Array<string> {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Host() private source: SourceComponent) {}
 
   /* we can do this at the very end */
   ngAfterViewInit() {
     if (this.attributions.length) {
-      this.instance = this.attributions.map((cmp) => cmp.label);
+      this.setInstance(this.attributions.map((cmp) => cmp.label));
       // console.log('setting attributions:', this.instance);
       this.source.instance.setAttributions(this.instance);
     }

--- a/projects/ngx-ol/src/lib/attributions.component.ts
+++ b/projects/ngx-ol/src/lib/attributions.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, Host, contentChildren, signal } from '@angular/core';
+import { AfterViewInit, Component, contentChildren, inject, signal } from '@angular/core';
 import { SourceComponent } from './sources/source.component';
 import { AttributionComponent } from './attribution.component';
 
@@ -22,7 +22,7 @@ export class AttributionsComponent implements AfterViewInit {
 
     return instance;
   }
-  constructor(@Host() private source: SourceComponent) {}
+  private readonly source = inject(SourceComponent, { host: true });
 
   /* we can do this at the very end */
   ngAfterViewInit() {

--- a/projects/ngx-ol/src/lib/collectioncoordinates.component.spec.ts
+++ b/projects/ngx-ol/src/lib/collectioncoordinates.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { fromLonLat } from 'ol/proj';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -42,11 +42,11 @@ class CollectionCoordinatesHostComponent {
     ],
   ];
 
-  @ViewChild(CollectionCoordinatesComponent)
-  collectionCoordinates!: CollectionCoordinatesComponent;
+  readonly collectionCoordinates = viewChild.required<CollectionCoordinatesComponent>(
+    CollectionCoordinatesComponent,
+  );
 
-  @ViewChild(GeometryPolygonComponent)
-  geometry!: GeometryPolygonComponent;
+  readonly geometry = viewChild.required<GeometryPolygonComponent>(GeometryPolygonComponent);
 }
 
 @Component({
@@ -80,8 +80,7 @@ class LinestringCollectionCoordinatesHostComponent {
     [1, 1],
   ];
 
-  @ViewChild(GeometryLinestringComponent)
-  geometry!: GeometryLinestringComponent;
+  readonly geometry = viewChild.required<GeometryLinestringComponent>(GeometryLinestringComponent);
 }
 
 @Component({
@@ -119,8 +118,9 @@ class MultiPolygonCollectionCoordinatesHostComponent {
     ],
   ];
 
-  @ViewChild(GeometryMultiPolygonComponent)
-  geometry!: GeometryMultiPolygonComponent;
+  readonly geometry = viewChild.required<GeometryMultiPolygonComponent>(
+    GeometryMultiPolygonComponent,
+  );
 }
 
 describe('CollectionCoordinatesComponent', () => {
@@ -144,7 +144,7 @@ describe('CollectionCoordinatesComponent', () => {
   });
 
   it('projects nested coordinate arrays into the host geometry', () => {
-    expect(fixture.componentInstance.geometry.instance.getCoordinates()).toEqual(
+    expect(fixture.componentInstance.geometry().instance.getCoordinates()).toEqual(
       fixture.componentInstance.coordinates,
     );
   });
@@ -152,7 +152,7 @@ describe('CollectionCoordinatesComponent', () => {
   it('transforms line string coordinates into the map projection', () => {
     const linestringFixture = TestBed.createComponent(LinestringCollectionCoordinatesHostComponent);
     linestringFixture.detectChanges();
-    const coordinates = linestringFixture.componentInstance.geometry.instance.getCoordinates();
+    const coordinates = linestringFixture.componentInstance.geometry().instance.getCoordinates();
 
     expect(coordinates[0]).toEqual(fromLonLat([0, 0]));
     expect(coordinates[1][0]).toBeCloseTo(fromLonLat([1, 1])[0]);
@@ -169,7 +169,7 @@ describe('CollectionCoordinatesComponent', () => {
 
     linestringFixture.detectChanges();
 
-    expect(linestringFixture.componentInstance.geometry.instance.getCoordinates()).toEqual(
+    expect(linestringFixture.componentInstance.geometry().instance.getCoordinates()).toEqual(
       linestringFixture.componentInstance.coordinates,
     );
 
@@ -181,7 +181,7 @@ describe('CollectionCoordinatesComponent', () => {
       MultiPolygonCollectionCoordinatesHostComponent,
     );
     multiPolygonFixture.detectChanges();
-    const coordinates = multiPolygonFixture.componentInstance.geometry.instance.getCoordinates();
+    const coordinates = multiPolygonFixture.componentInstance.geometry().instance.getCoordinates();
     const expected = fromLonLat([1, 1]);
 
     expect(coordinates[0][0][1][0]).toBeCloseTo(expected[0]);

--- a/projects/ngx-ol/src/lib/collectioncoordinates.component.ts
+++ b/projects/ngx-ol/src/lib/collectioncoordinates.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, OnInit, Optional, SimpleChanges, input } from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges, inject, input } from '@angular/core';
 import { MapComponent } from './map.component';
 import { GeometryLinestringComponent } from './geom/geometrylinestring.component';
 import { GeometryPolygonComponent } from './geom/geometrypolygon.component';
@@ -18,26 +18,29 @@ export class CollectionCoordinatesComponent implements OnChanges, OnInit {
   srid = input('EPSG:3857');
 
   private host: any;
+  private readonly map = inject(MapComponent);
+  private readonly geometryLinestring = inject(GeometryLinestringComponent, { optional: true });
+  private readonly geometryPolygon = inject(GeometryPolygonComponent, { optional: true });
+  private readonly geometryMultipoint = inject(GeometryMultiPointComponent, { optional: true });
+  private readonly geometryMultilinestring = inject(GeometryMultiLinestringComponent, {
+    optional: true,
+  });
+  private readonly geometryMultipolygon = inject(GeometryMultiPolygonComponent, {
+    optional: true,
+  });
   private mapSrid = 'EPSG:3857';
 
-  constructor(
-    private map: MapComponent,
-    @Optional() geometryLinestring: GeometryLinestringComponent,
-    @Optional() geometryPolygon: GeometryPolygonComponent,
-    @Optional() geometryMultipoint: GeometryMultiPointComponent,
-    @Optional() geometryMultilinestring: GeometryMultiLinestringComponent,
-    @Optional() geometryMultipolygon: GeometryMultiPolygonComponent,
-  ) {
-    if (!!geometryLinestring) {
-      this.host = geometryLinestring;
-    } else if (!!geometryPolygon) {
-      this.host = geometryPolygon;
-    } else if (!!geometryMultipoint) {
-      this.host = geometryMultipoint;
-    } else if (!!geometryMultilinestring) {
-      this.host = geometryMultilinestring;
-    } else if (!!geometryMultipolygon) {
-      this.host = geometryMultipolygon;
+  constructor() {
+    if (!!this.geometryLinestring) {
+      this.host = this.geometryLinestring;
+    } else if (!!this.geometryPolygon) {
+      this.host = this.geometryPolygon;
+    } else if (!!this.geometryMultipoint) {
+      this.host = this.geometryMultipoint;
+    } else if (!!this.geometryMultilinestring) {
+      this.host = this.geometryMultilinestring;
+    } else if (!!this.geometryMultipolygon) {
+      this.host = this.geometryMultipolygon;
     } else {
       throw new Error('aol-collection-coordinates must be a child of a geometry component');
     }

--- a/projects/ngx-ol/src/lib/collectioncoordinates.component.ts
+++ b/projects/ngx-ol/src/lib/collectioncoordinates.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, Optional, SimpleChanges } from '@angular/core';
+import { Component, OnChanges, OnInit, Optional, SimpleChanges, input } from '@angular/core';
 import { MapComponent } from './map.component';
 import { GeometryLinestringComponent } from './geom/geometrylinestring.component';
 import { GeometryPolygonComponent } from './geom/geometrypolygon.component';
@@ -14,10 +14,8 @@ import { ObjectEvent } from 'ol/Object';
   template: ` <div class="aol-collection-coordinates"></div> `,
 })
 export class CollectionCoordinatesComponent implements OnChanges, OnInit {
-  @Input()
-  coordinates: Coordinate[] | Coordinate[][] | Coordinate[][][] | Array<number>;
-  @Input()
-  srid = 'EPSG:3857';
+  coordinates = input.required<Coordinate[] | Coordinate[][] | Coordinate[][][] | Array<number>>();
+  srid = input('EPSG:3857');
 
   private host: any;
   private mapSrid = 'EPSG:3857';
@@ -64,25 +62,25 @@ export class CollectionCoordinatesComponent implements OnChanges, OnInit {
     let transformedCoordinates: Coordinate[] | Coordinate[][] | Coordinate[][][] | Array<number> =
       [];
 
-    if (this.srid === this.mapSrid) {
-      transformedCoordinates = this.coordinates;
+    if (this.srid() === this.mapSrid) {
+      transformedCoordinates = this.coordinates();
     } else {
       switch (this.host.componentType) {
         case 'geometry-linestring':
         case 'geometry-multipoint':
-          transformedCoordinates = (this.coordinates as Coordinate[]).map((c) =>
-            transform(c, this.srid, this.mapSrid),
+          transformedCoordinates = (this.coordinates() as Coordinate[]).map((c) =>
+            transform(c, this.srid(), this.mapSrid),
           );
           break;
         case 'geometry-polygon':
         case 'geometry-multilinestring':
-          transformedCoordinates = (this.coordinates as Coordinate[][]).map((cc) =>
-            cc.map((c) => transform(c, this.srid, this.mapSrid)),
+          transformedCoordinates = (this.coordinates() as Coordinate[][]).map((cc) =>
+            cc.map((c) => transform(c, this.srid(), this.mapSrid)),
           );
           break;
         case 'geometry-multipolygon':
-          transformedCoordinates = (this.coordinates as Coordinate[][][]).map((ccc) =>
-            ccc.map((cc) => cc.map((c) => transform(c, this.srid, this.mapSrid))),
+          transformedCoordinates = (this.coordinates() as Coordinate[][][]).map((ccc) =>
+            ccc.map((cc) => cc.map((c) => transform(c, this.srid(), this.mapSrid))),
           );
           break;
       }

--- a/projects/ngx-ol/src/lib/collectioncoordinates.component.ts
+++ b/projects/ngx-ol/src/lib/collectioncoordinates.component.ts
@@ -14,10 +14,12 @@ import { ObjectEvent } from 'ol/Object';
   template: ` <div class="aol-collection-coordinates"></div> `,
 })
 export class CollectionCoordinatesComponent implements OnChanges, OnInit {
-  coordinates = input.required<Coordinate[] | Coordinate[][] | Coordinate[][][] | Array<number>>();
-  srid = input('EPSG:3857');
+  readonly coordinates = input.required<
+    Coordinate[] | Coordinate[][] | Coordinate[][][] | Array<number>
+  >();
+  readonly srid = input('EPSG:3857');
 
-  private host: any;
+  private readonly host: any;
   private readonly map = inject(MapComponent);
   private readonly geometryLinestring = inject(GeometryLinestringComponent, { optional: true });
   private readonly geometryPolygon = inject(GeometryPolygonComponent, { optional: true });

--- a/projects/ngx-ol/src/lib/content.component.spec.ts
+++ b/projects/ngx-ol/src/lib/content.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../public-api';
@@ -14,8 +14,7 @@ import { ContentComponent } from './content.component';
   imports: [AngularOpenlayersModule],
 })
 class ContentHostComponent {
-  @ViewChild(ContentComponent)
-  content!: ContentComponent;
+  readonly content = viewChild.required<ContentComponent>(ContentComponent);
 }
 
 describe('ContentComponent', () => {
@@ -35,7 +34,7 @@ describe('ContentComponent', () => {
   });
 
   it('exposes the projected host element through Angular queries', () => {
-    expect(fixture.componentInstance.content.elementRef.nativeElement.textContent).toContain(
+    expect(fixture.componentInstance.content().elementRef.nativeElement.textContent).toContain(
       'Projected content',
     );
   });

--- a/projects/ngx-ol/src/lib/content.component.ts
+++ b/projects/ngx-ol/src/lib/content.component.ts
@@ -1,9 +1,9 @@
-import { Component, ElementRef } from '@angular/core';
+import { Component, ElementRef, inject } from '@angular/core';
 
 @Component({
   selector: 'aol-content',
   template: '<ng-content></ng-content>',
 })
 export class ContentComponent {
-  constructor(public elementRef: ElementRef) {}
+  readonly elementRef = inject(ElementRef);
 }

--- a/projects/ngx-ol/src/lib/controls/attribution.component.spec.ts
+++ b/projects/ngx-ol/src/lib/controls/attribution.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -20,11 +20,9 @@ class ControlAttributionHostComponent {
   zoom = 2;
   collapsed = false;
 
-  @ViewChild(ControlAttributionComponent)
-  control!: ControlAttributionComponent;
+  readonly control = viewChild.required<ControlAttributionComponent>(ControlAttributionComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('ControlAttributionComponent', () => {
@@ -45,8 +43,8 @@ describe('ControlAttributionComponent', () => {
 
   it('adds and removes an attribution control with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const control = host.control.instance;
+    const map = host.map().instance;
+    const control = host.control().instance;
 
     expect(map.getControls().getArray()).toContain(control);
 

--- a/projects/ngx-ol/src/lib/controls/attribution.component.ts
+++ b/projects/ngx-ol/src/lib/controls/attribution.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, ElementRef, OnDestroy, OnInit, input, signal } from '@angular/core';
 import Attribution from 'ol/control/Attribution';
 import { Options } from 'ol/control/Attribution';
 import MapEvent from 'ol/MapEvent';
@@ -9,27 +9,26 @@ import { MapComponent } from '../map.component';
   template: ``,
 })
 export class ControlAttributionComponent implements OnInit, OnDestroy {
-  @Input()
-  className?: string;
-  @Input()
-  collapsible?: boolean;
-  @Input()
-  collapsed?: boolean;
-  @Input()
-  tipLabel?: string;
-  @Input()
-  label?: string | HTMLElement;
-  @Input()
-  expandClassName?: string;
-  @Input()
-  collapseLabel?: string | HTMLElement;
-  @Input()
-  collapseClassName?: string;
-  @Input()
-  render?: (event: MapEvent) => void;
+  className = input<string>();
+  collapsible = input<boolean>();
+  collapsed = input<boolean>();
+  tipLabel = input<string>();
+  label = input<string | HTMLElement>();
+  expandClassName = input<string>();
+  collapseLabel = input<string | HTMLElement>();
+  collapseClassName = input<string>();
+  render = input<(event: MapEvent) => void>();
 
   public componentType = 'control';
   instance: Attribution;
+  protected readonly _instanceSignal = signal<Attribution | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Attribution): Attribution {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   target: HTMLElement;
 
   constructor(
@@ -40,7 +39,7 @@ export class ControlAttributionComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.target = this.element.nativeElement;
     // console.log('ol.control.Attribution init: ', this);
-    this.instance = new Attribution(this.createOptions());
+    this.setInstance(new Attribution(this.createOptions()));
     this.map.instance.addControl(this.instance);
   }
 
@@ -51,15 +50,15 @@ export class ControlAttributionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      className: this.className,
-      collapsible: this.collapsible,
-      collapsed: this.collapsed,
-      tipLabel: this.tipLabel,
-      label: this.label,
-      expandClassName: this.expandClassName,
-      collapseLabel: this.collapseLabel,
-      collapseClassName: this.collapseClassName,
-      render: this.render,
+      className: this.className(),
+      collapsible: this.collapsible(),
+      collapsed: this.collapsed(),
+      tipLabel: this.tipLabel(),
+      label: this.label(),
+      expandClassName: this.expandClassName(),
+      collapseLabel: this.collapseLabel(),
+      collapseClassName: this.collapseClassName(),
+      render: this.render(),
       target: this.target,
     };
   }

--- a/projects/ngx-ol/src/lib/controls/attribution.component.ts
+++ b/projects/ngx-ol/src/lib/controls/attribution.component.ts
@@ -18,17 +18,17 @@ import { MapComponent } from '../map.component';
   template: ``,
 })
 export class ControlAttributionComponent implements OnInit, OnChanges, OnDestroy {
-  className = input<string>();
-  collapsible = input<boolean>();
-  collapsed = input<boolean>();
-  tipLabel = input<string>();
-  label = input<string | HTMLElement>();
-  expandClassName = input<string>();
-  collapseLabel = input<string | HTMLElement>();
-  collapseClassName = input<string>();
-  render = input<(event: MapEvent) => void>();
+  readonly className = input<string>();
+  readonly collapsible = input<boolean>();
+  readonly collapsed = input<boolean>();
+  readonly tipLabel = input<string>();
+  readonly label = input<string | HTMLElement>();
+  readonly expandClassName = input<string>();
+  readonly collapseLabel = input<string | HTMLElement>();
+  readonly collapseClassName = input<string>();
+  readonly render = input<(event: MapEvent) => void>();
 
-  public componentType = 'control';
+  readonly componentType: string = 'control';
   instance: Attribution;
   protected readonly _instanceSignal = signal<Attribution | undefined>(undefined);
   readonly instanceSignal = this._instanceSignal.asReadonly();
@@ -41,8 +41,8 @@ export class ControlAttributionComponent implements OnInit, OnChanges, OnDestroy
   target: HTMLElement;
 
   constructor(
-    private map: MapComponent,
-    private element: ElementRef,
+    private readonly map: MapComponent,
+    private readonly element: ElementRef,
   ) {}
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/controls/attribution.component.ts
+++ b/projects/ngx-ol/src/lib/controls/attribution.component.ts
@@ -1,4 +1,13 @@
-import { Component, ElementRef, OnDestroy, OnInit, input, signal } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import Attribution from 'ol/control/Attribution';
 import { Options } from 'ol/control/Attribution';
 import MapEvent from 'ol/MapEvent';
@@ -8,7 +17,7 @@ import { MapComponent } from '../map.component';
   selector: 'aol-control-attribution',
   template: ``,
 })
-export class ControlAttributionComponent implements OnInit, OnDestroy {
+export class ControlAttributionComponent implements OnInit, OnChanges, OnDestroy {
   className = input<string>();
   collapsible = input<boolean>();
   collapsed = input<boolean>();
@@ -46,6 +55,18 @@ export class ControlAttributionComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     // console.log('removing aol-control-attribution');
     this.map.instance.removeControl(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (!this.instance) {
+      return;
+    }
+    if (changes.collapsible?.currentValue !== undefined) {
+      this.instance.setCollapsible(changes.collapsible.currentValue);
+    }
+    if (changes.collapsed?.currentValue !== undefined) {
+      this.instance.setCollapsed(changes.collapsed.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/controls/control.component.spec.ts
+++ b/projects/ngx-ol/src/lib/controls/control.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -21,11 +21,9 @@ class ControlHostComponent {
   center = [0, 0];
   zoom = 2;
 
-  @ViewChild(ControlComponent)
-  control!: ControlComponent;
+  readonly control = viewChild.required<ControlComponent>(ControlComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('ControlComponent', () => {
@@ -46,8 +44,8 @@ describe('ControlComponent', () => {
 
   it('projects custom content into an OpenLayers control attached to the map', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const control = host.control.instance;
+    const map = host.map().instance;
+    const control = host.control().instance;
 
     expect(map.getControls().getArray()).toContain(control);
     expect(fixture!.nativeElement.textContent).toContain('Custom');

--- a/projects/ngx-ol/src/lib/controls/control.component.ts
+++ b/projects/ngx-ol/src/lib/controls/control.component.ts
@@ -11,7 +11,7 @@ import { ContentComponent } from '../content.component';
 export class ControlComponent implements OnInit, OnDestroy {
   protected readonly content = contentChild(ContentComponent);
 
-  public componentType = 'control';
+  readonly componentType: string = 'control';
   instance: Control;
   protected readonly _instanceSignal = signal<Control | undefined>(undefined);
   readonly instanceSignal = this._instanceSignal.asReadonly();

--- a/projects/ngx-ol/src/lib/controls/control.component.ts
+++ b/projects/ngx-ol/src/lib/controls/control.component.ts
@@ -1,4 +1,4 @@
-import { Component, ContentChild, OnDestroy, OnInit, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, contentChild, signal } from '@angular/core';
 import Control from 'ol/control/Control';
 import { Options } from 'ol/control/Control';
 import { MapComponent } from '../map.component';
@@ -9,8 +9,7 @@ import { ContentComponent } from '../content.component';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlComponent implements OnInit, OnDestroy {
-  @ContentChild(ContentComponent, { static: true })
-  content: ContentComponent;
+  protected readonly content = contentChild(ContentComponent);
 
   public componentType = 'control';
   instance: Control;
@@ -27,8 +26,10 @@ export class ControlComponent implements OnInit, OnDestroy {
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    if (this.content) {
-      this.element = this.content.elementRef.nativeElement;
+    const content = this.content();
+
+    if (content) {
+      this.element = content.elementRef.nativeElement;
       this.setInstance(new Control(this.createOptions()));
       this.map.instance.addControl(this.instance);
     }

--- a/projects/ngx-ol/src/lib/controls/control.component.ts
+++ b/projects/ngx-ol/src/lib/controls/control.component.ts
@@ -1,4 +1,4 @@
-import { Component, ContentChild, OnDestroy, OnInit } from '@angular/core';
+import { Component, ContentChild, OnDestroy, OnInit, signal } from '@angular/core';
 import Control from 'ol/control/Control';
 import { Options } from 'ol/control/Control';
 import { MapComponent } from '../map.component';
@@ -14,6 +14,14 @@ export class ControlComponent implements OnInit, OnDestroy {
 
   public componentType = 'control';
   instance: Control;
+  protected readonly _instanceSignal = signal<Control | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Control): Control {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   element: HTMLElement;
 
   constructor(private map: MapComponent) {}
@@ -21,7 +29,7 @@ export class ControlComponent implements OnInit, OnDestroy {
   ngOnInit() {
     if (this.content) {
       this.element = this.content.elementRef.nativeElement;
-      this.instance = new Control(this.createOptions());
+      this.setInstance(new Control(this.createOptions()));
       this.map.instance.addControl(this.instance);
     }
   }

--- a/projects/ngx-ol/src/lib/controls/control.component.ts
+++ b/projects/ngx-ol/src/lib/controls/control.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, contentChild, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, contentChild, signal, inject } from '@angular/core';
 import Control from 'ol/control/Control';
 import { Options } from 'ol/control/Control';
 import { MapComponent } from '../map.component';
@@ -23,7 +23,7 @@ export class ControlComponent implements OnInit, OnDestroy {
   }
   element: HTMLElement;
 
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     const content = this.content();

--- a/projects/ngx-ol/src/lib/controls/default.component.spec.ts
+++ b/projects/ngx-ol/src/lib/controls/default.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -21,11 +21,9 @@ class DefaultControlHostComponent {
   showZoom = true;
   showRotate = true;
 
-  @ViewChild(DefaultControlComponent)
-  control!: DefaultControlComponent;
+  readonly control = viewChild.required<DefaultControlComponent>(DefaultControlComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('DefaultControlComponent', () => {
@@ -46,8 +44,8 @@ describe('DefaultControlComponent', () => {
 
   it('adds and removes the default controls collection with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const controls = host.control.instance.getArray();
+    const map = host.map().instance;
+    const controls = host.control().instance.getArray();
 
     expect(controls.length).toBeGreaterThan(0);
     controls.forEach((control) => {

--- a/projects/ngx-ol/src/lib/controls/default.component.ts
+++ b/projects/ngx-ol/src/lib/controls/default.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, Input } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import Control from 'ol/control/Control';
 import { defaults } from 'ol/control/defaults';
 import { DefaultsOptions } from 'ol/control/defaults';
@@ -14,26 +14,31 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class DefaultControlComponent implements OnInit, OnDestroy {
-  @Input()
-  attribution?: boolean;
-  @Input()
-  attributionOptions?: AttributionOptions;
-  @Input()
-  rotate?: boolean;
-  @Input()
-  rotateOptions?: RotateOptions;
-  @Input()
-  zoom?: boolean;
-  @Input()
-  zoomOptions?: ZoomOptions;
+  attribution = input<boolean>();
+  attributionOptions = input<AttributionOptions>();
+  rotate = input<boolean>();
+  rotateOptions = input<RotateOptions>();
+  zoom = input<boolean>();
+  zoomOptions = input<ZoomOptions>();
 
   instance: Collection<Control>;
 
+  protected readonly _instanceSignal = signal<Collection<Control> | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Collection<Control>): Collection<Control> {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
     // console.log('ol.control.defaults init: ', this);
-    this.instance = defaults(this.createOptions());
+    this.setInstance(defaults(this.createOptions()));
     this.instance.forEach((c) => this.map.instance.addControl(c));
   }
 
@@ -44,12 +49,12 @@ export class DefaultControlComponent implements OnInit, OnDestroy {
 
   private createOptions(): DefaultsOptions {
     return {
-      attribution: this.attribution,
-      attributionOptions: this.attributionOptions,
-      rotate: this.rotate,
-      rotateOptions: this.rotateOptions,
-      zoom: this.zoom,
-      zoomOptions: this.zoomOptions,
+      attribution: this.attribution(),
+      attributionOptions: this.attributionOptions(),
+      rotate: this.rotate(),
+      rotateOptions: this.rotateOptions(),
+      zoom: this.zoom(),
+      zoomOptions: this.zoomOptions(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/controls/default.component.ts
+++ b/projects/ngx-ol/src/lib/controls/default.component.ts
@@ -14,12 +14,12 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class DefaultControlComponent implements OnInit, OnDestroy {
-  attribution = input<boolean>();
-  attributionOptions = input<AttributionOptions>();
-  rotate = input<boolean>();
-  rotateOptions = input<RotateOptions>();
-  zoom = input<boolean>();
-  zoomOptions = input<ZoomOptions>();
+  readonly attribution = input<boolean>();
+  readonly attributionOptions = input<AttributionOptions>();
+  readonly rotate = input<boolean>();
+  readonly rotateOptions = input<RotateOptions>();
+  readonly zoom = input<boolean>();
+  readonly zoomOptions = input<ZoomOptions>();
 
   instance: Collection<Control>;
 

--- a/projects/ngx-ol/src/lib/controls/default.component.ts
+++ b/projects/ngx-ol/src/lib/controls/default.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import Control from 'ol/control/Control';
 import { defaults } from 'ol/control/defaults';
 import { DefaultsOptions } from 'ol/control/defaults';
@@ -34,7 +34,7 @@ export class DefaultControlComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     // console.log('ol.control.defaults init: ', this);

--- a/projects/ngx-ol/src/lib/controls/fullscreen.component.spec.ts
+++ b/projects/ngx-ol/src/lib/controls/fullscreen.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -19,11 +19,9 @@ class ControlFullScreenHostComponent {
   center = [0, 0];
   zoom = 2;
 
-  @ViewChild(ControlFullScreenComponent)
-  control!: ControlFullScreenComponent;
+  readonly control = viewChild.required<ControlFullScreenComponent>(ControlFullScreenComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('ControlFullScreenComponent', () => {
@@ -44,8 +42,8 @@ describe('ControlFullScreenComponent', () => {
 
   it('adds and removes a fullscreen control with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const control = host.control.instance;
+    const map = host.map().instance;
+    const control = host.control().instance;
 
     expect(map.getControls().getArray()).toContain(control);
 

--- a/projects/ngx-ol/src/lib/controls/fullscreen.component.ts
+++ b/projects/ngx-ol/src/lib/controls/fullscreen.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import {
+  Component,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import FullScreen from 'ol/control/FullScreen';
 import { Options } from 'ol/control/FullScreen';
 import { MapComponent } from '../map.component';
@@ -7,7 +15,7 @@ import { MapComponent } from '../map.component';
   selector: 'aol-control-fullscreen',
   template: ` <ng-content></ng-content> `,
 })
-export class ControlFullScreenComponent implements OnInit, OnDestroy {
+export class ControlFullScreenComponent implements OnInit, OnChanges, OnDestroy {
   className = input<string>();
   label = input<string | HTMLElement | Text>();
   labelActive = input<string | HTMLElement | Text>();
@@ -43,6 +51,12 @@ export class ControlFullScreenComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     // console.log('removing aol-control-fullscreen');
     this.map.instance.removeControl(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.instance && changes.target?.currentValue !== undefined) {
+      this.instance.setTarget(changes.target.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/controls/fullscreen.component.ts
+++ b/projects/ngx-ol/src/lib/controls/fullscreen.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import FullScreen from 'ol/control/FullScreen';
 import { Options } from 'ol/control/FullScreen';
 import { MapComponent } from '../map.component';
@@ -8,33 +8,35 @@ import { MapComponent } from '../map.component';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlFullScreenComponent implements OnInit, OnDestroy {
-  @Input()
-  className?: string;
-  @Input()
-  label?: string | HTMLElement | Text;
-  @Input()
-  labelActive?: string | HTMLElement | Text;
-  @Input()
-  activeClassName?: string;
-  @Input()
-  inactiveClassName?: string;
-  @Input()
-  tipLabel?: string;
-  @Input()
-  keys?: boolean;
-  @Input()
-  target?: string | HTMLElement;
-  @Input()
-  source?: string | HTMLElement;
+  className = input<string>();
+  label = input<string | HTMLElement | Text>();
+  labelActive = input<string | HTMLElement | Text>();
+  activeClassName = input<string>();
+  inactiveClassName = input<string>();
+  tipLabel = input<string>();
+  keys = input<boolean>();
+  target = input<string | HTMLElement>();
+  source = input<string | HTMLElement>();
 
   instance: FullScreen;
 
+  protected readonly _instanceSignal = signal<FullScreen | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: FullScreen): FullScreen {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {
     // console.log('instancing aol-control-fullscreen');
   }
 
   ngOnInit() {
-    this.instance = new FullScreen(this.createOptions());
+    this.setInstance(new FullScreen(this.createOptions()));
     this.map.instance.addControl(this.instance);
   }
 
@@ -45,15 +47,15 @@ export class ControlFullScreenComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      className: this.className,
-      label: this.label,
-      labelActive: this.labelActive,
-      activeClassName: this.activeClassName,
-      inactiveClassName: this.inactiveClassName,
-      tipLabel: this.tipLabel,
-      keys: this.keys,
-      target: this.target,
-      source: this.source,
+      className: this.className(),
+      label: this.label(),
+      labelActive: this.labelActive(),
+      activeClassName: this.activeClassName(),
+      inactiveClassName: this.inactiveClassName(),
+      tipLabel: this.tipLabel(),
+      keys: this.keys(),
+      target: this.target(),
+      source: this.source(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/controls/fullscreen.component.ts
+++ b/projects/ngx-ol/src/lib/controls/fullscreen.component.ts
@@ -16,15 +16,15 @@ import { MapComponent } from '../map.component';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlFullScreenComponent implements OnInit, OnChanges, OnDestroy {
-  className = input<string>();
-  label = input<string | HTMLElement | Text>();
-  labelActive = input<string | HTMLElement | Text>();
-  activeClassName = input<string>();
-  inactiveClassName = input<string>();
-  tipLabel = input<string>();
-  keys = input<boolean>();
-  target = input<string | HTMLElement>();
-  source = input<string | HTMLElement>();
+  readonly className = input<string>();
+  readonly label = input<string | HTMLElement | Text>();
+  readonly labelActive = input<string | HTMLElement | Text>();
+  readonly activeClassName = input<string>();
+  readonly inactiveClassName = input<string>();
+  readonly tipLabel = input<string>();
+  readonly keys = input<boolean>();
+  readonly target = input<string | HTMLElement>();
+  readonly source = input<string | HTMLElement>();
 
   instance: FullScreen;
 
@@ -39,7 +39,7 @@ export class ControlFullScreenComponent implements OnInit, OnChanges, OnDestroy 
 
     return instance;
   }
-  constructor(private map: MapComponent) {
+  constructor(private readonly map: MapComponent) {
     // console.log('instancing aol-control-fullscreen');
   }
 

--- a/projects/ngx-ol/src/lib/controls/mouseposition.component.spec.ts
+++ b/projects/ngx-ol/src/lib/controls/mouseposition.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -20,11 +20,11 @@ class ControlMousePositionHostComponent {
   zoom = 2;
   projection = 'EPSG:4326';
 
-  @ViewChild(ControlMousePositionComponent)
-  control!: ControlMousePositionComponent;
+  readonly control = viewChild.required<ControlMousePositionComponent>(
+    ControlMousePositionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('ControlMousePositionComponent', () => {
@@ -45,8 +45,8 @@ describe('ControlMousePositionComponent', () => {
 
   it('adds and removes a mouse position control with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const control = host.control.instance;
+    const map = host.map().instance;
+    const control = host.control().instance;
 
     expect(control.getProjection()?.getCode()).toBe('EPSG:4326');
     expect(map.getControls().getArray()).toContain(control);

--- a/projects/ngx-ol/src/lib/controls/mouseposition.component.ts
+++ b/projects/ngx-ol/src/lib/controls/mouseposition.component.ts
@@ -19,12 +19,12 @@ import MapEvent from 'ol/MapEvent';
   template: ``,
 })
 export class ControlMousePositionComponent implements OnInit, OnChanges, OnDestroy {
-  className = input<string>();
-  coordinateFormat = input<CoordinateFormat>();
-  projection = input<ProjectionLike>();
-  render = input<(event: MapEvent) => void>();
-  placeholder = input<string>();
-  wrapX = input<boolean>();
+  readonly className = input<string>();
+  readonly coordinateFormat = input<CoordinateFormat>();
+  readonly projection = input<ProjectionLike>();
+  readonly render = input<(event: MapEvent) => void>();
+  readonly placeholder = input<string>();
+  readonly wrapX = input<boolean>();
 
   instance: MousePosition;
 
@@ -42,8 +42,8 @@ export class ControlMousePositionComponent implements OnInit, OnChanges, OnDestr
   target: HTMLElement;
 
   constructor(
-    private map: MapComponent,
-    private element: ElementRef,
+    private readonly map: MapComponent,
+    private readonly element: ElementRef,
   ) {}
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/controls/mouseposition.component.ts
+++ b/projects/ngx-ol/src/lib/controls/mouseposition.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, ElementRef, OnDestroy, OnInit, input, signal } from '@angular/core';
 import MousePosition, { Options } from 'ol/control/MousePosition';
 import { MapComponent } from '../map.component';
 import { CoordinateFormat } from 'ol/coordinate';
@@ -10,20 +10,26 @@ import MapEvent from 'ol/MapEvent';
   template: ``,
 })
 export class ControlMousePositionComponent implements OnInit, OnDestroy {
-  @Input()
-  className?: string;
-  @Input()
-  coordinateFormat?: CoordinateFormat;
-  @Input()
-  projection?: ProjectionLike;
-  @Input()
-  render?: (event: MapEvent) => void;
-  @Input()
-  placeholder?: string;
-  @Input()
-  wrapX?: boolean;
+  className = input<string>();
+  coordinateFormat = input<CoordinateFormat>();
+  projection = input<ProjectionLike>();
+  render = input<(event: MapEvent) => void>();
+  placeholder = input<string>();
+  wrapX = input<boolean>();
 
   instance: MousePosition;
+
+  protected readonly _instanceSignal = signal<MousePosition | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: MousePosition): MousePosition {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   target: HTMLElement;
 
   constructor(
@@ -34,7 +40,7 @@ export class ControlMousePositionComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.target = this.element.nativeElement;
     // console.log('ol.control.MousePosition init: ', this);
-    this.instance = new MousePosition(this.createOptions());
+    this.setInstance(new MousePosition(this.createOptions()));
     this.map.instance.addControl(this.instance);
   }
 
@@ -45,13 +51,13 @@ export class ControlMousePositionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      className: this.className,
-      coordinateFormat: this.coordinateFormat,
-      projection: this.projection,
-      render: this.render,
+      className: this.className(),
+      coordinateFormat: this.coordinateFormat(),
+      projection: this.projection(),
+      render: this.render(),
       target: this.target,
-      placeholder: this.placeholder,
-      wrapX: this.wrapX,
+      placeholder: this.placeholder(),
+      wrapX: this.wrapX(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/controls/mouseposition.component.ts
+++ b/projects/ngx-ol/src/lib/controls/mouseposition.component.ts
@@ -1,4 +1,13 @@
-import { Component, ElementRef, OnDestroy, OnInit, input, signal } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import MousePosition, { Options } from 'ol/control/MousePosition';
 import { MapComponent } from '../map.component';
 import { CoordinateFormat } from 'ol/coordinate';
@@ -9,7 +18,7 @@ import MapEvent from 'ol/MapEvent';
   selector: 'aol-control-mouseposition',
   template: ``,
 })
-export class ControlMousePositionComponent implements OnInit, OnDestroy {
+export class ControlMousePositionComponent implements OnInit, OnChanges, OnDestroy {
   className = input<string>();
   coordinateFormat = input<CoordinateFormat>();
   projection = input<ProjectionLike>();
@@ -47,6 +56,18 @@ export class ControlMousePositionComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     // console.log('removing aol-control-mouseposition');
     this.map.instance.removeControl(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (!this.instance) {
+      return;
+    }
+    if (changes.coordinateFormat?.currentValue !== undefined) {
+      this.instance.setCoordinateFormat(changes.coordinateFormat.currentValue);
+    }
+    if (changes.projection?.currentValue !== undefined) {
+      this.instance.setProjection(changes.projection.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/controls/overviewmap.component.spec.ts
+++ b/projects/ngx-ol/src/lib/controls/overviewmap.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -20,11 +20,9 @@ class ControlOverviewMapHostComponent {
   zoom = 2;
   collapsed = false;
 
-  @ViewChild(ControlOverviewMapComponent)
-  control!: ControlOverviewMapComponent;
+  readonly control = viewChild.required<ControlOverviewMapComponent>(ControlOverviewMapComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('ControlOverviewMapComponent', () => {
@@ -45,8 +43,8 @@ describe('ControlOverviewMapComponent', () => {
 
   it('adds and removes an overview map control with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const control = host.control.instance;
+    const map = host.map().instance;
+    const control = host.control().instance;
 
     expect(map.getControls().getArray()).toContain(control);
 

--- a/projects/ngx-ol/src/lib/controls/overviewmap.component.ts
+++ b/projects/ngx-ol/src/lib/controls/overviewmap.component.ts
@@ -71,11 +71,11 @@ export class ControlOverviewMapComponent implements OnInit, OnChanges, OnDestroy
       this.instance.setRotateWithView(changes.rotateWithView.currentValue);
     }
     if (this.instance != null && changes.hasOwnProperty('view')) {
-      this.reloadInstance();
+      this.replaceInstance();
     }
   }
 
-  private reloadInstance() {
+  private replaceInstance() {
     this.map.instance.removeControl(this.instance);
     this.setInstance(new OverviewMap(this.createOptions()));
     this.map.instance.addControl(this.instance);

--- a/projects/ngx-ol/src/lib/controls/overviewmap.component.ts
+++ b/projects/ngx-ol/src/lib/controls/overviewmap.component.ts
@@ -6,6 +6,7 @@ import {
   SimpleChanges,
   input,
   signal,
+  inject,
 } from '@angular/core';
 import Collection from 'ol/Collection';
 import MapEvent from 'ol/MapEvent';
@@ -45,7 +46,7 @@ export class ControlOverviewMapComponent implements OnInit, OnChanges, OnDestroy
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new OverviewMap(this.createOptions()));

--- a/projects/ngx-ol/src/lib/controls/overviewmap.component.ts
+++ b/projects/ngx-ol/src/lib/controls/overviewmap.component.ts
@@ -1,4 +1,12 @@
-import { Component, Input, OnDestroy, OnInit, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  OnDestroy,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import Collection from 'ol/Collection';
 import MapEvent from 'ol/MapEvent';
 import BaseLayer from 'ol/layer/Base';
@@ -12,35 +20,35 @@ import { MapComponent } from '../map.component';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlOverviewMapComponent implements OnInit, OnChanges, OnDestroy {
-  @Input()
-  className?: string;
-  @Input()
-  collapsed?: boolean;
-  @Input()
-  collapseLabel?: string | HTMLElement;
-  @Input()
-  collapsible?: boolean;
-  @Input()
-  label?: string | HTMLElement;
-  @Input()
-  layers?: BaseLayer[] | Collection<BaseLayer>;
-  @Input()
-  render?: (event: MapEvent) => void;
-  @Input()
-  rotateWithView?: boolean;
-  @Input()
-  target?: string | HTMLElement;
-  @Input()
-  tipLabel?: string;
-  @Input()
-  view?: View;
+  className = input<string>();
+  collapsed = input<boolean>();
+  collapseLabel = input<string | HTMLElement>();
+  collapsible = input<boolean>();
+  label = input<string | HTMLElement>();
+  layers = input<BaseLayer[] | Collection<BaseLayer>>();
+  render = input<(event: MapEvent) => void>();
+  rotateWithView = input<boolean>();
+  target = input<string | HTMLElement>();
+  tipLabel = input<string>();
+  view = input<View>();
 
   instance: OverviewMap;
 
+  protected readonly _instanceSignal = signal<OverviewMap | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: OverviewMap): OverviewMap {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new OverviewMap(this.createOptions());
+    this.setInstance(new OverviewMap(this.createOptions()));
     this.map.instance.addControl(this.instance);
   }
 
@@ -56,23 +64,23 @@ export class ControlOverviewMapComponent implements OnInit, OnChanges, OnDestroy
 
   private reloadInstance() {
     this.map.instance.removeControl(this.instance);
-    this.instance = new OverviewMap(this.createOptions());
+    this.setInstance(new OverviewMap(this.createOptions()));
     this.map.instance.addControl(this.instance);
   }
 
   private createOptions(): Options {
     return {
-      className: this.className,
-      collapsed: this.collapsed,
-      collapseLabel: this.collapseLabel,
-      collapsible: this.collapsible,
-      label: this.label,
-      layers: this.layers,
-      render: this.render,
-      rotateWithView: this.rotateWithView,
-      target: this.target,
-      tipLabel: this.tipLabel,
-      view: this.view,
+      className: this.className(),
+      collapsed: this.collapsed(),
+      collapseLabel: this.collapseLabel(),
+      collapsible: this.collapsible(),
+      label: this.label(),
+      layers: this.layers(),
+      render: this.render(),
+      rotateWithView: this.rotateWithView(),
+      target: this.target(),
+      tipLabel: this.tipLabel(),
+      view: this.view(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/controls/overviewmap.component.ts
+++ b/projects/ngx-ol/src/lib/controls/overviewmap.component.ts
@@ -57,6 +57,18 @@ export class ControlOverviewMapComponent implements OnInit, OnChanges, OnDestroy
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    if (!this.instance) {
+      return;
+    }
+    if (changes.collapsible?.currentValue !== undefined) {
+      this.instance.setCollapsible(changes.collapsible.currentValue);
+    }
+    if (changes.collapsed?.currentValue !== undefined) {
+      this.instance.setCollapsed(changes.collapsed.currentValue);
+    }
+    if (changes.rotateWithView?.currentValue !== undefined) {
+      this.instance.setRotateWithView(changes.rotateWithView.currentValue);
+    }
     if (this.instance != null && changes.hasOwnProperty('view')) {
       this.reloadInstance();
     }

--- a/projects/ngx-ol/src/lib/controls/overviewmap.component.ts
+++ b/projects/ngx-ol/src/lib/controls/overviewmap.component.ts
@@ -21,17 +21,17 @@ import { MapComponent } from '../map.component';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlOverviewMapComponent implements OnInit, OnChanges, OnDestroy {
-  className = input<string>();
-  collapsed = input<boolean>();
-  collapseLabel = input<string | HTMLElement>();
-  collapsible = input<boolean>();
-  label = input<string | HTMLElement>();
-  layers = input<BaseLayer[] | Collection<BaseLayer>>();
-  render = input<(event: MapEvent) => void>();
-  rotateWithView = input<boolean>();
-  target = input<string | HTMLElement>();
-  tipLabel = input<string>();
-  view = input<View>();
+  readonly className = input<string>();
+  readonly collapsed = input<boolean>();
+  readonly collapseLabel = input<string | HTMLElement>();
+  readonly collapsible = input<boolean>();
+  readonly label = input<string | HTMLElement>();
+  readonly layers = input<BaseLayer[] | Collection<BaseLayer>>();
+  readonly render = input<(event: MapEvent) => void>();
+  readonly rotateWithView = input<boolean>();
+  readonly target = input<string | HTMLElement>();
+  readonly tipLabel = input<string>();
+  readonly view = input<View>();
 
   instance: OverviewMap;
 

--- a/projects/ngx-ol/src/lib/controls/rotate.component.spec.ts
+++ b/projects/ngx-ol/src/lib/controls/rotate.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -20,11 +20,9 @@ class ControlRotateHostComponent {
   zoom = 2;
   autoHide = false;
 
-  @ViewChild(ControlRotateComponent)
-  control!: ControlRotateComponent;
+  readonly control = viewChild.required<ControlRotateComponent>(ControlRotateComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('ControlRotateComponent', () => {
@@ -45,8 +43,8 @@ describe('ControlRotateComponent', () => {
 
   it('adds and removes a rotate control with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const control = host.control.instance;
+    const map = host.map().instance;
+    const control = host.control().instance;
 
     expect(map.getControls().getArray()).toContain(control);
 

--- a/projects/ngx-ol/src/lib/controls/rotate.component.ts
+++ b/projects/ngx-ol/src/lib/controls/rotate.component.ts
@@ -17,15 +17,15 @@ import { MapComponent } from '../map.component';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlRotateComponent implements OnInit, OnChanges, OnDestroy {
-  className = input<string>();
-  label = input<string | HTMLElement>();
-  tipLabel = input<string>();
-  compassClassName = input<string>();
-  duration = input<number>();
-  autoHide = input<boolean>();
-  render = input<(event: MapEvent) => void>();
-  resetNorth = input<() => void>();
-  target = input<string | HTMLElement>();
+  readonly className = input<string>();
+  readonly label = input<string | HTMLElement>();
+  readonly tipLabel = input<string>();
+  readonly compassClassName = input<string>();
+  readonly duration = input<number>();
+  readonly autoHide = input<boolean>();
+  readonly render = input<(event: MapEvent) => void>();
+  readonly resetNorth = input<() => void>();
+  readonly target = input<string | HTMLElement>();
 
   instance: Rotate;
 
@@ -40,7 +40,7 @@ export class ControlRotateComponent implements OnInit, OnChanges, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {
+  constructor(private readonly map: MapComponent) {
     // console.log('instancing aol-control-rotate');
   }
 

--- a/projects/ngx-ol/src/lib/controls/rotate.component.ts
+++ b/projects/ngx-ol/src/lib/controls/rotate.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import {
+  Component,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import MapEvent from 'ol/MapEvent';
 import Rotate from 'ol/control/Rotate';
 import { Options } from 'ol/control/Rotate';
@@ -8,7 +16,7 @@ import { MapComponent } from '../map.component';
   selector: 'aol-control-rotate',
   template: ` <ng-content></ng-content> `,
 })
-export class ControlRotateComponent implements OnInit, OnDestroy {
+export class ControlRotateComponent implements OnInit, OnChanges, OnDestroy {
   className = input<string>();
   label = input<string | HTMLElement>();
   tipLabel = input<string>();
@@ -44,6 +52,12 @@ export class ControlRotateComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     // console.log('removing aol-control-rotate');
     this.map.instance.removeControl(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.instance && changes.target?.currentValue !== undefined) {
+      this.instance.setTarget(changes.target.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/controls/rotate.component.ts
+++ b/projects/ngx-ol/src/lib/controls/rotate.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import MapEvent from 'ol/MapEvent';
 import Rotate from 'ol/control/Rotate';
 import { Options } from 'ol/control/Rotate';
@@ -9,33 +9,35 @@ import { MapComponent } from '../map.component';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlRotateComponent implements OnInit, OnDestroy {
-  @Input()
-  className?: string;
-  @Input()
-  label?: string | HTMLElement;
-  @Input()
-  tipLabel?: string;
-  @Input()
-  compassClassName?: string;
-  @Input()
-  duration?: number;
-  @Input()
-  autoHide?: boolean;
-  @Input()
-  render?: (event: MapEvent) => void;
-  @Input()
-  resetNorth?: () => void;
-  @Input()
-  target?: string | HTMLElement;
+  className = input<string>();
+  label = input<string | HTMLElement>();
+  tipLabel = input<string>();
+  compassClassName = input<string>();
+  duration = input<number>();
+  autoHide = input<boolean>();
+  render = input<(event: MapEvent) => void>();
+  resetNorth = input<() => void>();
+  target = input<string | HTMLElement>();
 
   instance: Rotate;
 
+  protected readonly _instanceSignal = signal<Rotate | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Rotate): Rotate {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {
     // console.log('instancing aol-control-rotate');
   }
 
   ngOnInit() {
-    this.instance = new Rotate(this.createOptions());
+    this.setInstance(new Rotate(this.createOptions()));
     this.map.instance.addControl(this.instance);
   }
 
@@ -46,15 +48,15 @@ export class ControlRotateComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      className: this.className,
-      label: this.label,
-      tipLabel: this.tipLabel,
-      compassClassName: this.compassClassName,
-      duration: this.duration,
-      autoHide: this.autoHide,
-      render: this.render,
-      resetNorth: this.resetNorth,
-      target: this.target,
+      className: this.className(),
+      label: this.label(),
+      tipLabel: this.tipLabel(),
+      compassClassName: this.compassClassName(),
+      duration: this.duration(),
+      autoHide: this.autoHide(),
+      render: this.render(),
+      resetNorth: this.resetNorth(),
+      target: this.target(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/controls/scaleline.component.spec.ts
+++ b/projects/ngx-ol/src/lib/controls/scaleline.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { Units } from 'ol/control/ScaleLine';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -21,11 +21,9 @@ class ControlScaleLineHostComponent {
   zoom = 2;
   units: Units = 'metric';
 
-  @ViewChild(ControlScaleLineComponent)
-  control!: ControlScaleLineComponent;
+  readonly control = viewChild.required<ControlScaleLineComponent>(ControlScaleLineComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('ControlScaleLineComponent', () => {
@@ -46,8 +44,8 @@ describe('ControlScaleLineComponent', () => {
 
   it('adds and removes a scale line control with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const control = host.control.instance;
+    const map = host.map().instance;
+    const control = host.control().instance;
 
     expect(map.getControls().getArray()).toContain(control);
 

--- a/projects/ngx-ol/src/lib/controls/scaleline.component.ts
+++ b/projects/ngx-ol/src/lib/controls/scaleline.component.ts
@@ -18,16 +18,16 @@ import MapEvent from 'ol/MapEvent';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlScaleLineComponent implements OnInit, OnChanges, OnDestroy {
-  className = input<string>();
-  minWidth = input<number>();
-  maxWidth = input<number>();
-  render = input<(event: MapEvent) => void>();
-  target = input<string | HTMLElement>();
-  units = input<Units>();
-  bar = input<boolean>();
-  steps = input<number>();
-  text = input<boolean>();
-  dpi = input<number>();
+  readonly className = input<string>();
+  readonly minWidth = input<number>();
+  readonly maxWidth = input<number>();
+  readonly render = input<(event: MapEvent) => void>();
+  readonly target = input<string | HTMLElement>();
+  readonly units = input<Units>();
+  readonly bar = input<boolean>();
+  readonly steps = input<number>();
+  readonly text = input<boolean>();
+  readonly dpi = input<number>();
 
   instance: ScaleLine;
 

--- a/projects/ngx-ol/src/lib/controls/scaleline.component.ts
+++ b/projects/ngx-ol/src/lib/controls/scaleline.component.ts
@@ -6,6 +6,7 @@ import {
   SimpleChanges,
   input,
   signal,
+  inject,
 } from '@angular/core';
 import ScaleLine from 'ol/control/ScaleLine';
 import { MapComponent } from '../map.component';
@@ -41,7 +42,7 @@ export class ControlScaleLineComponent implements OnInit, OnChanges, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new ScaleLine(this.createOptions()));

--- a/projects/ngx-ol/src/lib/controls/scaleline.component.ts
+++ b/projects/ngx-ol/src/lib/controls/scaleline.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import ScaleLine from 'ol/control/ScaleLine';
 import { MapComponent } from '../map.component';
 import { Options, Units } from 'ol/control/ScaleLine';
@@ -9,33 +9,34 @@ import MapEvent from 'ol/MapEvent';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlScaleLineComponent implements OnInit, OnDestroy {
-  @Input()
-  className?: string;
-  @Input()
-  minWidth?: number;
-  @Input()
-  maxWidth?: number;
-  @Input()
-  render?: (event: MapEvent) => void;
-  @Input()
-  target?: string | HTMLElement;
-  @Input()
-  units?: Units;
-  @Input()
-  bar?: boolean;
-  @Input()
-  steps?: number;
-  @Input()
-  text?: boolean;
-  @Input()
-  dpi?: number;
+  className = input<string>();
+  minWidth = input<number>();
+  maxWidth = input<number>();
+  render = input<(event: MapEvent) => void>();
+  target = input<string | HTMLElement>();
+  units = input<Units>();
+  bar = input<boolean>();
+  steps = input<number>();
+  text = input<boolean>();
+  dpi = input<number>();
 
   instance: ScaleLine;
 
+  protected readonly _instanceSignal = signal<ScaleLine | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: ScaleLine): ScaleLine {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new ScaleLine(this.createOptions());
+    this.setInstance(new ScaleLine(this.createOptions()));
     this.map.instance.addControl(this.instance);
   }
 
@@ -45,16 +46,16 @@ export class ControlScaleLineComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      className: this.className,
-      minWidth: this.minWidth,
-      maxWidth: this.maxWidth,
-      render: this.render,
-      target: this.target,
-      units: this.units,
-      bar: this.bar,
-      steps: this.steps,
-      text: this.text,
-      dpi: this.dpi,
+      className: this.className(),
+      minWidth: this.minWidth(),
+      maxWidth: this.maxWidth(),
+      render: this.render(),
+      target: this.target(),
+      units: this.units(),
+      bar: this.bar(),
+      steps: this.steps(),
+      text: this.text(),
+      dpi: this.dpi(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/controls/scaleline.component.ts
+++ b/projects/ngx-ol/src/lib/controls/scaleline.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import {
+  Component,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import ScaleLine from 'ol/control/ScaleLine';
 import { MapComponent } from '../map.component';
 import { Options, Units } from 'ol/control/ScaleLine';
@@ -8,7 +16,7 @@ import MapEvent from 'ol/MapEvent';
   selector: 'aol-control-scaleline',
   template: ` <ng-content></ng-content> `,
 })
-export class ControlScaleLineComponent implements OnInit, OnDestroy {
+export class ControlScaleLineComponent implements OnInit, OnChanges, OnDestroy {
   className = input<string>();
   minWidth = input<number>();
   maxWidth = input<number>();
@@ -42,6 +50,18 @@ export class ControlScaleLineComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.map.instance.removeControl(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (!this.instance) {
+      return;
+    }
+    if (changes.units?.currentValue !== undefined) {
+      this.instance.setUnits(changes.units.currentValue);
+    }
+    if (changes.dpi) {
+      this.instance.setDpi(changes.dpi.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/controls/zoom.component.spec.ts
+++ b/projects/ngx-ol/src/lib/controls/zoom.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -21,11 +21,9 @@ class ControlZoomHostComponent {
   duration = 0;
   delta = 2;
 
-  @ViewChild(ControlZoomComponent)
-  control!: ControlZoomComponent;
+  readonly control = viewChild.required<ControlZoomComponent>(ControlZoomComponent);
 
-  @ViewChild(ViewComponent)
-  view!: ViewComponent;
+  readonly view = viewChild.required<ViewComponent>(ViewComponent);
 }
 
 describe('ControlZoomComponent', () => {
@@ -45,19 +43,15 @@ describe('ControlZoomComponent', () => {
   });
 
   it('wires the zoom buttons to the map view using bound Angular inputs', () => {
-    const zoomInButton = fixture.nativeElement.querySelector(
-      '.ol-zoom-in',
-    ) as HTMLButtonElement;
-    const zoomOutButton = fixture.nativeElement.querySelector(
-      '.ol-zoom-out',
-    ) as HTMLButtonElement;
+    const zoomInButton = fixture.nativeElement.querySelector('.ol-zoom-in') as HTMLButtonElement;
+    const zoomOutButton = fixture.nativeElement.querySelector('.ol-zoom-out') as HTMLButtonElement;
 
-    expect(fixture.componentInstance.view.instance.getZoom()).toBe(2);
+    expect(fixture.componentInstance.view().instance.getZoom()).toBe(2);
 
     zoomInButton.click();
-    expect(fixture.componentInstance.view.instance.getZoom()).toBe(4);
+    expect(fixture.componentInstance.view().instance.getZoom()).toBe(4);
 
     zoomOutButton.click();
-    expect(fixture.componentInstance.view.instance.getZoom()).toBe(2);
+    expect(fixture.componentInstance.view().instance.getZoom()).toBe(2);
   });
 });

--- a/projects/ngx-ol/src/lib/controls/zoom.component.ts
+++ b/projects/ngx-ol/src/lib/controls/zoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import Zoom from 'ol/control/Zoom';
 import { Options } from 'ol/control/Zoom';
 import { MapComponent } from '../map.component';
@@ -8,35 +8,36 @@ import { MapComponent } from '../map.component';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlZoomComponent implements OnInit, OnDestroy {
-  @Input()
-  duration?: number;
-  @Input()
-  className?: string;
-  @Input()
-  zoomInClassName?: string;
-  @Input()
-  zoomOutClassName?: string;
-  @Input()
-  zoomInLabel?: string | HTMLElement;
-  @Input()
-  zoomOutLabel?: string | HTMLElement;
-  @Input()
-  zoomInTipLabel?: string;
-  @Input()
-  zoomOutTipLabel?: string;
-  @Input()
-  delta?: number;
-  @Input()
-  target?: string | HTMLElement;
+  duration = input<number>();
+  className = input<string>();
+  zoomInClassName = input<string>();
+  zoomOutClassName = input<string>();
+  zoomInLabel = input<string | HTMLElement>();
+  zoomOutLabel = input<string | HTMLElement>();
+  zoomInTipLabel = input<string>();
+  zoomOutTipLabel = input<string>();
+  delta = input<number>();
+  target = input<string | HTMLElement>();
 
   instance: Zoom;
 
+  protected readonly _instanceSignal = signal<Zoom | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Zoom): Zoom {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {
     // console.log('instancing aol-control-zoom');
   }
 
   ngOnInit() {
-    this.instance = new Zoom(this.createOptions());
+    this.setInstance(new Zoom(this.createOptions()));
     this.map.instance.addControl(this.instance);
   }
 
@@ -47,16 +48,16 @@ export class ControlZoomComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      duration: this.duration,
-      className: this.className,
-      zoomInClassName: this.zoomInClassName,
-      zoomOutClassName: this.zoomOutClassName,
-      zoomInLabel: this.zoomInLabel,
-      zoomOutLabel: this.zoomOutLabel,
-      zoomInTipLabel: this.zoomInTipLabel,
-      zoomOutTipLabel: this.zoomOutTipLabel,
-      delta: this.delta,
-      target: this.target,
+      duration: this.duration(),
+      className: this.className(),
+      zoomInClassName: this.zoomInClassName(),
+      zoomOutClassName: this.zoomOutClassName(),
+      zoomInLabel: this.zoomInLabel(),
+      zoomOutLabel: this.zoomOutLabel(),
+      zoomInTipLabel: this.zoomInTipLabel(),
+      zoomOutTipLabel: this.zoomOutTipLabel(),
+      delta: this.delta(),
+      target: this.target(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/controls/zoom.component.ts
+++ b/projects/ngx-ol/src/lib/controls/zoom.component.ts
@@ -16,16 +16,16 @@ import { MapComponent } from '../map.component';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlZoomComponent implements OnInit, OnChanges, OnDestroy {
-  duration = input<number>();
-  className = input<string>();
-  zoomInClassName = input<string>();
-  zoomOutClassName = input<string>();
-  zoomInLabel = input<string | HTMLElement>();
-  zoomOutLabel = input<string | HTMLElement>();
-  zoomInTipLabel = input<string>();
-  zoomOutTipLabel = input<string>();
-  delta = input<number>();
-  target = input<string | HTMLElement>();
+  readonly duration = input<number>();
+  readonly className = input<string>();
+  readonly zoomInClassName = input<string>();
+  readonly zoomOutClassName = input<string>();
+  readonly zoomInLabel = input<string | HTMLElement>();
+  readonly zoomOutLabel = input<string | HTMLElement>();
+  readonly zoomInTipLabel = input<string>();
+  readonly zoomOutTipLabel = input<string>();
+  readonly delta = input<number>();
+  readonly target = input<string | HTMLElement>();
 
   instance: Zoom;
 
@@ -40,7 +40,7 @@ export class ControlZoomComponent implements OnInit, OnChanges, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {
+  constructor(private readonly map: MapComponent) {
     // console.log('instancing aol-control-zoom');
   }
 

--- a/projects/ngx-ol/src/lib/controls/zoom.component.ts
+++ b/projects/ngx-ol/src/lib/controls/zoom.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import {
+  Component,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import Zoom from 'ol/control/Zoom';
 import { Options } from 'ol/control/Zoom';
 import { MapComponent } from '../map.component';
@@ -7,7 +15,7 @@ import { MapComponent } from '../map.component';
   selector: 'aol-control-zoom',
   template: ` <ng-content></ng-content> `,
 })
-export class ControlZoomComponent implements OnInit, OnDestroy {
+export class ControlZoomComponent implements OnInit, OnChanges, OnDestroy {
   duration = input<number>();
   className = input<string>();
   zoomInClassName = input<string>();
@@ -44,6 +52,12 @@ export class ControlZoomComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     // console.log('removing aol-control-zoom');
     this.map.instance.removeControl(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.instance && changes.target?.currentValue !== undefined) {
+      this.instance.setTarget(changes.target.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/controls/zoomslider.component.spec.ts
+++ b/projects/ngx-ol/src/lib/controls/zoomslider.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -19,11 +19,9 @@ class ControlZoomSliderHostComponent {
   center = [0, 0];
   zoom = 2;
 
-  @ViewChild(ControlZoomSliderComponent)
-  control!: ControlZoomSliderComponent;
+  readonly control = viewChild.required<ControlZoomSliderComponent>(ControlZoomSliderComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('ControlZoomSliderComponent', () => {
@@ -44,8 +42,8 @@ describe('ControlZoomSliderComponent', () => {
 
   it('adds and removes a zoom slider control with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const control = host.control.instance;
+    const map = host.map().instance;
+    const control = host.control().instance;
 
     expect(map.getControls().getArray()).toContain(control);
 

--- a/projects/ngx-ol/src/lib/controls/zoomslider.component.ts
+++ b/projects/ngx-ol/src/lib/controls/zoomslider.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import MapEvent from 'ol/MapEvent';
 import ZoomSlider from 'ol/control/ZoomSlider';
 import { Options } from 'ol/control/ZoomSlider';
@@ -9,23 +9,30 @@ import { MapComponent } from '../map.component';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlZoomSliderComponent implements OnInit, OnDestroy {
-  @Input()
-  className?: string;
-  @Input()
-  duration?: number;
-  @Input()
-  render?: (event: MapEvent) => void;
-  @Input()
-  target?: string | HTMLElement;
+  className = input<string>();
+  duration = input<number>();
+  render = input<(event: MapEvent) => void>();
+  target = input<string | HTMLElement>();
 
   instance: ZoomSlider;
 
+  protected readonly _instanceSignal = signal<ZoomSlider | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: ZoomSlider): ZoomSlider {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {
     // console.log('instancing aol-control-zoomslider');
   }
 
   ngOnInit() {
-    this.instance = new ZoomSlider(this.createOptions());
+    this.setInstance(new ZoomSlider(this.createOptions()));
     this.map.instance.addControl(this.instance);
   }
 
@@ -36,10 +43,10 @@ export class ControlZoomSliderComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      className: this.className,
-      duration: this.duration,
-      render: this.render,
-      target: this.target,
+      className: this.className(),
+      duration: this.duration(),
+      render: this.render(),
+      target: this.target(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/controls/zoomslider.component.ts
+++ b/projects/ngx-ol/src/lib/controls/zoomslider.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import {
+  Component,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import MapEvent from 'ol/MapEvent';
 import ZoomSlider from 'ol/control/ZoomSlider';
 import { Options } from 'ol/control/ZoomSlider';
@@ -8,7 +16,7 @@ import { MapComponent } from '../map.component';
   selector: 'aol-control-zoomslider',
   template: ` <ng-content></ng-content> `,
 })
-export class ControlZoomSliderComponent implements OnInit, OnDestroy {
+export class ControlZoomSliderComponent implements OnInit, OnChanges, OnDestroy {
   className = input<string>();
   duration = input<number>();
   render = input<(event: MapEvent) => void>();
@@ -39,6 +47,12 @@ export class ControlZoomSliderComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     // console.log('removing aol-control-zoomslider');
     this.map.instance.removeControl(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.instance && changes.target?.currentValue !== undefined) {
+      this.instance.setTarget(changes.target.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/controls/zoomslider.component.ts
+++ b/projects/ngx-ol/src/lib/controls/zoomslider.component.ts
@@ -17,10 +17,10 @@ import { MapComponent } from '../map.component';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlZoomSliderComponent implements OnInit, OnChanges, OnDestroy {
-  className = input<string>();
-  duration = input<number>();
-  render = input<(event: MapEvent) => void>();
-  target = input<string | HTMLElement>();
+  readonly className = input<string>();
+  readonly duration = input<number>();
+  readonly render = input<(event: MapEvent) => void>();
+  readonly target = input<string | HTMLElement>();
 
   instance: ZoomSlider;
 
@@ -35,7 +35,7 @@ export class ControlZoomSliderComponent implements OnInit, OnChanges, OnDestroy 
 
     return instance;
   }
-  constructor(private map: MapComponent) {
+  constructor(private readonly map: MapComponent) {
     // console.log('instancing aol-control-zoomslider');
   }
 

--- a/projects/ngx-ol/src/lib/controls/zoomtoextent.component.spec.ts
+++ b/projects/ngx-ol/src/lib/controls/zoomtoextent.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -20,11 +20,9 @@ class ControlZoomToExtentHostComponent {
   zoom = 2;
   extent: [number, number, number, number] = [-10, -10, 10, 10];
 
-  @ViewChild(ControlZoomToExtentComponent)
-  control!: ControlZoomToExtentComponent;
+  readonly control = viewChild.required<ControlZoomToExtentComponent>(ControlZoomToExtentComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('ControlZoomToExtentComponent', () => {
@@ -45,8 +43,8 @@ describe('ControlZoomToExtentComponent', () => {
 
   it('adds and removes a zoom-to-extent control with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const control = host.control.instance;
+    const map = host.map().instance;
+    const control = host.control().instance;
 
     expect(map.getControls().getArray()).toContain(control);
 

--- a/projects/ngx-ol/src/lib/controls/zoomtoextent.component.ts
+++ b/projects/ngx-ol/src/lib/controls/zoomtoextent.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import ZoomToExtent from 'ol/control/ZoomToExtent';
 import { Options } from 'ol/control/ZoomToExtent';
 import { MapComponent } from '../map.component';
@@ -9,25 +9,31 @@ import { Extent } from 'ol/extent';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlZoomToExtentComponent implements OnInit, OnDestroy {
-  @Input()
-  className?: string;
-  @Input()
-  target?: string | HTMLElement;
-  @Input()
-  label?: string | HTMLElement;
-  @Input()
-  tipLabel?: string;
-  @Input()
-  extent?: Extent;
+  className = input<string>();
+  target = input<string | HTMLElement>();
+  label = input<string | HTMLElement>();
+  tipLabel = input<string>();
+  extent = input<Extent>();
 
   instance: ZoomToExtent;
 
+  protected readonly _instanceSignal = signal<ZoomToExtent | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: ZoomToExtent): ZoomToExtent {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {
     // console.log('instancing aol-control-zoomtoextent');
   }
 
   ngOnInit() {
-    this.instance = new ZoomToExtent(this.createOptions());
+    this.setInstance(new ZoomToExtent(this.createOptions()));
     this.map.instance.addControl(this.instance);
   }
 
@@ -38,11 +44,11 @@ export class ControlZoomToExtentComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      className: this.className,
-      target: this.target,
-      label: this.label,
-      tipLabel: this.tipLabel,
-      extent: this.extent,
+      className: this.className(),
+      target: this.target(),
+      label: this.label(),
+      tipLabel: this.tipLabel(),
+      extent: this.extent(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/controls/zoomtoextent.component.ts
+++ b/projects/ngx-ol/src/lib/controls/zoomtoextent.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import {
+  Component,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import ZoomToExtent from 'ol/control/ZoomToExtent';
 import { Options } from 'ol/control/ZoomToExtent';
 import { MapComponent } from '../map.component';
@@ -8,7 +16,7 @@ import { Extent } from 'ol/extent';
   selector: 'aol-control-zoomtoextent',
   template: ` <ng-content></ng-content> `,
 })
-export class ControlZoomToExtentComponent implements OnInit, OnDestroy {
+export class ControlZoomToExtentComponent implements OnInit, OnChanges, OnDestroy {
   className = input<string>();
   target = input<string | HTMLElement>();
   label = input<string | HTMLElement>();
@@ -40,6 +48,12 @@ export class ControlZoomToExtentComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     // console.log('removing aol-control-zoomtoextent');
     this.map.instance.removeControl(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.instance && changes.target?.currentValue !== undefined) {
+      this.instance.setTarget(changes.target.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/controls/zoomtoextent.component.ts
+++ b/projects/ngx-ol/src/lib/controls/zoomtoextent.component.ts
@@ -17,11 +17,11 @@ import { Extent } from 'ol/extent';
   template: ` <ng-content></ng-content> `,
 })
 export class ControlZoomToExtentComponent implements OnInit, OnChanges, OnDestroy {
-  className = input<string>();
-  target = input<string | HTMLElement>();
-  label = input<string | HTMLElement>();
-  tipLabel = input<string>();
-  extent = input<Extent>();
+  readonly className = input<string>();
+  readonly target = input<string | HTMLElement>();
+  readonly label = input<string | HTMLElement>();
+  readonly tipLabel = input<string>();
+  readonly extent = input<Extent>();
 
   instance: ZoomToExtent;
 
@@ -36,7 +36,7 @@ export class ControlZoomToExtentComponent implements OnInit, OnChanges, OnDestro
 
     return instance;
   }
-  constructor(private map: MapComponent) {
+  constructor(private readonly map: MapComponent) {
     // console.log('instancing aol-control-zoomtoextent');
   }
 

--- a/projects/ngx-ol/src/lib/coordinate.component.spec.ts
+++ b/projects/ngx-ol/src/lib/coordinate.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../public-api';
@@ -31,11 +31,9 @@ class CoordinateHostComponent {
   overlayY = 2;
   overlaySrid = 'EPSG:3857';
 
-  @ViewChild(ViewComponent)
-  view!: ViewComponent;
+  readonly view = viewChild.required<ViewComponent>(ViewComponent);
 
-  @ViewChild(OverlayComponent)
-  overlay!: OverlayComponent;
+  readonly overlay = viewChild.required<OverlayComponent>(OverlayComponent);
 }
 
 describe('CoordinateComponent', () => {
@@ -55,7 +53,7 @@ describe('CoordinateComponent', () => {
   });
 
   it('projects bound coordinates into its host view and overlay', () => {
-    expect(fixture.componentInstance.view.instance.getCenter()).toEqual([7, 9]);
-    expect(fixture.componentInstance.overlay.instance.getPosition()).toEqual([1, 2]);
+    expect(fixture.componentInstance.view().instance.getCenter()).toEqual([7, 9]);
+    expect(fixture.componentInstance.overlay().instance.getPosition()).toEqual([1, 2]);
   });
 });

--- a/projects/ngx-ol/src/lib/coordinate.component.ts
+++ b/projects/ngx-ol/src/lib/coordinate.component.ts
@@ -12,11 +12,11 @@ import { ObjectEvent } from 'ol/Object';
   template: ` <div class="aol-coordinate"></div> `,
 })
 export class CoordinateComponent implements OnChanges, OnInit {
-  x = input.required<number>();
-  y = input.required<number>();
-  srid = input('EPSG:3857');
+  readonly x = input.required<number>();
+  readonly y = input.required<number>();
+  readonly srid = input('EPSG:3857');
 
-  private host: any;
+  private readonly host: any;
   private readonly map = inject(MapComponent);
   private readonly viewHost = inject(ViewComponent, { optional: true });
   private readonly geometryPointHost = inject(GeometryPointComponent, { optional: true });

--- a/projects/ngx-ol/src/lib/coordinate.component.ts
+++ b/projects/ngx-ol/src/lib/coordinate.component.ts
@@ -1,4 +1,4 @@
-import { Component, Optional, OnChanges, Input, SimpleChanges, OnInit } from '@angular/core';
+import { Component, Optional, OnChanges, SimpleChanges, OnInit, input } from '@angular/core';
 import { transform } from 'ol/proj';
 import { MapComponent } from './map.component';
 import { GeometryPointComponent } from './geom/geometrypoint.component';
@@ -12,12 +12,9 @@ import { ObjectEvent } from 'ol/Object';
   template: ` <div class="aol-coordinate"></div> `,
 })
 export class CoordinateComponent implements OnChanges, OnInit {
-  @Input()
-  x: number;
-  @Input()
-  y: number;
-  @Input()
-  srid = 'EPSG:3857';
+  x = input.required<number>();
+  y = input.required<number>();
+  srid = input('EPSG:3857');
 
   private host: any;
   private mapSrid = 'EPSG:3857';
@@ -59,10 +56,10 @@ export class CoordinateComponent implements OnChanges, OnInit {
   private transformCoordinates() {
     let transformedCoordinates: number[];
 
-    if (this.srid === this.mapSrid) {
-      transformedCoordinates = [this.x, this.y];
+    if (this.srid() === this.mapSrid) {
+      transformedCoordinates = [this.x(), this.y()];
     } else {
-      transformedCoordinates = transform([this.x, this.y], this.srid, this.mapSrid);
+      transformedCoordinates = transform([this.x(), this.y()], this.srid(), this.mapSrid);
     }
 
     switch (this.host.componentType) {

--- a/projects/ngx-ol/src/lib/coordinate.component.ts
+++ b/projects/ngx-ol/src/lib/coordinate.component.ts
@@ -1,4 +1,4 @@
-import { Component, Optional, OnChanges, SimpleChanges, OnInit, input } from '@angular/core';
+import { Component, OnChanges, SimpleChanges, OnInit, inject, input } from '@angular/core';
 import { transform } from 'ol/proj';
 import { MapComponent } from './map.component';
 import { GeometryPointComponent } from './geom/geometrypoint.component';
@@ -17,24 +17,23 @@ export class CoordinateComponent implements OnChanges, OnInit {
   srid = input('EPSG:3857');
 
   private host: any;
+  private readonly map = inject(MapComponent);
+  private readonly viewHost = inject(ViewComponent, { optional: true });
+  private readonly geometryPointHost = inject(GeometryPointComponent, { optional: true });
+  private readonly geometryCircleHost = inject(GeometryCircleComponent, { optional: true });
+  private readonly overlayHost = inject(OverlayComponent, { optional: true });
   private mapSrid = 'EPSG:3857';
 
-  constructor(
-    private map: MapComponent,
-    @Optional() viewHost: ViewComponent,
-    @Optional() geometryPointHost: GeometryPointComponent,
-    @Optional() geometryCircleHost: GeometryCircleComponent,
-    @Optional() overlayHost: OverlayComponent,
-  ) {
+  constructor() {
     // console.log('instancing aol-coordinate');
-    if (geometryPointHost !== null) {
-      this.host = geometryPointHost;
-    } else if (geometryCircleHost !== null) {
-      this.host = geometryCircleHost;
-    } else if (viewHost !== null) {
-      this.host = viewHost;
-    } else if (overlayHost !== null) {
-      this.host = overlayHost;
+    if (this.geometryPointHost !== null) {
+      this.host = this.geometryPointHost;
+    } else if (this.geometryCircleHost !== null) {
+      this.host = this.geometryCircleHost;
+    } else if (this.viewHost !== null) {
+      this.host = this.viewHost;
+    } else if (this.overlayHost !== null) {
+      this.host = this.overlayHost;
     }
   }
 

--- a/projects/ngx-ol/src/lib/feature.component.spec.ts
+++ b/projects/ngx-ol/src/lib/feature.component.spec.ts
@@ -30,7 +30,7 @@ class FeatureHostComponent {
   zoom = 2;
   feature = signal(new Feature());
   id = signal('feature-1');
-  properties = signal({ name: 'test' });
+  properties = signal<Record<string, string>>({ name: 'test' });
   clickable = signal(true);
 
   @ViewChild(FeatureComponent)
@@ -85,6 +85,22 @@ describe('FeatureComponent', () => {
     );
   });
 
+  it('updates and removes feature properties when template bindings change', () => {
+    fixture.componentInstance.properties.set({ name: 'updated', category: 'road' });
+
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.feature().get('name')).toBe('updated');
+    expect(fixture.componentInstance.feature().get('category')).toBe('road');
+
+    fixture.componentInstance.properties.set({ category: 'river' });
+
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.feature().get('name')).toBeUndefined();
+    expect(fixture.componentInstance.feature().get('category')).toBe('river');
+  });
+
   it('replaces the OpenLayers feature in the vector source when the binding changes', () => {
     const previousFeature = fixture.componentInstance.feature();
     const nextFeature = new Feature();
@@ -97,5 +113,7 @@ describe('FeatureComponent', () => {
     expect(fixture.componentInstance.source.instance.getFeatures()).toContain(nextFeature);
     expect(previousFeature.get('__aol-feature')).toBeNull();
     expect(nextFeature.get('__aol-feature')).toBe(fixture.componentInstance.featureComponent);
+    expect(nextFeature.getId()).toBe('feature-1');
+    expect(nextFeature.get('name')).toBe('test');
   });
 });

--- a/projects/ngx-ol/src/lib/feature.component.spec.ts
+++ b/projects/ngx-ol/src/lib/feature.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Feature from 'ol/Feature';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -33,11 +33,9 @@ class FeatureHostComponent {
   properties = signal<Record<string, string>>({ name: 'test' });
   clickable = signal(true);
 
-  @ViewChild(FeatureComponent)
-  featureComponent!: FeatureComponent;
+  readonly featureComponent = viewChild.required<FeatureComponent>(FeatureComponent);
 
-  @ViewChild(SourceVectorComponent)
-  source!: SourceVectorComponent;
+  readonly source = viewChild.required<SourceVectorComponent>(SourceVectorComponent);
 }
 
 describe('FeatureComponent', () => {
@@ -57,13 +55,13 @@ describe('FeatureComponent', () => {
   });
 
   it('adds the bound feature to the vector source and applies metadata', () => {
-    expect(fixture.componentInstance.source.instance.getFeatures()).toContain(
+    expect(fixture.componentInstance.source().instance.getFeatures()).toContain(
       fixture.componentInstance.feature(),
     );
     expect(fixture.componentInstance.feature().getId()).toBe('feature-1');
     expect(fixture.componentInstance.feature().get('name')).toBe('test');
     expect(fixture.componentInstance.feature().get('__aol-feature')).toBe(
-      fixture.componentInstance.featureComponent,
+      fixture.componentInstance.featureComponent(),
     );
   });
 
@@ -81,7 +79,7 @@ describe('FeatureComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.componentInstance.feature().get('__aol-feature')).toBe(
-      fixture.componentInstance.featureComponent,
+      fixture.componentInstance.featureComponent(),
     );
   });
 
@@ -109,10 +107,12 @@ describe('FeatureComponent', () => {
 
     fixture.detectChanges();
 
-    expect(fixture.componentInstance.source.instance.getFeatures()).not.toContain(previousFeature);
-    expect(fixture.componentInstance.source.instance.getFeatures()).toContain(nextFeature);
+    expect(fixture.componentInstance.source().instance.getFeatures()).not.toContain(
+      previousFeature,
+    );
+    expect(fixture.componentInstance.source().instance.getFeatures()).toContain(nextFeature);
     expect(previousFeature.get('__aol-feature')).toBeNull();
-    expect(nextFeature.get('__aol-feature')).toBe(fixture.componentInstance.featureComponent);
+    expect(nextFeature.get('__aol-feature')).toBe(fixture.componentInstance.featureComponent());
     expect(nextFeature.getId()).toBe('feature-1');
     expect(nextFeature.get('name')).toBe('test');
   });

--- a/projects/ngx-ol/src/lib/feature.component.ts
+++ b/projects/ngx-ol/src/lib/feature.component.ts
@@ -3,10 +3,10 @@ import {
   OnInit,
   OnDestroy,
   OnChanges,
-  Input,
   SimpleChanges,
-  Output,
-  EventEmitter,
+  input,
+  output,
+  signal,
 } from '@angular/core';
 import Feature from 'ol/Feature';
 import MapBrowserEvent from 'ol/MapBrowserEvent';
@@ -17,39 +17,40 @@ import { SourceVectorComponent } from './sources/vector.component';
   template: ` <ng-content></ng-content> `,
 })
 export class FeatureComponent implements OnInit, OnDestroy, OnChanges {
-  @Input()
-  id: string | number | undefined;
+  id = input<string | number | undefined>();
 
-  @Input()
-  properties: Record<any, any>;
+  properties = input<Record<any, any>>();
 
-  @Input()
-  feature: Feature;
+  feature = input<Feature>();
 
-  @Input()
-  clickable: boolean;
+  clickable = input<boolean>();
 
-  @Output()
-  olClick = new EventEmitter<{ event: MapBrowserEvent<MouseEvent> | any; feature: Feature }>();
-  @Output()
-  singleClick = new EventEmitter<{ event: MapBrowserEvent<MouseEvent> | any; feature: Feature }>();
-  @Output()
-  dblClick = new EventEmitter<{ event: MapBrowserEvent<MouseEvent> | any; feature: Feature }>();
+  olClick = output<{ event: MapBrowserEvent<MouseEvent> | any; feature: Feature }>();
+  singleClick = output<{ event: MapBrowserEvent<MouseEvent> | any; feature: Feature }>();
+  dblClick = output<{ event: MapBrowserEvent<MouseEvent> | any; feature: Feature }>();
 
   public componentType = 'feature';
   public instance: Feature;
 
+  protected readonly _instanceSignal = signal<Feature | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Feature): Feature {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   constructor(private host: SourceVectorComponent) {}
 
   ngOnInit() {
-    this.instance = this.feature || new Feature();
-    if (this.properties) {
-      this.instance.setProperties(this.properties);
+    this.setInstance(this.feature() || new Feature());
+    if (this.properties()) {
+      this.instance.setProperties(this.properties()!);
     }
-    if (this.id !== undefined) {
-      this.instance.setId(this.id);
+    if (this.id() !== undefined) {
+      this.instance.setId(this.id());
     }
-    if (this.clickable) {
+    if (this.clickable()) {
       this.instance.set('__aol-feature', this);
     }
     this.host.instance.addFeature(this.instance);
@@ -63,14 +64,14 @@ export class FeatureComponent implements OnInit, OnDestroy, OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     const { feature, clickable } = changes;
     if (this.instance) {
-      this.instance.setId(this.id);
+      this.instance.setId(this.id());
     }
 
     if (feature && !feature.firstChange) {
       this.instance.set('__aol-feature', null);
       this.host.instance.removeFeature(this.instance);
-      this.instance = feature.currentValue;
-      if (this.clickable) {
+      this.setInstance(feature.currentValue);
+      if (this.clickable()) {
         this.instance.set('__aol-feature', this);
       }
       this.host.instance.addFeature(this.instance);

--- a/projects/ngx-ol/src/lib/feature.component.ts
+++ b/projects/ngx-ol/src/lib/feature.component.ts
@@ -18,19 +18,19 @@ import { SourceVectorComponent } from './sources/vector.component';
   template: ` <ng-content></ng-content> `,
 })
 export class FeatureComponent implements OnInit, OnDestroy, OnChanges {
-  id = input<string | number | undefined>();
+  readonly id = input<string | number | undefined>();
 
-  properties = input<Record<any, any>>();
+  readonly properties = input<Record<any, any>>();
 
-  feature = input<Feature>();
+  readonly feature = input<Feature>();
 
-  clickable = input<boolean>();
+  readonly clickable = input<boolean>();
 
-  olClick = output<{ event: MapBrowserEvent<MouseEvent> | any; feature: Feature }>();
-  singleClick = output<{ event: MapBrowserEvent<MouseEvent> | any; feature: Feature }>();
-  dblClick = output<{ event: MapBrowserEvent<MouseEvent> | any; feature: Feature }>();
+  readonly olClick = output<{ event: MapBrowserEvent<MouseEvent> | any; feature: Feature }>();
+  readonly singleClick = output<{ event: MapBrowserEvent<MouseEvent> | any; feature: Feature }>();
+  readonly dblClick = output<{ event: MapBrowserEvent<MouseEvent> | any; feature: Feature }>();
 
-  public componentType = 'feature';
+  readonly componentType: string = 'feature';
   public instance: Feature;
 
   protected readonly _instanceSignal = signal<Feature | undefined>(undefined);

--- a/projects/ngx-ol/src/lib/feature.component.ts
+++ b/projects/ngx-ol/src/lib/feature.component.ts
@@ -7,6 +7,7 @@ import {
   input,
   output,
   signal,
+  inject,
 } from '@angular/core';
 import Feature from 'ol/Feature';
 import MapBrowserEvent from 'ol/MapBrowserEvent';
@@ -40,7 +41,7 @@ export class FeatureComponent implements OnInit, OnDestroy, OnChanges {
     this._instanceSignal.set(instance);
     return instance;
   }
-  constructor(private host: SourceVectorComponent) {}
+  private readonly host = inject(SourceVectorComponent);
 
   ngOnInit() {
     this.setInstance(this.feature() || new Feature());

--- a/projects/ngx-ol/src/lib/feature.component.ts
+++ b/projects/ngx-ol/src/lib/feature.component.ts
@@ -44,15 +44,9 @@ export class FeatureComponent implements OnInit, OnDestroy, OnChanges {
 
   ngOnInit() {
     this.setInstance(this.feature() || new Feature());
-    if (this.properties()) {
-      this.instance.setProperties(this.properties()!);
-    }
-    if (this.id() !== undefined) {
-      this.instance.setId(this.id());
-    }
-    if (this.clickable()) {
-      this.instance.set('__aol-feature', this);
-    }
+    this.syncProperties(this.properties());
+    this.syncId();
+    this.syncClickable();
     this.host.instance.addFeature(this.instance);
   }
 
@@ -62,23 +56,52 @@ export class FeatureComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    const { feature, clickable } = changes;
-    if (this.instance) {
-      this.instance.setId(this.id());
-    }
+    const { feature, clickable, id, properties } = changes;
 
     if (feature && !feature.firstChange) {
       this.instance.set('__aol-feature', null);
       this.host.instance.removeFeature(this.instance);
-      this.setInstance(feature.currentValue);
-      if (this.clickable()) {
-        this.instance.set('__aol-feature', this);
-      }
+      this.setInstance(feature.currentValue || new Feature());
+      this.syncProperties(this.properties());
+      this.syncId();
+      this.syncClickable();
       this.host.instance.addFeature(this.instance);
     }
 
+    if (id && !id.firstChange) {
+      this.syncId();
+    }
+
+    if (properties && !properties.firstChange && !(feature && !feature.firstChange)) {
+      this.syncProperties(properties.currentValue, properties.previousValue);
+    }
+
     if (clickable && !clickable.firstChange) {
-      this.instance.set('__aol-feature', clickable.currentValue ? this : null);
+      this.syncClickable();
+    }
+  }
+
+  private syncId() {
+    this.instance.setId(this.id());
+  }
+
+  private syncClickable() {
+    this.instance.set('__aol-feature', this.clickable() ? this : null);
+  }
+
+  private syncProperties(
+    nextProperties?: Record<any, any>,
+    previousProperties?: Record<any, any>,
+  ) {
+    if (previousProperties) {
+      const nextKeys = new Set(Object.keys(nextProperties ?? {}));
+      Object.keys(previousProperties)
+        .filter((key) => !nextKeys.has(key))
+        .forEach((key) => this.instance.unset(key));
+    }
+
+    if (nextProperties) {
+      this.instance.setProperties(nextProperties);
     }
   }
 }

--- a/projects/ngx-ol/src/lib/feature.component.ts
+++ b/projects/ngx-ol/src/lib/feature.component.ts
@@ -89,10 +89,7 @@ export class FeatureComponent implements OnInit, OnDestroy, OnChanges {
     this.instance.set('__aol-feature', this.clickable() ? this : null);
   }
 
-  private syncProperties(
-    nextProperties?: Record<any, any>,
-    previousProperties?: Record<any, any>,
-  ) {
+  private syncProperties(nextProperties?: Record<any, any>, previousProperties?: Record<any, any>) {
     if (previousProperties) {
       const nextKeys = new Set(Object.keys(nextProperties ?? {}));
       Object.keys(previousProperties)

--- a/projects/ngx-ol/src/lib/formats/geojson.component.spec.ts
+++ b/projects/ngx-ol/src/lib/formats/geojson.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import GeoJSON from 'ol/format/GeoJSON';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -19,8 +19,7 @@ class FormatGeoJSONHostComponent {
   geometryName = 'geom';
   dataProjection = 'EPSG:4326';
 
-  @ViewChild(FormatGeoJSONComponent)
-  format!: FormatGeoJSONComponent;
+  readonly format = viewChild.required<FormatGeoJSONComponent>(FormatGeoJSONComponent);
 }
 
 describe('FormatGeoJSONComponent', () => {
@@ -40,6 +39,6 @@ describe('FormatGeoJSONComponent', () => {
   });
 
   it('creates a GeoJSON format from template bindings', () => {
-    expect(fixture.componentInstance.format.instance).toBeInstanceOf(GeoJSON);
+    expect(fixture.componentInstance.format().instance).toBeInstanceOf(GeoJSON);
   });
 });

--- a/projects/ngx-ol/src/lib/formats/geojson.component.ts
+++ b/projects/ngx-ol/src/lib/formats/geojson.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 import GeoJSON from 'ol/format/GeoJSON.js';
 import { Options } from 'ol/format/GeoJSON';
 import { ProjectionLike } from 'ol/proj';
@@ -8,32 +8,38 @@ import { ProjectionLike } from 'ol/proj';
   template: '',
 })
 export class FormatGeoJSONComponent {
-  @Input()
-  featureClass: any;
-  @Input()
-  geometryName?: string;
-  @Input()
-  dataProjection?: ProjectionLike;
-  @Input()
-  featureProjection?: ProjectionLike;
-  @Input()
-  extractGeometryName?: boolean;
+  featureClass = input<any>();
+  geometryName = input<string>();
+  dataProjection = input<ProjectionLike>();
+  featureProjection = input<ProjectionLike>();
+  extractGeometryName = input<boolean>();
 
   public componentType = 'format';
 
   instance: GeoJSON;
 
+  protected readonly _instanceSignal = signal<GeoJSON | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: GeoJSON): GeoJSON {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor() {
-    this.instance = new GeoJSON(this.createOptions());
+    this.setInstance(new GeoJSON(this.createOptions()));
   }
 
   private createOptions(): Options {
     return {
-      featureClass: this.featureClass,
-      geometryName: this.geometryName,
-      dataProjection: this.dataProjection,
-      featureProjection: this.featureProjection,
-      extractGeometryName: this.extractGeometryName,
+      featureClass: this.featureClass(),
+      geometryName: this.geometryName(),
+      dataProjection: this.dataProjection(),
+      featureProjection: this.featureProjection(),
+      extractGeometryName: this.extractGeometryName(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/formats/geojson.component.ts
+++ b/projects/ngx-ol/src/lib/formats/geojson.component.ts
@@ -8,13 +8,13 @@ import { ProjectionLike } from 'ol/proj';
   template: '',
 })
 export class FormatGeoJSONComponent {
-  featureClass = input<any>();
-  geometryName = input<string>();
-  dataProjection = input<ProjectionLike>();
-  featureProjection = input<ProjectionLike>();
-  extractGeometryName = input<boolean>();
+  readonly featureClass = input<any>();
+  readonly geometryName = input<string>();
+  readonly dataProjection = input<ProjectionLike>();
+  readonly featureProjection = input<ProjectionLike>();
+  readonly extractGeometryName = input<boolean>();
 
-  public componentType = 'format';
+  readonly componentType: string = 'format';
 
   instance: GeoJSON;
 

--- a/projects/ngx-ol/src/lib/formats/geojson.component.ts
+++ b/projects/ngx-ol/src/lib/formats/geojson.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, signal } from '@angular/core';
+import { Component, OnInit, input, signal } from '@angular/core';
 import GeoJSON from 'ol/format/GeoJSON.js';
 import { Options } from 'ol/format/GeoJSON';
 import { ProjectionLike } from 'ol/proj';
@@ -7,7 +7,7 @@ import { ProjectionLike } from 'ol/proj';
   selector: 'aol-format-geojson',
   template: '',
 })
-export class FormatGeoJSONComponent {
+export class FormatGeoJSONComponent implements OnInit {
   readonly featureClass = input<any>();
   readonly geometryName = input<string>();
   readonly dataProjection = input<ProjectionLike>();
@@ -29,7 +29,7 @@ export class FormatGeoJSONComponent {
 
     return instance;
   }
-  constructor() {
+  ngOnInit() {
     this.setInstance(new GeoJSON(this.createOptions()));
   }
 

--- a/projects/ngx-ol/src/lib/formats/mvt.component.spec.ts
+++ b/projects/ngx-ol/src/lib/formats/mvt.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import MVT from 'ol/format/MVT';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -13,8 +13,7 @@ import { FormatMVTComponent } from './mvt.component';
 class FormatMVTHostComponent {
   featureClass = undefined;
 
-  @ViewChild(FormatMVTComponent)
-  format!: FormatMVTComponent;
+  readonly format = viewChild.required<FormatMVTComponent>(FormatMVTComponent);
 }
 
 describe('FormatMVTComponent', () => {
@@ -34,6 +33,6 @@ describe('FormatMVTComponent', () => {
   });
 
   it('creates an MVT format from template bindings', () => {
-    expect(fixture.componentInstance.format.instance).toBeInstanceOf(MVT);
+    expect(fixture.componentInstance.format().instance).toBeInstanceOf(MVT);
   });
 });

--- a/projects/ngx-ol/src/lib/formats/mvt.component.ts
+++ b/projects/ngx-ol/src/lib/formats/mvt.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 import MVT from 'ol/format/MVT';
 import { FeatureClass } from 'ol/Feature';
 import { Options } from 'ol/format/MVT';
@@ -8,32 +8,38 @@ import { Options } from 'ol/format/MVT';
   template: '',
 })
 export class FormatMVTComponent {
-  @Input()
-  featureClass?: FeatureClass;
-  @Input()
-  geometryName?: string;
-  @Input()
-  layerName?: string;
-  @Input()
-  layers?: string[];
-  @Input()
-  idProperty?: string;
+  featureClass = input<FeatureClass>();
+  geometryName = input<string>();
+  layerName = input<string>();
+  layers = input<string[]>();
+  idProperty = input<string>();
 
   public componentType = 'format';
 
   instance: MVT;
 
+  protected readonly _instanceSignal = signal<MVT | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: MVT): MVT {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor() {
-    this.instance = new MVT(this.createOptions());
+    this.setInstance(new MVT(this.createOptions()));
   }
 
   private createOptions(): Options<any> {
     return {
-      featureClass: this.featureClass,
-      geometryName: this.geometryName,
-      layerName: this.layerName,
-      layers: this.layers,
-      idProperty: this.idProperty,
+      featureClass: this.featureClass(),
+      geometryName: this.geometryName(),
+      layerName: this.layerName(),
+      layers: this.layers(),
+      idProperty: this.idProperty(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/formats/mvt.component.ts
+++ b/projects/ngx-ol/src/lib/formats/mvt.component.ts
@@ -8,13 +8,13 @@ import { Options } from 'ol/format/MVT';
   template: '',
 })
 export class FormatMVTComponent {
-  featureClass = input<FeatureClass>();
-  geometryName = input<string>();
-  layerName = input<string>();
-  layers = input<string[]>();
-  idProperty = input<string>();
+  readonly featureClass = input<FeatureClass>();
+  readonly geometryName = input<string>();
+  readonly layerName = input<string>();
+  readonly layers = input<string[]>();
+  readonly idProperty = input<string>();
 
-  public componentType = 'format';
+  readonly componentType: string = 'format';
 
   instance: MVT;
 

--- a/projects/ngx-ol/src/lib/formats/mvt.component.ts
+++ b/projects/ngx-ol/src/lib/formats/mvt.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, signal } from '@angular/core';
+import { Component, OnInit, input, signal } from '@angular/core';
 import MVT from 'ol/format/MVT';
 import { FeatureClass } from 'ol/Feature';
 import { Options } from 'ol/format/MVT';
@@ -7,7 +7,7 @@ import { Options } from 'ol/format/MVT';
   selector: 'aol-format-mvt',
   template: '',
 })
-export class FormatMVTComponent {
+export class FormatMVTComponent implements OnInit {
   readonly featureClass = input<FeatureClass>();
   readonly geometryName = input<string>();
   readonly layerName = input<string>();
@@ -29,7 +29,7 @@ export class FormatMVTComponent {
 
     return instance;
   }
-  constructor() {
+  ngOnInit() {
     this.setInstance(new MVT(this.createOptions()));
   }
 

--- a/projects/ngx-ol/src/lib/geom/geometrycircle.component.spec.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrycircle.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Circle from 'ol/geom/Circle';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -28,11 +28,9 @@ class GeometryCircleHostComponent {
   center = [5, 6];
   radius = 10;
 
-  @ViewChild(GeometryCircleComponent)
-  geometry!: GeometryCircleComponent;
+  readonly geometry = viewChild.required<GeometryCircleComponent>(GeometryCircleComponent);
 
-  @ViewChild(FeatureComponent)
-  feature!: FeatureComponent;
+  readonly feature = viewChild.required<FeatureComponent>(FeatureComponent);
 }
 
 describe('GeometryCircleComponent', () => {
@@ -52,11 +50,11 @@ describe('GeometryCircleComponent', () => {
   });
 
   it('binds center and radius through Angular inputs and attaches the geometry to the feature', () => {
-    expect(fixture.componentInstance.geometry.instance).toBeInstanceOf(Circle);
-    expect(fixture.componentInstance.feature.instance.getGeometry()).toBe(
-      fixture.componentInstance.geometry.instance,
+    expect(fixture.componentInstance.geometry().instance).toBeInstanceOf(Circle);
+    expect(fixture.componentInstance.feature().instance.getGeometry()).toBe(
+      fixture.componentInstance.geometry().instance,
     );
-    expect(fixture.componentInstance.geometry.instance.getCenter()).toEqual([5, 6]);
-    expect(fixture.componentInstance.geometry.instance.getRadius()).toBe(10);
+    expect(fixture.componentInstance.geometry().instance.getCenter()).toEqual([5, 6]);
+    expect(fixture.componentInstance.geometry().instance.getRadius()).toBe(10);
   });
 });

--- a/projects/ngx-ol/src/lib/geom/geometrycircle.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrycircle.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges, input, signal } from '@angular/core';
 import { FeatureComponent } from '../feature.component';
 import Circle from 'ol/geom/Circle';
 import { SimpleGeometryComponent } from './simplegeometry.component';
@@ -11,19 +11,27 @@ import { GeometryLayout } from 'ol/geom/Geometry';
   template: ` <ng-content></ng-content> `,
 })
 export class GeometryCircleComponent extends SimpleGeometryComponent implements OnInit, OnChanges {
-  @Input() center: Coordinate = [0, 0];
-  @Input() layout: GeometryLayout;
-  @Input() radius: number;
+  center = input<Coordinate>([0, 0]);
+  layout = input<GeometryLayout>();
+  radius = input<number>();
 
   public componentType = 'geometry-circle';
   public instance: Circle;
 
+  protected readonly _instanceSignal = signal<Circle | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Circle): Circle {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   constructor(map: MapComponent, host: FeatureComponent) {
     super(map, host);
   }
 
   ngOnInit() {
-    this.instance = new Circle(this.center, this.radius, this.layout);
+    this.setInstance(new Circle(this.center(), this.radius(), this.layout()));
     super.ngOnInit();
   }
 

--- a/projects/ngx-ol/src/lib/geom/geometrycircle.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrycircle.component.ts
@@ -11,11 +11,11 @@ import { GeometryLayout } from 'ol/geom/Geometry';
   template: ` <ng-content></ng-content> `,
 })
 export class GeometryCircleComponent extends SimpleGeometryComponent implements OnInit, OnChanges {
-  center = input<Coordinate>([0, 0]);
-  layout = input<GeometryLayout>();
-  radius = input<number>();
+  readonly center = input<Coordinate>([0, 0]);
+  readonly layout = input<GeometryLayout>();
+  readonly radius = input<number>();
 
-  public componentType = 'geometry-circle';
+  readonly componentType: string = 'geometry-circle';
   public instance: Circle;
 
   protected readonly _instanceSignal = signal<Circle | undefined>(undefined);

--- a/projects/ngx-ol/src/lib/geom/geometrycollection.component.spec.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrycollection.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import GeometryCollection from 'ol/geom/GeometryCollection';
 import Point from 'ol/geom/Point';
@@ -28,11 +28,9 @@ class GeometryCollectionHostComponent {
   zoom = 2;
   geometries = [new Point([1, 2]), new Point([3, 4])];
 
-  @ViewChild(GeometryCollectionComponent)
-  geometry!: GeometryCollectionComponent;
+  readonly geometry = viewChild.required<GeometryCollectionComponent>(GeometryCollectionComponent);
 
-  @ViewChild(FeatureComponent)
-  feature!: FeatureComponent;
+  readonly feature = viewChild.required<FeatureComponent>(FeatureComponent);
 }
 
 describe('GeometryCollectionComponent', () => {
@@ -52,16 +50,17 @@ describe('GeometryCollectionComponent', () => {
   });
 
   it('attaches the bound geometry collection to its feature', () => {
-    expect(fixture.componentInstance.geometry.instance).toBeInstanceOf(GeometryCollection);
+    expect(fixture.componentInstance.geometry().instance).toBeInstanceOf(GeometryCollection);
     expect(
-      fixture.componentInstance.geometry.instance.getGeometries().map((geometry) =>
-        (geometry as any).getCoordinates(),
-      ),
+      fixture.componentInstance
+        .geometry()
+        .instance.getGeometries()
+        .map((geometry) => (geometry as any).getCoordinates()),
     ).toEqual(
       fixture.componentInstance.geometries.map((geometry) => (geometry as any).getCoordinates()),
     );
-    expect(fixture.componentInstance.feature.instance.getGeometry()).toBe(
-      fixture.componentInstance.geometry.instance,
+    expect(fixture.componentInstance.feature().instance.getGeometry()).toBe(
+      fixture.componentInstance.geometry().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/geom/geometrycollection.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrycollection.component.ts
@@ -8,9 +8,9 @@ import { FeatureComponent } from '../feature.component';
   template: ` <ng-content></ng-content> `,
 })
 export class GeometryCollectionComponent implements OnInit, OnChanges {
-  geometries = input<Geometry[]>([]);
+  readonly geometries = input<Geometry[]>([]);
 
-  public componentType = 'geometry-collection';
+  readonly componentType: string = 'geometry-collection';
   public instance: GeometryCollection;
 
   protected readonly _instanceSignal = signal<GeometryCollection | undefined>(undefined);

--- a/projects/ngx-ol/src/lib/geom/geometrycollection.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrycollection.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges, input, signal } from '@angular/core';
 import Geometry from 'ol/geom/Geometry';
 import GeometryCollection from 'ol/geom/GeometryCollection';
 import { FeatureComponent } from '../feature.component';
@@ -8,16 +8,23 @@ import { FeatureComponent } from '../feature.component';
   template: ` <ng-content></ng-content> `,
 })
 export class GeometryCollectionComponent implements OnInit, OnChanges {
-  @Input()
-  geometries: Geometry[] = [];
+  geometries = input<Geometry[]>([]);
 
   public componentType = 'geometry-collection';
   public instance: GeometryCollection;
 
+  protected readonly _instanceSignal = signal<GeometryCollection | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: GeometryCollection): GeometryCollection {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   constructor(private host: FeatureComponent) {}
 
   ngOnInit() {
-    this.instance = new GeometryCollection(this.geometries);
+    this.setInstance(new GeometryCollection(this.geometries()));
     this.host.instance.setGeometry(this.instance);
   }
 

--- a/projects/ngx-ol/src/lib/geom/geometrycollection.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrycollection.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, OnInit, SimpleChanges, input, signal } from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges, input, signal, inject } from '@angular/core';
 import Geometry from 'ol/geom/Geometry';
 import GeometryCollection from 'ol/geom/GeometryCollection';
 import { FeatureComponent } from '../feature.component';
@@ -21,7 +21,7 @@ export class GeometryCollectionComponent implements OnInit, OnChanges {
     this._instanceSignal.set(instance);
     return instance;
   }
-  constructor(private host: FeatureComponent) {}
+  private readonly host = inject(FeatureComponent);
 
   ngOnInit() {
     this.setInstance(new GeometryCollection(this.geometries()));

--- a/projects/ngx-ol/src/lib/geom/geometrylinestring.component.spec.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrylinestring.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import LineString from 'ol/geom/LineString';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -14,7 +14,10 @@ import { GeometryLinestringComponent } from './geometrylinestring.component';
         <aol-source-vector>
           <aol-feature>
             <aol-geometry-linestring>
-              <aol-collection-coordinates [coordinates]="coordinates" [srid]="srid"></aol-collection-coordinates>
+              <aol-collection-coordinates
+                [coordinates]="coordinates"
+                [srid]="srid"
+              ></aol-collection-coordinates>
             </aol-geometry-linestring>
           </aol-feature>
         </aol-source-vector>
@@ -34,11 +37,9 @@ class GeometryLinestringHostComponent {
     [3, 4],
   ];
 
-  @ViewChild(GeometryLinestringComponent)
-  geometry!: GeometryLinestringComponent;
+  readonly geometry = viewChild.required<GeometryLinestringComponent>(GeometryLinestringComponent);
 
-  @ViewChild(FeatureComponent)
-  feature!: FeatureComponent;
+  readonly feature = viewChild.required<FeatureComponent>(FeatureComponent);
 }
 
 describe('GeometryLinestringComponent', () => {
@@ -58,12 +59,12 @@ describe('GeometryLinestringComponent', () => {
   });
 
   it('attaches the bound line string geometry to its feature', () => {
-    expect(fixture.componentInstance.geometry.instance).toBeInstanceOf(LineString);
-    expect(fixture.componentInstance.geometry.instance.getCoordinates()).toEqual(
+    expect(fixture.componentInstance.geometry().instance).toBeInstanceOf(LineString);
+    expect(fixture.componentInstance.geometry().instance.getCoordinates()).toEqual(
       fixture.componentInstance.coordinates,
     );
-    expect(fixture.componentInstance.feature.instance.getGeometry()).toBe(
-      fixture.componentInstance.geometry.instance,
+    expect(fixture.componentInstance.feature().instance.getGeometry()).toBe(
+      fixture.componentInstance.geometry().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/geom/geometrylinestring.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrylinestring.component.ts
@@ -9,7 +9,7 @@ import LineString from 'ol/geom/LineString';
   template: ` <ng-content></ng-content> `,
 })
 export class GeometryLinestringComponent extends SimpleGeometryComponent implements OnInit {
-  public componentType = 'geometry-linestring';
+  readonly componentType: string = 'geometry-linestring';
   public instance: LineString;
 
   protected readonly _instanceSignal = signal<LineString | undefined>(undefined);

--- a/projects/ngx-ol/src/lib/geom/geometrylinestring.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrylinestring.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { FeatureComponent } from '../feature.component';
 import { SimpleGeometryComponent } from './simplegeometry.component';
 import { MapComponent } from '../map.component';
@@ -12,15 +12,25 @@ export class GeometryLinestringComponent extends SimpleGeometryComponent impleme
   public componentType = 'geometry-linestring';
   public instance: LineString;
 
+  protected readonly _instanceSignal = signal<LineString | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: LineString): LineString {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   constructor(map: MapComponent, host: FeatureComponent) {
     super(map, host);
   }
 
   ngOnInit() {
-    this.instance = new LineString([
-      [0, 0],
-      [1, 1],
-    ]);
+    this.setInstance(
+      new LineString([
+        [0, 0],
+        [1, 1],
+      ]),
+    );
     super.ngOnInit();
   }
 }

--- a/projects/ngx-ol/src/lib/geom/geometrymultilinestring.component.spec.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrymultilinestring.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import MultiLineString from 'ol/geom/MultiLineString';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -14,7 +14,10 @@ import { GeometryMultiLinestringComponent } from './geometrymultilinestring.comp
         <aol-source-vector>
           <aol-feature>
             <aol-geometry-multilinestring>
-              <aol-collection-coordinates [coordinates]="coordinates" [srid]="srid"></aol-collection-coordinates>
+              <aol-collection-coordinates
+                [coordinates]="coordinates"
+                [srid]="srid"
+              ></aol-collection-coordinates>
             </aol-geometry-multilinestring>
           </aol-feature>
         </aol-source-vector>
@@ -39,11 +42,11 @@ class GeometryMultiLinestringHostComponent {
     ],
   ];
 
-  @ViewChild(GeometryMultiLinestringComponent)
-  geometry!: GeometryMultiLinestringComponent;
+  readonly geometry = viewChild.required<GeometryMultiLinestringComponent>(
+    GeometryMultiLinestringComponent,
+  );
 
-  @ViewChild(FeatureComponent)
-  feature!: FeatureComponent;
+  readonly feature = viewChild.required<FeatureComponent>(FeatureComponent);
 }
 
 describe('GeometryMultiLinestringComponent', () => {
@@ -63,12 +66,12 @@ describe('GeometryMultiLinestringComponent', () => {
   });
 
   it('attaches the bound multi-line string geometry to its feature', () => {
-    expect(fixture.componentInstance.geometry.instance).toBeInstanceOf(MultiLineString);
-    expect(fixture.componentInstance.geometry.instance.getCoordinates()).toEqual(
+    expect(fixture.componentInstance.geometry().instance).toBeInstanceOf(MultiLineString);
+    expect(fixture.componentInstance.geometry().instance.getCoordinates()).toEqual(
       fixture.componentInstance.coordinates,
     );
-    expect(fixture.componentInstance.feature.instance.getGeometry()).toBe(
-      fixture.componentInstance.geometry.instance,
+    expect(fixture.componentInstance.feature().instance.getGeometry()).toBe(
+      fixture.componentInstance.geometry().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/geom/geometrymultilinestring.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrymultilinestring.component.ts
@@ -9,7 +9,7 @@ import MultiLineString from 'ol/geom/MultiLineString';
   template: ` <ng-content></ng-content> `,
 })
 export class GeometryMultiLinestringComponent extends SimpleGeometryComponent implements OnInit {
-  public componentType = 'geometry-multilinestring';
+  readonly componentType: string = 'geometry-multilinestring';
   public instance: MultiLineString;
 
   protected readonly _instanceSignal = signal<MultiLineString | undefined>(undefined);

--- a/projects/ngx-ol/src/lib/geom/geometrymultilinestring.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrymultilinestring.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { FeatureComponent } from '../feature.component';
 import { SimpleGeometryComponent } from './simplegeometry.component';
 import { MapComponent } from '../map.component';
@@ -12,17 +12,27 @@ export class GeometryMultiLinestringComponent extends SimpleGeometryComponent im
   public componentType = 'geometry-multilinestring';
   public instance: MultiLineString;
 
+  protected readonly _instanceSignal = signal<MultiLineString | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: MultiLineString): MultiLineString {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   constructor(map: MapComponent, host: FeatureComponent) {
     super(map, host);
   }
 
   ngOnInit() {
-    this.instance = new MultiLineString([
-      [
-        [0, 0],
-        [1, 1],
-      ],
-    ]);
+    this.setInstance(
+      new MultiLineString([
+        [
+          [0, 0],
+          [1, 1],
+        ],
+      ]),
+    );
     super.ngOnInit();
   }
 }

--- a/projects/ngx-ol/src/lib/geom/geometrymultipoint.component.spec.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrymultipoint.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import MultiPoint from 'ol/geom/MultiPoint';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -14,7 +14,10 @@ import { GeometryMultiPointComponent } from './geometrymultipoint.component';
         <aol-source-vector>
           <aol-feature>
             <aol-geometry-multipoint>
-              <aol-collection-coordinates [coordinates]="coordinates" [srid]="srid"></aol-collection-coordinates>
+              <aol-collection-coordinates
+                [coordinates]="coordinates"
+                [srid]="srid"
+              ></aol-collection-coordinates>
             </aol-geometry-multipoint>
           </aol-feature>
         </aol-source-vector>
@@ -33,11 +36,9 @@ class GeometryMultiPointHostComponent {
     [2, 2],
   ];
 
-  @ViewChild(GeometryMultiPointComponent)
-  geometry!: GeometryMultiPointComponent;
+  readonly geometry = viewChild.required<GeometryMultiPointComponent>(GeometryMultiPointComponent);
 
-  @ViewChild(FeatureComponent)
-  feature!: FeatureComponent;
+  readonly feature = viewChild.required<FeatureComponent>(FeatureComponent);
 }
 
 describe('GeometryMultiPointComponent', () => {
@@ -57,11 +58,11 @@ describe('GeometryMultiPointComponent', () => {
   });
 
   it('binds multipoint coordinates through Angular inputs and attaches the geometry to the feature', () => {
-    expect(fixture.componentInstance.geometry.instance).toBeInstanceOf(MultiPoint);
-    expect(fixture.componentInstance.feature.instance.getGeometry()).toBe(
-      fixture.componentInstance.geometry.instance,
+    expect(fixture.componentInstance.geometry().instance).toBeInstanceOf(MultiPoint);
+    expect(fixture.componentInstance.feature().instance.getGeometry()).toBe(
+      fixture.componentInstance.geometry().instance,
     );
-    expect(fixture.componentInstance.geometry.instance.getCoordinates()).toEqual(
+    expect(fixture.componentInstance.geometry().instance.getCoordinates()).toEqual(
       fixture.componentInstance.coordinates,
     );
   });

--- a/projects/ngx-ol/src/lib/geom/geometrymultipoint.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrymultipoint.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { FeatureComponent } from '../feature.component';
 import { SimpleGeometryComponent } from './simplegeometry.component';
 import { MapComponent } from '../map.component';
@@ -12,15 +12,25 @@ export class GeometryMultiPointComponent extends SimpleGeometryComponent impleme
   public componentType = 'geometry-multipoint';
   public instance: MultiPoint;
 
+  protected readonly _instanceSignal = signal<MultiPoint | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: MultiPoint): MultiPoint {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   constructor(map: MapComponent, host: FeatureComponent) {
     super(map, host);
   }
 
   ngOnInit() {
-    this.instance = new MultiPoint([
-      [0, 0],
-      [1, 1],
-    ]);
+    this.setInstance(
+      new MultiPoint([
+        [0, 0],
+        [1, 1],
+      ]),
+    );
     super.ngOnInit();
   }
 }

--- a/projects/ngx-ol/src/lib/geom/geometrymultipoint.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrymultipoint.component.ts
@@ -9,7 +9,7 @@ import MultiPoint from 'ol/geom/MultiPoint';
   template: ` <ng-content></ng-content> `,
 })
 export class GeometryMultiPointComponent extends SimpleGeometryComponent implements OnInit {
-  public componentType = 'geometry-multipoint';
+  readonly componentType: string = 'geometry-multipoint';
   public instance: MultiPoint;
 
   protected readonly _instanceSignal = signal<MultiPoint | undefined>(undefined);

--- a/projects/ngx-ol/src/lib/geom/geometrymultipolygon.component.spec.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrymultipolygon.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import MultiPolygon from 'ol/geom/MultiPolygon';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -14,7 +14,10 @@ import { GeometryMultiPolygonComponent } from './geometrymultipolygon.component'
         <aol-source-vector>
           <aol-feature>
             <aol-geometry-multipolygon>
-              <aol-collection-coordinates [coordinates]="coordinates" [srid]="srid"></aol-collection-coordinates>
+              <aol-collection-coordinates
+                [coordinates]="coordinates"
+                [srid]="srid"
+              ></aol-collection-coordinates>
             </aol-geometry-multipolygon>
           </aol-feature>
         </aol-source-vector>
@@ -39,11 +42,11 @@ class GeometryMultiPolygonHostComponent {
     ],
   ];
 
-  @ViewChild(GeometryMultiPolygonComponent)
-  geometry!: GeometryMultiPolygonComponent;
+  readonly geometry = viewChild.required<GeometryMultiPolygonComponent>(
+    GeometryMultiPolygonComponent,
+  );
 
-  @ViewChild(FeatureComponent)
-  feature!: FeatureComponent;
+  readonly feature = viewChild.required<FeatureComponent>(FeatureComponent);
 }
 
 describe('GeometryMultiPolygonComponent', () => {
@@ -63,12 +66,12 @@ describe('GeometryMultiPolygonComponent', () => {
   });
 
   it('attaches the bound multi-polygon geometry to its feature', () => {
-    expect(fixture.componentInstance.geometry.instance).toBeInstanceOf(MultiPolygon);
-    expect(fixture.componentInstance.geometry.instance.getCoordinates()).toEqual(
+    expect(fixture.componentInstance.geometry().instance).toBeInstanceOf(MultiPolygon);
+    expect(fixture.componentInstance.geometry().instance.getCoordinates()).toEqual(
       fixture.componentInstance.coordinates,
     );
-    expect(fixture.componentInstance.feature.instance.getGeometry()).toBe(
-      fixture.componentInstance.geometry.instance,
+    expect(fixture.componentInstance.feature().instance.getGeometry()).toBe(
+      fixture.componentInstance.geometry().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/geom/geometrymultipolygon.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrymultipolygon.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { FeatureComponent } from '../feature.component';
 import { SimpleGeometryComponent } from './simplegeometry.component';
 import { MapComponent } from '../map.component';
@@ -12,20 +12,30 @@ export class GeometryMultiPolygonComponent extends SimpleGeometryComponent imple
   public componentType = 'geometry-multipolygon';
   public instance: MultiPolygon;
 
+  protected readonly _instanceSignal = signal<MultiPolygon | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: MultiPolygon): MultiPolygon {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   constructor(map: MapComponent, host: FeatureComponent) {
     super(map, host);
   }
 
   ngOnInit() {
-    this.instance = new MultiPolygon([
-      [
+    this.setInstance(
+      new MultiPolygon([
         [
-          [0, 0],
-          [1, 1],
-          [0, 1],
+          [
+            [0, 0],
+            [1, 1],
+            [0, 1],
+          ],
         ],
-      ],
-    ]);
+      ]),
+    );
     super.ngOnInit();
   }
 }

--- a/projects/ngx-ol/src/lib/geom/geometrymultipolygon.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrymultipolygon.component.ts
@@ -9,7 +9,7 @@ import MultiPolygon from 'ol/geom/MultiPolygon';
   template: ` <ng-content></ng-content> `,
 })
 export class GeometryMultiPolygonComponent extends SimpleGeometryComponent implements OnInit {
-  public componentType = 'geometry-multipolygon';
+  readonly componentType: string = 'geometry-multipolygon';
   public instance: MultiPolygon;
 
   protected readonly _instanceSignal = signal<MultiPolygon | undefined>(undefined);

--- a/projects/ngx-ol/src/lib/geom/geometrypoint.component.spec.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrypoint.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Point from 'ol/geom/Point';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -31,11 +31,9 @@ class GeometryPointHostComponent {
   y = 2;
   srid = 'EPSG:3857';
 
-  @ViewChild(GeometryPointComponent)
-  geometry!: GeometryPointComponent;
+  readonly geometry = viewChild.required<GeometryPointComponent>(GeometryPointComponent);
 
-  @ViewChild(FeatureComponent)
-  feature!: FeatureComponent;
+  readonly feature = viewChild.required<FeatureComponent>(FeatureComponent);
 }
 
 describe('GeometryPointComponent', () => {
@@ -55,10 +53,10 @@ describe('GeometryPointComponent', () => {
   });
 
   it('attaches the bound point geometry to its feature', () => {
-    expect(fixture.componentInstance.geometry.instance).toBeInstanceOf(Point);
-    expect(fixture.componentInstance.geometry.instance.getCoordinates()).toEqual([1, 2]);
-    expect(fixture.componentInstance.feature.instance.getGeometry()).toBe(
-      fixture.componentInstance.geometry.instance,
+    expect(fixture.componentInstance.geometry().instance).toBeInstanceOf(Point);
+    expect(fixture.componentInstance.geometry().instance.getCoordinates()).toEqual([1, 2]);
+    expect(fixture.componentInstance.feature().instance.getGeometry()).toBe(
+      fixture.componentInstance.geometry().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/geom/geometrypoint.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrypoint.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges, input, signal } from '@angular/core';
 import { FeatureComponent } from '../feature.component';
 import { SimpleGeometryComponent } from './simplegeometry.component';
 import { MapComponent } from '../map.component';
@@ -11,18 +11,26 @@ import { GeometryLayout } from 'ol/geom/Geometry';
   template: ` <ng-content></ng-content> `,
 })
 export class GeometryPointComponent extends SimpleGeometryComponent implements OnInit, OnChanges {
-  @Input() coordinates: Coordinate = [0, 0];
-  @Input() layout: GeometryLayout;
+  coordinates = input<Coordinate>([0, 0]);
+  layout = input<GeometryLayout>();
 
   public componentType = 'geometry-point';
   public instance: Point;
 
+  protected readonly _instanceSignal = signal<Point | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Point): Point {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   constructor(map: MapComponent, host: FeatureComponent) {
     super(map, host);
   }
 
   ngOnInit() {
-    this.instance = new Point(this.coordinates, this.layout);
+    this.setInstance(new Point(this.coordinates(), this.layout()));
     super.ngOnInit();
   }
 

--- a/projects/ngx-ol/src/lib/geom/geometrypoint.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrypoint.component.ts
@@ -11,10 +11,10 @@ import { GeometryLayout } from 'ol/geom/Geometry';
   template: ` <ng-content></ng-content> `,
 })
 export class GeometryPointComponent extends SimpleGeometryComponent implements OnInit, OnChanges {
-  coordinates = input<Coordinate>([0, 0]);
-  layout = input<GeometryLayout>();
+  readonly coordinates = input<Coordinate>([0, 0]);
+  readonly layout = input<GeometryLayout>();
 
-  public componentType = 'geometry-point';
+  readonly componentType: string = 'geometry-point';
   public instance: Point;
 
   protected readonly _instanceSignal = signal<Point | undefined>(undefined);

--- a/projects/ngx-ol/src/lib/geom/geometrypolygon.component.spec.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrypolygon.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Polygon from 'ol/geom/Polygon';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -14,7 +14,10 @@ import { GeometryPolygonComponent } from './geometrypolygon.component';
         <aol-source-vector>
           <aol-feature>
             <aol-geometry-polygon>
-              <aol-collection-coordinates [coordinates]="coordinates" [srid]="srid"></aol-collection-coordinates>
+              <aol-collection-coordinates
+                [coordinates]="coordinates"
+                [srid]="srid"
+              ></aol-collection-coordinates>
             </aol-geometry-polygon>
           </aol-feature>
         </aol-source-vector>
@@ -37,11 +40,9 @@ class GeometryPolygonHostComponent {
     ],
   ];
 
-  @ViewChild(GeometryPolygonComponent)
-  geometry!: GeometryPolygonComponent;
+  readonly geometry = viewChild.required<GeometryPolygonComponent>(GeometryPolygonComponent);
 
-  @ViewChild(FeatureComponent)
-  feature!: FeatureComponent;
+  readonly feature = viewChild.required<FeatureComponent>(FeatureComponent);
 }
 
 describe('GeometryPolygonComponent', () => {
@@ -61,11 +62,11 @@ describe('GeometryPolygonComponent', () => {
   });
 
   it('binds polygon coordinates through Angular inputs and attaches the geometry to the feature', () => {
-    expect(fixture.componentInstance.geometry.instance).toBeInstanceOf(Polygon);
-    expect(fixture.componentInstance.feature.instance.getGeometry()).toBe(
-      fixture.componentInstance.geometry.instance,
+    expect(fixture.componentInstance.geometry().instance).toBeInstanceOf(Polygon);
+    expect(fixture.componentInstance.feature().instance.getGeometry()).toBe(
+      fixture.componentInstance.geometry().instance,
     );
-    expect(fixture.componentInstance.geometry.instance.getCoordinates()).toEqual(
+    expect(fixture.componentInstance.geometry().instance.getCoordinates()).toEqual(
       fixture.componentInstance.coordinates,
     );
   });

--- a/projects/ngx-ol/src/lib/geom/geometrypolygon.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrypolygon.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { FeatureComponent } from '../feature.component';
 import { SimpleGeometryComponent } from './simplegeometry.component';
 import { MapComponent } from '../map.component';
@@ -12,18 +12,28 @@ export class GeometryPolygonComponent extends SimpleGeometryComponent implements
   public componentType = 'geometry-polygon';
   public instance: Polygon;
 
+  protected readonly _instanceSignal = signal<Polygon | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Polygon): Polygon {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   constructor(map: MapComponent, host: FeatureComponent) {
     super(map, host);
   }
 
   ngOnInit() {
-    this.instance = new Polygon([
-      [
-        [0, 0],
-        [1, 1],
-        [0, 1],
-      ],
-    ]);
+    this.setInstance(
+      new Polygon([
+        [
+          [0, 0],
+          [1, 1],
+          [0, 1],
+        ],
+      ]),
+    );
     super.ngOnInit();
   }
 }

--- a/projects/ngx-ol/src/lib/geom/geometrypolygon.component.ts
+++ b/projects/ngx-ol/src/lib/geom/geometrypolygon.component.ts
@@ -9,7 +9,7 @@ import Polygon from 'ol/geom/Polygon';
   template: ` <ng-content></ng-content> `,
 })
 export class GeometryPolygonComponent extends SimpleGeometryComponent implements OnInit {
-  public componentType = 'geometry-polygon';
+  readonly componentType: string = 'geometry-polygon';
   public instance: Polygon;
 
   protected readonly _instanceSignal = signal<Polygon | undefined>(undefined);

--- a/projects/ngx-ol/src/lib/geom/simplegeometry.component.ts
+++ b/projects/ngx-ol/src/lib/geom/simplegeometry.component.ts
@@ -6,7 +6,7 @@ import SimpleGeometry from 'ol/geom/SimpleGeometry';
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export abstract class SimpleGeometryComponent implements OnInit {
-  srid = input<string>();
+  readonly srid = input<string>();
 
   public instance: SimpleGeometry;
 
@@ -21,11 +21,11 @@ export abstract class SimpleGeometryComponent implements OnInit {
 
     return instance;
   }
-  public componentType = 'simple-geometry';
+  readonly componentType: string = 'simple-geometry';
 
   protected constructor(
-    protected map: MapComponent,
-    protected host: FeatureComponent,
+    protected readonly map: MapComponent,
+    protected readonly host: FeatureComponent,
   ) {}
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/geom/simplegeometry.component.ts
+++ b/projects/ngx-ol/src/lib/geom/simplegeometry.component.ts
@@ -1,4 +1,4 @@
-import { Input, OnInit, Directive } from '@angular/core';
+import { OnInit, Directive, input, signal } from '@angular/core';
 import { FeatureComponent } from '../feature.component';
 import { MapComponent } from '../map.component';
 import SimpleGeometry from 'ol/geom/SimpleGeometry';
@@ -6,9 +6,21 @@ import SimpleGeometry from 'ol/geom/SimpleGeometry';
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export abstract class SimpleGeometryComponent implements OnInit {
-  @Input() srid: string;
+  srid = input<string>();
 
   public instance: SimpleGeometry;
+
+  protected readonly _instanceSignal = signal<SimpleGeometry | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: SimpleGeometry): SimpleGeometry {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   public componentType = 'simple-geometry';
 
   protected constructor(

--- a/projects/ngx-ol/src/lib/graticule.component.spec.ts
+++ b/projects/ngx-ol/src/lib/graticule.component.spec.ts
@@ -1,6 +1,6 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, signal, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AngularOpenlayersModule } from '../public-api';
 import { MapComponent } from './map.component';
 import { GraticuleComponent } from './graticule.component';
@@ -9,7 +9,7 @@ import { GraticuleComponent } from './graticule.component';
   template: `
     <aol-map width="320px" height="240px">
       <aol-view [center]="center" [zoom]="zoom"></aol-view>
-      <aol-graticule [showLabels]="showLabels"></aol-graticule>
+      <aol-graticule [showLabels]="showLabels()"></aol-graticule>
     </aol-map>
   `,
   standalone: true,
@@ -18,7 +18,7 @@ import { GraticuleComponent } from './graticule.component';
 class GraticuleHostComponent {
   center = [0, 0];
   zoom = 2;
-  showLabels = true;
+  showLabels = signal(true);
 
   @ViewChild(GraticuleComponent)
   graticule!: GraticuleComponent;
@@ -46,5 +46,16 @@ describe('GraticuleComponent', () => {
   it('creates a graticule bound to the map from template inputs', () => {
     expect(fixture.componentInstance.graticule.instance).toBeDefined();
     expect(fixture.componentInstance.graticule.instance.getMeridians()).toBeDefined();
+  });
+
+  it('detaches the previous graticule when input changes require a rebuild', () => {
+    const previousGraticule = fixture.componentInstance.graticule.instance;
+    const setMap = vi.spyOn(previousGraticule, 'setMap');
+
+    fixture.componentInstance.showLabels.set(false);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.graticule.instance).not.toBe(previousGraticule);
+    expect(setMap).toHaveBeenCalledWith(null);
   });
 });

--- a/projects/ngx-ol/src/lib/graticule.component.spec.ts
+++ b/projects/ngx-ol/src/lib/graticule.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AngularOpenlayersModule } from '../public-api';
@@ -20,11 +20,9 @@ class GraticuleHostComponent {
   zoom = 2;
   showLabels = signal(true);
 
-  @ViewChild(GraticuleComponent)
-  graticule!: GraticuleComponent;
+  readonly graticule = viewChild.required<GraticuleComponent>(GraticuleComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('GraticuleComponent', () => {
@@ -44,18 +42,18 @@ describe('GraticuleComponent', () => {
   });
 
   it('creates a graticule bound to the map from template inputs', () => {
-    expect(fixture.componentInstance.graticule.instance).toBeDefined();
-    expect(fixture.componentInstance.graticule.instance.getMeridians()).toBeDefined();
+    expect(fixture.componentInstance.graticule().instance).toBeDefined();
+    expect(fixture.componentInstance.graticule().instance.getMeridians()).toBeDefined();
   });
 
   it('detaches the previous graticule when input changes require a rebuild', () => {
-    const previousGraticule = fixture.componentInstance.graticule.instance;
+    const previousGraticule = fixture.componentInstance.graticule().instance;
     const setMap = vi.spyOn(previousGraticule, 'setMap');
 
     fixture.componentInstance.showLabels.set(false);
     fixture.detectChanges();
 
-    expect(fixture.componentInstance.graticule.instance).not.toBe(previousGraticule);
+    expect(fixture.componentInstance.graticule().instance).not.toBe(previousGraticule);
     expect(setMap).toHaveBeenCalledWith(null);
   });
 });

--- a/projects/ngx-ol/src/lib/graticule.component.ts
+++ b/projects/ngx-ol/src/lib/graticule.component.ts
@@ -21,13 +21,13 @@ export class GraticuleComponent implements AfterContentInit, OnChanges, OnDestro
   lonLabelPosition = input<number>();
   latLabelPosition = input<number>();
 
-  instance: any;
+  instance: Graticule;
 
-  protected readonly _instanceSignal = signal<any | undefined>(undefined);
+  protected readonly _instanceSignal = signal<Graticule | undefined>(undefined);
 
   readonly instanceSignal = this._instanceSignal.asReadonly();
 
-  protected setInstance(instance: any): any {
+  protected setInstance(instance: Graticule): Graticule {
     this.instance = instance;
 
     this._instanceSignal.set(instance);
@@ -39,37 +39,30 @@ export class GraticuleComponent implements AfterContentInit, OnChanges, OnDestro
   constructor(private map: MapComponent) {}
 
   ngOnChanges(changes: SimpleChanges) {
-    const properties: { [index: string]: any } = {};
-
     if (!this.instance) {
       return;
     }
 
-    for (const key in changes) {
-      if (changes.hasOwnProperty(key)) {
-        properties[key] = changes[key].currentValue;
-      }
-    }
-
-    if (properties) {
-      this.setInstance(new Graticule(properties));
-    }
+    this.instance.setMap(null);
+    this.setInstance(new Graticule(this.createOptions()));
     this.instance.setMap(this.map.instance);
   }
 
   ngAfterContentInit(): void {
-    this.setInstance(
-      new Graticule({
-        strokeStyle: this.strokeStyle(),
-        showLabels: this.showLabels(),
-        lonLabelPosition: this.lonLabelPosition(),
-        latLabelPosition: this.latLabelPosition(),
-      }),
-    );
+    this.setInstance(new Graticule(this.createOptions()));
     this.instance.setMap(this.map.instance);
   }
 
   ngOnDestroy(): void {
     this.instance.setMap(null);
+  }
+
+  private createOptions() {
+    return {
+      strokeStyle: this.strokeStyle(),
+      showLabels: this.showLabels(),
+      lonLabelPosition: this.lonLabelPosition(),
+      latLabelPosition: this.latLabelPosition(),
+    };
   }
 }

--- a/projects/ngx-ol/src/lib/graticule.component.ts
+++ b/projects/ngx-ol/src/lib/graticule.component.ts
@@ -1,10 +1,11 @@
 import {
   Component,
-  Input,
   AfterContentInit,
   OnChanges,
   SimpleChanges,
   OnDestroy,
+  input,
+  signal,
 } from '@angular/core';
 import Graticule from 'ol/layer/Graticule';
 import Stroke from 'ol/style/Stroke';
@@ -15,16 +16,24 @@ import { MapComponent } from './map.component';
   template: '<ng-content></ng-content>',
 })
 export class GraticuleComponent implements AfterContentInit, OnChanges, OnDestroy {
-  @Input()
-  strokeStyle: Stroke;
-  @Input()
-  showLabels: boolean;
-  @Input()
-  lonLabelPosition: number;
-  @Input()
-  latLabelPosition: number;
+  strokeStyle = input<Stroke>();
+  showLabels = input<boolean>();
+  lonLabelPosition = input<number>();
+  latLabelPosition = input<number>();
 
   instance: any;
+
+  protected readonly _instanceSignal = signal<any | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: any): any {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   public componentType = 'graticule';
 
   constructor(private map: MapComponent) {}
@@ -43,18 +52,20 @@ export class GraticuleComponent implements AfterContentInit, OnChanges, OnDestro
     }
 
     if (properties) {
-      this.instance = new Graticule(properties);
+      this.setInstance(new Graticule(properties));
     }
     this.instance.setMap(this.map.instance);
   }
 
   ngAfterContentInit(): void {
-    this.instance = new Graticule({
-      strokeStyle: this.strokeStyle,
-      showLabels: this.showLabels,
-      lonLabelPosition: this.lonLabelPosition,
-      latLabelPosition: this.latLabelPosition,
-    });
+    this.setInstance(
+      new Graticule({
+        strokeStyle: this.strokeStyle(),
+        showLabels: this.showLabels(),
+        lonLabelPosition: this.lonLabelPosition(),
+        latLabelPosition: this.latLabelPosition(),
+      }),
+    );
     this.instance.setMap(this.map.instance);
   }
 

--- a/projects/ngx-ol/src/lib/graticule.component.ts
+++ b/projects/ngx-ol/src/lib/graticule.component.ts
@@ -17,10 +17,10 @@ import { MapComponent } from './map.component';
   template: '<ng-content></ng-content>',
 })
 export class GraticuleComponent implements AfterContentInit, OnChanges, OnDestroy {
-  strokeStyle = input<Stroke>();
-  showLabels = input<boolean>();
-  lonLabelPosition = input<number>();
-  latLabelPosition = input<number>();
+  readonly strokeStyle = input<Stroke>();
+  readonly showLabels = input<boolean>();
+  readonly lonLabelPosition = input<number>();
+  readonly latLabelPosition = input<number>();
 
   instance: Graticule;
 
@@ -35,7 +35,7 @@ export class GraticuleComponent implements AfterContentInit, OnChanges, OnDestro
 
     return instance;
   }
-  public componentType = 'graticule';
+  readonly componentType: string = 'graticule';
 
   private readonly map = inject(MapComponent);
 

--- a/projects/ngx-ol/src/lib/graticule.component.ts
+++ b/projects/ngx-ol/src/lib/graticule.component.ts
@@ -6,6 +6,7 @@ import {
   OnDestroy,
   input,
   signal,
+  inject,
 } from '@angular/core';
 import Graticule from 'ol/layer/Graticule';
 import Stroke from 'ol/style/Stroke';
@@ -36,7 +37,7 @@ export class GraticuleComponent implements AfterContentInit, OnChanges, OnDestro
   }
   public componentType = 'graticule';
 
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnChanges(changes: SimpleChanges) {
     if (!this.instance) {

--- a/projects/ngx-ol/src/lib/interactions/dblclickdragzoom.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/dblclickdragzoom.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -9,9 +9,7 @@ import { DblClickDragZoomInteractionComponent } from './dblclickdragzoom.compone
   template: `
     <aol-map width="320px" height="240px">
       <aol-view [center]="center" [zoom]="zoom"></aol-view>
-      <aol-interaction-dblclickdragzoom
-        [duration]="duration"
-      ></aol-interaction-dblclickdragzoom>
+      <aol-interaction-dblclickdragzoom [duration]="duration"></aol-interaction-dblclickdragzoom>
     </aol-map>
   `,
   standalone: true,
@@ -22,11 +20,11 @@ class DblClickDragZoomInteractionHostComponent {
   zoom = 2;
   duration = 100;
 
-  @ViewChild(DblClickDragZoomInteractionComponent)
-  interaction!: DblClickDragZoomInteractionComponent;
+  readonly interaction = viewChild.required<DblClickDragZoomInteractionComponent>(
+    DblClickDragZoomInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('DblClickDragZoomInteractionComponent', () => {
@@ -47,8 +45,8 @@ describe('DblClickDragZoomInteractionComponent', () => {
 
   it('adds and removes a double-click drag zoom interaction with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interaction = host.interaction.instance;
+    const map = host.map().instance;
+    const interaction = host.interaction().instance;
 
     expect(map.getInteractions().getArray()).toContain(interaction);
 

--- a/projects/ngx-ol/src/lib/interactions/dblclickdragzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dblclickdragzoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import DblClickDragZoom from 'ol/interaction/DblClickDragZoom';
 import type { Options } from 'ol/interaction/DblClickDragZoom';
 import { MapComponent } from '../map.component';
@@ -8,21 +8,29 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class DblClickDragZoomInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  duration?: number;
+  duration = input<number>();
 
-  @Input()
-  delta?: number;
+  delta = input<number>();
 
-  @Input()
-  stopDown?: (handled: boolean) => boolean;
+  stopDown = input<(handled: boolean) => boolean>();
 
   instance: DblClickDragZoom;
 
+  protected readonly _instanceSignal = signal<DblClickDragZoom | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: DblClickDragZoom): DblClickDragZoom {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new DblClickDragZoom(this.createOptions());
+    this.setInstance(new DblClickDragZoom(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -32,9 +40,9 @@ export class DblClickDragZoomInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      duration: this.duration,
-      delta: this.delta,
-      stopDown: this.stopDown,
+      duration: this.duration(),
+      delta: this.delta(),
+      stopDown: this.stopDown(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/dblclickdragzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dblclickdragzoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import DblClickDragZoom from 'ol/interaction/DblClickDragZoom';
 import type { Options } from 'ol/interaction/DblClickDragZoom';
 import { MapComponent } from '../map.component';
@@ -27,7 +27,7 @@ export class DblClickDragZoomInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new DblClickDragZoom(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/dblclickdragzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dblclickdragzoom.component.ts
@@ -8,11 +8,11 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class DblClickDragZoomInteractionComponent implements OnInit, OnDestroy {
-  duration = input<number>();
+  readonly duration = input<number>();
 
-  delta = input<number>();
+  readonly delta = input<number>();
 
-  stopDown = input<(handled: boolean) => boolean>();
+  readonly stopDown = input<(handled: boolean) => boolean>();
 
   instance: DblClickDragZoom;
 

--- a/projects/ngx-ol/src/lib/interactions/default.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/default.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -20,11 +20,11 @@ class DefaultInteractionHostComponent {
   zoom = 2;
   dragPan = true;
 
-  @ViewChild(DefaultInteractionComponent)
-  interaction!: DefaultInteractionComponent;
+  readonly interaction = viewChild.required<DefaultInteractionComponent>(
+    DefaultInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('DefaultInteractionComponent', () => {
@@ -45,8 +45,8 @@ describe('DefaultInteractionComponent', () => {
 
   it('adds and removes the default interaction collection with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interactions = host.interaction.instance.getArray();
+    const map = host.map().instance;
+    const interactions = host.interaction().instance.getArray();
 
     expect(interactions.length).toBeGreaterThan(0);
     interactions.forEach((interaction) => {

--- a/projects/ngx-ol/src/lib/interactions/default.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/default.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import { defaults } from 'ol/interaction/defaults';
 import Interaction from 'ol/interaction/Interaction';
 import { DefaultsOptions } from 'ol/interaction/defaults';
@@ -10,35 +10,35 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class DefaultInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  altShiftDragRotate?: boolean;
-  @Input()
-  onFocusOnly?: boolean;
-  @Input()
-  doubleClickZoom?: boolean;
-  @Input()
-  keyboard?: boolean;
-  @Input()
-  mouseWheelZoom?: boolean;
-  @Input()
-  shiftDragZoom?: boolean;
-  @Input()
-  dragPan?: boolean;
-  @Input()
-  pinchRotate?: boolean;
-  @Input()
-  pinchZoom?: boolean;
-  @Input()
-  zoomDelta?: number;
-  @Input()
-  zoomDuration?: number;
+  altShiftDragRotate = input<boolean>();
+  onFocusOnly = input<boolean>();
+  doubleClickZoom = input<boolean>();
+  keyboard = input<boolean>();
+  mouseWheelZoom = input<boolean>();
+  shiftDragZoom = input<boolean>();
+  dragPan = input<boolean>();
+  pinchRotate = input<boolean>();
+  pinchZoom = input<boolean>();
+  zoomDelta = input<number>();
+  zoomDuration = input<number>();
 
   instance: Collection<Interaction>;
 
+  protected readonly _instanceSignal = signal<Collection<Interaction> | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Collection<Interaction>): Collection<Interaction> {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = defaults(this.createOptions());
+    this.setInstance(defaults(this.createOptions()));
     this.instance.forEach((i) => this.map.instance.addInteraction(i));
   }
 
@@ -48,17 +48,17 @@ export class DefaultInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): DefaultsOptions {
     return {
-      altShiftDragRotate: this.altShiftDragRotate,
-      onFocusOnly: this.onFocusOnly,
-      doubleClickZoom: this.doubleClickZoom,
-      keyboard: this.keyboard,
-      mouseWheelZoom: this.mouseWheelZoom,
-      shiftDragZoom: this.shiftDragZoom,
-      dragPan: this.dragPan,
-      pinchRotate: this.pinchRotate,
-      pinchZoom: this.pinchZoom,
-      zoomDelta: this.zoomDelta,
-      zoomDuration: this.zoomDuration,
+      altShiftDragRotate: this.altShiftDragRotate(),
+      onFocusOnly: this.onFocusOnly(),
+      doubleClickZoom: this.doubleClickZoom(),
+      keyboard: this.keyboard(),
+      mouseWheelZoom: this.mouseWheelZoom(),
+      shiftDragZoom: this.shiftDragZoom(),
+      dragPan: this.dragPan(),
+      pinchRotate: this.pinchRotate(),
+      pinchZoom: this.pinchZoom(),
+      zoomDelta: this.zoomDelta(),
+      zoomDuration: this.zoomDuration(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/default.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/default.component.ts
@@ -10,17 +10,17 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class DefaultInteractionComponent implements OnInit, OnDestroy {
-  altShiftDragRotate = input<boolean>();
-  onFocusOnly = input<boolean>();
-  doubleClickZoom = input<boolean>();
-  keyboard = input<boolean>();
-  mouseWheelZoom = input<boolean>();
-  shiftDragZoom = input<boolean>();
-  dragPan = input<boolean>();
-  pinchRotate = input<boolean>();
-  pinchZoom = input<boolean>();
-  zoomDelta = input<number>();
-  zoomDuration = input<number>();
+  readonly altShiftDragRotate = input<boolean>();
+  readonly onFocusOnly = input<boolean>();
+  readonly doubleClickZoom = input<boolean>();
+  readonly keyboard = input<boolean>();
+  readonly mouseWheelZoom = input<boolean>();
+  readonly shiftDragZoom = input<boolean>();
+  readonly dragPan = input<boolean>();
+  readonly pinchRotate = input<boolean>();
+  readonly pinchZoom = input<boolean>();
+  readonly zoomDelta = input<number>();
+  readonly zoomDuration = input<number>();
 
   instance: Collection<Interaction>;
 

--- a/projects/ngx-ol/src/lib/interactions/default.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/default.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import { defaults } from 'ol/interaction/defaults';
 import Interaction from 'ol/interaction/Interaction';
 import { DefaultsOptions } from 'ol/interaction/defaults';
@@ -35,7 +35,7 @@ export class DefaultInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(defaults(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/doubleclickzoom.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/doubleclickzoom.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import MapBrowserEvent from 'ol/MapBrowserEvent';
 import MapBrowserEventType from 'ol/MapBrowserEventType';
@@ -12,7 +12,10 @@ import { DoubleClickZoomInteractionComponent } from './doubleclickzoom.component
   template: `
     <aol-map width="320px" height="240px">
       <aol-view [center]="center" [zoom]="zoom"></aol-view>
-      <aol-interaction-doubleclickzoom [duration]="duration" [delta]="delta"></aol-interaction-doubleclickzoom>
+      <aol-interaction-doubleclickzoom
+        [duration]="duration"
+        [delta]="delta"
+      ></aol-interaction-doubleclickzoom>
     </aol-map>
   `,
   standalone: true,
@@ -24,14 +27,13 @@ class DoubleClickZoomHostComponent {
   duration = 0;
   delta = 2;
 
-  @ViewChild(DoubleClickZoomInteractionComponent)
-  interaction!: DoubleClickZoomInteractionComponent;
+  readonly interaction = viewChild.required<DoubleClickZoomInteractionComponent>(
+    DoubleClickZoomInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 
-  @ViewChild(ViewComponent)
-  view!: ViewComponent;
+  readonly view = viewChild.required<ViewComponent>(ViewComponent);
 }
 
 describe('DoubleClickZoomInteractionComponent', () => {
@@ -58,7 +60,7 @@ describe('DoubleClickZoomInteractionComponent', () => {
     } as unknown as MouseEvent;
     const event = new MapBrowserEvent(
       MapBrowserEventType.DBLCLICK,
-      fixture.componentInstance.map.instance,
+      fixture.componentInstance.map().instance,
       originalEvent,
       false,
       undefined,
@@ -66,12 +68,12 @@ describe('DoubleClickZoomInteractionComponent', () => {
     );
     event.coordinate = [0, 0];
 
-    expect(fixture.componentInstance.view.instance.getZoom()).toBe(2);
+    expect(fixture.componentInstance.view().instance.getZoom()).toBe(2);
 
-    const handled = fixture.componentInstance.interaction.instance.handleEvent(event);
+    const handled = fixture.componentInstance.interaction().instance.handleEvent(event);
 
     expect(handled).toBe(false);
     expect(preventDefault).toHaveBeenCalledOnce();
-    expect(fixture.componentInstance.view.instance.getZoom()).toBe(4);
+    expect(fixture.componentInstance.view().instance.getZoom()).toBe(4);
   });
 });

--- a/projects/ngx-ol/src/lib/interactions/doubleclickzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/doubleclickzoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import DoubleClickZoom from 'ol/interaction/DoubleClickZoom';
 import { Options } from 'ol/interaction/DoubleClickZoom';
 import { MapComponent } from '../map.component';
@@ -8,17 +8,26 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class DoubleClickZoomInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  duration?: number;
-  @Input()
-  delta?: number;
+  duration = input<number>();
+  delta = input<number>();
 
   instance: DoubleClickZoom;
 
+  protected readonly _instanceSignal = signal<DoubleClickZoom | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: DoubleClickZoom): DoubleClickZoom {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new DoubleClickZoom(this.createOptions());
+    this.setInstance(new DoubleClickZoom(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -28,8 +37,8 @@ export class DoubleClickZoomInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      duration: this.duration,
-      delta: this.delta,
+      duration: this.duration(),
+      delta: this.delta(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/doubleclickzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/doubleclickzoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import DoubleClickZoom from 'ol/interaction/DoubleClickZoom';
 import { Options } from 'ol/interaction/DoubleClickZoom';
 import { MapComponent } from '../map.component';
@@ -24,7 +24,7 @@ export class DoubleClickZoomInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new DoubleClickZoom(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/doubleclickzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/doubleclickzoom.component.ts
@@ -8,8 +8,8 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class DoubleClickZoomInteractionComponent implements OnInit, OnDestroy {
-  duration = input<number>();
-  delta = input<number>();
+  readonly duration = input<number>();
+  readonly delta = input<number>();
 
   instance: DoubleClickZoom;
 

--- a/projects/ngx-ol/src/lib/interactions/draganddrop.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/draganddrop.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import GeoJSON from 'ol/format/GeoJSON';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -25,11 +25,11 @@ class DragAndDropInteractionHostComponent {
   formats = [new GeoJSON()];
   projection = 'EPSG:4326';
 
-  @ViewChild(DragAndDropInteractionComponent)
-  interaction!: DragAndDropInteractionComponent;
+  readonly interaction = viewChild.required<DragAndDropInteractionComponent>(
+    DragAndDropInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('DragAndDropInteractionComponent', () => {
@@ -50,8 +50,8 @@ describe('DragAndDropInteractionComponent', () => {
 
   it('adds and removes a drag-and-drop interaction with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interaction = host.interaction.instance;
+    const map = host.map().instance;
+    const interaction = host.interaction().instance;
 
     expect(map.getInteractions().getArray()).toContain(interaction);
 

--- a/projects/ngx-ol/src/lib/interactions/draganddrop.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/draganddrop.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import DragAndDrop from 'ol/interaction/DragAndDrop';
 import { Options } from 'ol/interaction/DragAndDrop';
 import FeatureFormat from 'ol/format/Feature';
@@ -27,7 +27,7 @@ export class DragAndDropInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new DragAndDrop(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/draganddrop.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/draganddrop.component.ts
@@ -10,9 +10,9 @@ import { ProjectionLike } from 'ol/proj';
   template: '',
 })
 export class DragAndDropInteractionComponent implements OnInit, OnDestroy {
-  formatConstructors = input<FeatureFormat[]>();
-  projection = input<ProjectionLike>();
-  target = input<HTMLElement>();
+  readonly formatConstructors = input<FeatureFormat[]>();
+  readonly projection = input<ProjectionLike>();
+  readonly target = input<HTMLElement>();
 
   instance: DragAndDrop;
 

--- a/projects/ngx-ol/src/lib/interactions/draganddrop.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/draganddrop.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import DragAndDrop from 'ol/interaction/DragAndDrop';
 import { Options } from 'ol/interaction/DragAndDrop';
 import FeatureFormat from 'ol/format/Feature';
@@ -10,19 +10,27 @@ import { ProjectionLike } from 'ol/proj';
   template: '',
 })
 export class DragAndDropInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  formatConstructors?: FeatureFormat[];
-  @Input()
-  projection?: ProjectionLike;
-  @Input()
-  target?: HTMLElement;
+  formatConstructors = input<FeatureFormat[]>();
+  projection = input<ProjectionLike>();
+  target = input<HTMLElement>();
 
   instance: DragAndDrop;
 
+  protected readonly _instanceSignal = signal<DragAndDrop | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: DragAndDrop): DragAndDrop {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new DragAndDrop(this.createOptions());
+    this.setInstance(new DragAndDrop(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -32,9 +40,9 @@ export class DragAndDropInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      formatConstructors: this.formatConstructors,
-      projection: this.projection,
-      target: this.target,
+      formatConstructors: this.formatConstructors(),
+      projection: this.projection(),
+      target: this.target(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/dragbox.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragbox.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -20,11 +20,11 @@ class DragBoxInteractionHostComponent {
   zoom = 2;
   className = 'drag-box';
 
-  @ViewChild(DragBoxInteractionComponent)
-  interaction!: DragBoxInteractionComponent;
+  readonly interaction = viewChild.required<DragBoxInteractionComponent>(
+    DragBoxInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('DragBoxInteractionComponent', () => {
@@ -45,8 +45,8 @@ describe('DragBoxInteractionComponent', () => {
 
   it('adds and removes a drag-box interaction with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interaction = host.interaction.instance;
+    const map = host.map().instance;
+    const interaction = host.interaction().instance;
 
     expect(map.getInteractions().getArray()).toContain(interaction);
 

--- a/projects/ngx-ol/src/lib/interactions/dragbox.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragbox.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import DragBox from 'ol/interaction/DragBox';
 import { Options } from 'ol/interaction/DragBox';
 import { MapComponent } from '../map.component';
@@ -27,7 +27,7 @@ export class DragBoxInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new DragBox(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/dragbox.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragbox.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, Input } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import DragBox from 'ol/interaction/DragBox';
 import { Options } from 'ol/interaction/DragBox';
 import { MapComponent } from '../map.component';
@@ -10,19 +10,27 @@ import { EndCondition } from 'ol/interaction/DragBox';
   template: '',
 })
 export class DragBoxInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  className?: string;
-  @Input()
-  condition?: Condition;
-  @Input()
-  boxEndCondition?: EndCondition;
+  className = input<string>();
+  condition = input<Condition>();
+  boxEndCondition = input<EndCondition>();
 
   instance: DragBox;
 
+  protected readonly _instanceSignal = signal<DragBox | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: DragBox): DragBox {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new DragBox(this.createOptions());
+    this.setInstance(new DragBox(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -32,9 +40,9 @@ export class DragBoxInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      className: this.className,
-      condition: this.condition,
-      boxEndCondition: this.boxEndCondition,
+      className: this.className(),
+      condition: this.condition(),
+      boxEndCondition: this.boxEndCondition(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/dragbox.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragbox.component.ts
@@ -10,9 +10,9 @@ import { EndCondition } from 'ol/interaction/DragBox';
   template: '',
 })
 export class DragBoxInteractionComponent implements OnInit, OnDestroy {
-  className = input<string>();
-  condition = input<Condition>();
-  boxEndCondition = input<EndCondition>();
+  readonly className = input<string>();
+  readonly condition = input<Condition>();
+  readonly boxEndCondition = input<EndCondition>();
 
   instance: DragBox;
 

--- a/projects/ngx-ol/src/lib/interactions/dragpan.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragpan.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -19,11 +19,11 @@ class DragPanInteractionHostComponent {
   center = [0, 0];
   zoom = 2;
 
-  @ViewChild(DragPanInteractionComponent)
-  interaction!: DragPanInteractionComponent;
+  readonly interaction = viewChild.required<DragPanInteractionComponent>(
+    DragPanInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('DragPanInteractionComponent', () => {
@@ -44,8 +44,8 @@ describe('DragPanInteractionComponent', () => {
 
   it('adds and removes a drag-pan interaction with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interaction = host.interaction.instance;
+    const map = host.map().instance;
+    const interaction = host.interaction().instance;
 
     expect(map.getInteractions().getArray()).toContain(interaction);
 

--- a/projects/ngx-ol/src/lib/interactions/dragpan.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragpan.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import DragPan from 'ol/interaction/DragPan';
 import { Options } from 'ol/interaction/DragPan';
 import Kinetic from 'ol/Kinetic';
@@ -26,7 +26,7 @@ export class DragPanInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new DragPan(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/dragpan.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragpan.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, Input } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import DragPan from 'ol/interaction/DragPan';
 import { Options } from 'ol/interaction/DragPan';
 import Kinetic from 'ol/Kinetic';
@@ -10,17 +10,26 @@ import { Condition } from 'ol/events/condition';
   template: '',
 })
 export class DragPanInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  condition?: Condition;
-  @Input()
-  kinetic?: Kinetic;
+  condition = input<Condition>();
+  kinetic = input<Kinetic>();
 
   instance: DragPan;
 
+  protected readonly _instanceSignal = signal<DragPan | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: DragPan): DragPan {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new DragPan(this.createOptions());
+    this.setInstance(new DragPan(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -30,8 +39,8 @@ export class DragPanInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      condition: this.condition,
-      kinetic: this.kinetic,
+      condition: this.condition(),
+      kinetic: this.kinetic(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/dragpan.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragpan.component.ts
@@ -10,8 +10,8 @@ import { Condition } from 'ol/events/condition';
   template: '',
 })
 export class DragPanInteractionComponent implements OnInit, OnDestroy {
-  condition = input<Condition>();
-  kinetic = input<Kinetic>();
+  readonly condition = input<Condition>();
+  readonly kinetic = input<Kinetic>();
 
   instance: DragPan;
 

--- a/projects/ngx-ol/src/lib/interactions/dragrotate.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragrotate.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -20,11 +20,11 @@ class DragRotateInteractionHostComponent {
   zoom = 2;
   duration = 100;
 
-  @ViewChild(DragRotateInteractionComponent)
-  interaction!: DragRotateInteractionComponent;
+  readonly interaction = viewChild.required<DragRotateInteractionComponent>(
+    DragRotateInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('DragRotateInteractionComponent', () => {
@@ -45,8 +45,8 @@ describe('DragRotateInteractionComponent', () => {
 
   it('adds and removes a drag-rotate interaction with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interaction = host.interaction.instance;
+    const map = host.map().instance;
+    const interaction = host.interaction().instance;
 
     expect(map.getInteractions().getArray()).toContain(interaction);
 

--- a/projects/ngx-ol/src/lib/interactions/dragrotate.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragrotate.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import DragRotate from 'ol/interaction/DragRotate';
 import { Options } from 'ol/interaction/DragRotate';
 import { MapComponent } from '../map.component';
@@ -25,7 +25,7 @@ export class DragRotateInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new DragRotate(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/dragrotate.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragrotate.component.ts
@@ -9,8 +9,8 @@ import { Condition } from 'ol/events/condition';
   template: '',
 })
 export class DragRotateInteractionComponent implements OnInit, OnDestroy {
-  condition = input<Condition>();
-  duration = input<number>();
+  readonly condition = input<Condition>();
+  readonly duration = input<number>();
 
   instance: DragRotate;
 

--- a/projects/ngx-ol/src/lib/interactions/dragrotate.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragrotate.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, Input } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import DragRotate from 'ol/interaction/DragRotate';
 import { Options } from 'ol/interaction/DragRotate';
 import { MapComponent } from '../map.component';
@@ -9,17 +9,26 @@ import { Condition } from 'ol/events/condition';
   template: '',
 })
 export class DragRotateInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  condition?: Condition;
-  @Input()
-  duration?: number;
+  condition = input<Condition>();
+  duration = input<number>();
 
   instance: DragRotate;
 
+  protected readonly _instanceSignal = signal<DragRotate | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: DragRotate): DragRotate {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new DragRotate(this.createOptions());
+    this.setInstance(new DragRotate(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -29,8 +38,8 @@ export class DragRotateInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      condition: this.condition,
-      duration: this.duration,
+      condition: this.condition(),
+      duration: this.duration(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/dragrotateandzoom.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragrotateandzoom.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -9,9 +9,7 @@ import { DragRotateAndZoomInteractionComponent } from './dragrotateandzoom.compo
   template: `
     <aol-map width="320px" height="240px">
       <aol-view [center]="center" [zoom]="zoom"></aol-view>
-      <aol-interaction-dragrotateandzoom
-        [duration]="duration"
-      ></aol-interaction-dragrotateandzoom>
+      <aol-interaction-dragrotateandzoom [duration]="duration"></aol-interaction-dragrotateandzoom>
     </aol-map>
   `,
   standalone: true,
@@ -22,11 +20,11 @@ class DragRotateAndZoomInteractionHostComponent {
   zoom = 2;
   duration = 100;
 
-  @ViewChild(DragRotateAndZoomInteractionComponent)
-  interaction!: DragRotateAndZoomInteractionComponent;
+  readonly interaction = viewChild.required<DragRotateAndZoomInteractionComponent>(
+    DragRotateAndZoomInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('DragRotateAndZoomInteractionComponent', () => {
@@ -47,8 +45,8 @@ describe('DragRotateAndZoomInteractionComponent', () => {
 
   it('adds and removes a drag-rotate-and-zoom interaction with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interaction = host.interaction.instance;
+    const map = host.map().instance;
+    const interaction = host.interaction().instance;
 
     expect(map.getInteractions().getArray()).toContain(interaction);
 

--- a/projects/ngx-ol/src/lib/interactions/dragrotateandzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragrotateandzoom.component.ts
@@ -9,8 +9,8 @@ import { Condition } from 'ol/events/condition';
   template: '',
 })
 export class DragRotateAndZoomInteractionComponent implements OnInit, OnDestroy {
-  condition = input<Condition>();
-  duration = input<number>();
+  readonly condition = input<Condition>();
+  readonly duration = input<number>();
 
   instance: DragRotateAndZoom;
 

--- a/projects/ngx-ol/src/lib/interactions/dragrotateandzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragrotateandzoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import DragRotateAndZoom from 'ol/interaction/DragRotateAndZoom';
 import { Options } from 'ol/interaction/DragRotateAndZoom';
 import { MapComponent } from '../map.component';
@@ -25,7 +25,7 @@ export class DragRotateAndZoomInteractionComponent implements OnInit, OnDestroy 
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new DragRotateAndZoom(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/dragrotateandzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragrotateandzoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, Input } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import DragRotateAndZoom from 'ol/interaction/DragRotateAndZoom';
 import { Options } from 'ol/interaction/DragRotateAndZoom';
 import { MapComponent } from '../map.component';
@@ -9,17 +9,26 @@ import { Condition } from 'ol/events/condition';
   template: '',
 })
 export class DragRotateAndZoomInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  condition?: Condition;
-  @Input()
-  duration?: number;
+  condition = input<Condition>();
+  duration = input<number>();
 
   instance: DragRotateAndZoom;
 
+  protected readonly _instanceSignal = signal<DragRotateAndZoom | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: DragRotateAndZoom): DragRotateAndZoom {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new DragRotateAndZoom(this.createOptions());
+    this.setInstance(new DragRotateAndZoom(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -29,8 +38,8 @@ export class DragRotateAndZoomInteractionComponent implements OnInit, OnDestroy 
 
   private createOptions(): Options {
     return {
-      condition: this.condition,
-      duration: this.duration,
+      condition: this.condition(),
+      duration: this.duration(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/dragzoom.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragzoom.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -20,11 +20,11 @@ class DragZoomInteractionHostComponent {
   zoom = 2;
   duration = 100;
 
-  @ViewChild(DragZoomInteractionComponent)
-  interaction!: DragZoomInteractionComponent;
+  readonly interaction = viewChild.required<DragZoomInteractionComponent>(
+    DragZoomInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('DragZoomInteractionComponent', () => {
@@ -45,8 +45,8 @@ describe('DragZoomInteractionComponent', () => {
 
   it('adds and removes a drag-zoom interaction with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interaction = host.interaction.instance;
+    const map = host.map().instance;
+    const interaction = host.interaction().instance;
 
     expect(map.getInteractions().getArray()).toContain(interaction);
 

--- a/projects/ngx-ol/src/lib/interactions/dragzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragzoom.component.ts
@@ -9,10 +9,10 @@ import { Condition } from 'ol/events/condition';
   template: '',
 })
 export class DragZoomInteractionComponent implements OnInit, OnDestroy {
-  className = input<string>();
-  condition = input<Condition>();
-  duration = input<number>();
-  out = input<boolean>();
+  readonly className = input<string>();
+  readonly condition = input<Condition>();
+  readonly duration = input<number>();
+  readonly out = input<boolean>();
 
   instance: DragZoom;
 

--- a/projects/ngx-ol/src/lib/interactions/dragzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragzoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import DragZoom from 'ol/interaction/DragZoom';
 import { Options } from 'ol/interaction/DragZoom';
 import { MapComponent } from '../map.component';
@@ -27,7 +27,7 @@ export class DragZoomInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new DragZoom(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/dragzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/dragzoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, Input } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import DragZoom from 'ol/interaction/DragZoom';
 import { Options } from 'ol/interaction/DragZoom';
 import { MapComponent } from '../map.component';
@@ -9,21 +9,28 @@ import { Condition } from 'ol/events/condition';
   template: '',
 })
 export class DragZoomInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  className?: string;
-  @Input()
-  condition?: Condition;
-  @Input()
-  duration?: number;
-  @Input()
-  out?: boolean;
+  className = input<string>();
+  condition = input<Condition>();
+  duration = input<number>();
+  out = input<boolean>();
 
   instance: DragZoom;
 
+  protected readonly _instanceSignal = signal<DragZoom | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: DragZoom): DragZoom {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new DragZoom(this.createOptions());
+    this.setInstance(new DragZoom(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -33,10 +40,10 @@ export class DragZoomInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      className: this.className,
-      condition: this.condition,
-      duration: this.duration,
-      out: this.out,
+      className: this.className(),
+      condition: this.condition(),
+      duration: this.duration(),
+      out: this.out(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/draw.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/draw.component.spec.ts
@@ -1,6 +1,7 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, signal, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import VectorSource from 'ol/source/Vector';
+import type { Type } from 'ol/geom/Geometry';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
 import { MapComponent } from '../map.component';
@@ -11,7 +12,8 @@ import { DrawInteractionComponent } from './draw.component';
     <aol-map width="320px" height="240px">
       <aol-view [center]="center" [zoom]="zoom"></aol-view>
       <aol-interaction-draw
-        [type]="type"
+        [type]="type()"
+        [trace]="trace()"
         [source]="source"
         (drawStart)="drawStart($event)"
         (drawEnd)="drawEnd($event)"
@@ -29,7 +31,8 @@ import { DrawInteractionComponent } from './draw.component';
 class DrawInteractionHostComponent {
   center = [0, 0];
   zoom = 2;
-  type = 'Point' as const;
+  type = signal<Type>('Point');
+  trace = signal(false);
   source = new VectorSource();
   drawStart = vi.fn();
   drawEnd = vi.fn();
@@ -82,5 +85,27 @@ describe('DrawInteractionComponent', () => {
     expect(host.changeActive).toHaveBeenCalledOnce();
     expect(host.error).toHaveBeenCalledOnce();
     expect(host.propertyChange).toHaveBeenCalledOnce();
+  });
+
+  it('replaces the registered draw interaction when the draw type changes', () => {
+    const host = fixture.componentInstance;
+    const oldInteraction = host.interaction.instance;
+
+    host.type.set('Polygon');
+    fixture.detectChanges(false);
+
+    expect(host.interaction.instance).not.toBe(oldInteraction);
+    expect(host.map.instance.getInteractions().getArray()).toContain(host.interaction.instance);
+    expect(host.map.instance.getInteractions().getArray()).not.toContain(oldInteraction);
+  });
+
+  it('updates trace without replacing the draw interaction', () => {
+    const host = fixture.componentInstance;
+    const interaction = host.interaction.instance;
+
+    host.trace.set(true);
+    fixture.detectChanges(false);
+
+    expect(host.interaction.instance).toBe(interaction);
   });
 });

--- a/projects/ngx-ol/src/lib/interactions/draw.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/draw.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import VectorSource from 'ol/source/Vector';
 import type { Type } from 'ol/geom/Geometry';
@@ -42,11 +42,9 @@ class DrawInteractionHostComponent {
   error = vi.fn();
   propertyChange = vi.fn();
 
-  @ViewChild(DrawInteractionComponent)
-  interaction!: DrawInteractionComponent;
+  readonly interaction = viewChild.required<DrawInteractionComponent>(DrawInteractionComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('DrawInteractionComponent', () => {
@@ -68,15 +66,15 @@ describe('DrawInteractionComponent', () => {
   it('adds a draw interaction to the map and forwards OpenLayers events', () => {
     const host = fixture.componentInstance;
 
-    expect(host.map.instance.getInteractions().getArray()).toContain(host.interaction.instance);
+    expect(host.map().instance.getInteractions().getArray()).toContain(host.interaction().instance);
 
-    host.interaction.instance.dispatchEvent('drawstart');
-    host.interaction.instance.dispatchEvent('drawend');
-    host.interaction.instance.dispatchEvent('drawabort');
-    host.interaction.instance.dispatchEvent('change');
-    host.interaction.instance.dispatchEvent('change:active');
-    host.interaction.instance.dispatchEvent('error');
-    host.interaction.instance.dispatchEvent('propertychange');
+    host.interaction().instance.dispatchEvent('drawstart');
+    host.interaction().instance.dispatchEvent('drawend');
+    host.interaction().instance.dispatchEvent('drawabort');
+    host.interaction().instance.dispatchEvent('change');
+    host.interaction().instance.dispatchEvent('change:active');
+    host.interaction().instance.dispatchEvent('error');
+    host.interaction().instance.dispatchEvent('propertychange');
 
     expect(host.drawStart).toHaveBeenCalledOnce();
     expect(host.drawEnd).toHaveBeenCalledOnce();
@@ -89,23 +87,23 @@ describe('DrawInteractionComponent', () => {
 
   it('replaces the registered draw interaction when the draw type changes', () => {
     const host = fixture.componentInstance;
-    const oldInteraction = host.interaction.instance;
+    const oldInteraction = host.interaction().instance;
 
     host.type.set('Polygon');
     fixture.detectChanges(false);
 
-    expect(host.interaction.instance).not.toBe(oldInteraction);
-    expect(host.map.instance.getInteractions().getArray()).toContain(host.interaction.instance);
-    expect(host.map.instance.getInteractions().getArray()).not.toContain(oldInteraction);
+    expect(host.interaction().instance).not.toBe(oldInteraction);
+    expect(host.map().instance.getInteractions().getArray()).toContain(host.interaction().instance);
+    expect(host.map().instance.getInteractions().getArray()).not.toContain(oldInteraction);
   });
 
   it('updates trace without replacing the draw interaction', () => {
     const host = fixture.componentInstance;
-    const interaction = host.interaction.instance;
+    const interaction = host.interaction().instance;
 
     host.trace.set(true);
     fixture.detectChanges(false);
 
-    expect(host.interaction.instance).toBe(interaction);
+    expect(host.interaction().instance).toBe(interaction);
   });
 });

--- a/projects/ngx-ol/src/lib/interactions/draw.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/draw.component.ts
@@ -28,34 +28,34 @@ import { FlatStyleLike } from 'ol/style/flat';
   template: '',
 })
 export class DrawInteractionComponent implements OnInit, OnChanges, OnDestroy {
-  clickTolerance = input<number>();
-  features = input<Collection<Feature>>();
-  source = input<Vector>();
-  dragVertexDelay = input<number>();
-  snapTolerance = input<number>();
-  stopClick = input<boolean>();
-  type = input.required<Type>();
-  maxPoints = input<number>();
-  minPoints = input<number>();
-  finishCondition = input<Condition>();
-  style = input<StyleLike | FlatStyleLike | undefined>();
-  geometryFunction = input<GeometryFunction>();
-  geometryName = input<string>();
-  condition = input<Condition>();
-  freehandCondition = input<Condition>();
-  freehand = input<boolean>();
-  trace = input<boolean | Condition>();
-  traceSource = input<Vector>();
-  wrapX = input<boolean>();
-  geometryLayout = input<GeometryLayout>();
+  readonly clickTolerance = input<number>();
+  readonly features = input<Collection<Feature>>();
+  readonly source = input<Vector>();
+  readonly dragVertexDelay = input<number>();
+  readonly snapTolerance = input<number>();
+  readonly stopClick = input<boolean>();
+  readonly type = input.required<Type>();
+  readonly maxPoints = input<number>();
+  readonly minPoints = input<number>();
+  readonly finishCondition = input<Condition>();
+  readonly style = input<StyleLike | FlatStyleLike | undefined>();
+  readonly geometryFunction = input<GeometryFunction>();
+  readonly geometryName = input<string>();
+  readonly condition = input<Condition>();
+  readonly freehandCondition = input<Condition>();
+  readonly freehand = input<boolean>();
+  readonly trace = input<boolean | Condition>();
+  readonly traceSource = input<Vector>();
+  readonly wrapX = input<boolean>();
+  readonly geometryLayout = input<GeometryLayout>();
 
-  olChange = output<BaseEvent>();
-  changeActive = output<ObjectEvent>();
-  drawAbort = output<DrawEvent>();
-  drawEnd = output<DrawEvent>();
-  drawStart = output<DrawEvent>();
-  olError = output<BaseEvent>();
-  propertyChange = output<ObjectEvent>();
+  readonly olChange = output<BaseEvent>();
+  readonly changeActive = output<ObjectEvent>();
+  readonly drawAbort = output<DrawEvent>();
+  readonly drawEnd = output<DrawEvent>();
+  readonly drawStart = output<DrawEvent>();
+  readonly olError = output<BaseEvent>();
+  readonly propertyChange = output<ObjectEvent>();
 
   instance: Draw;
 

--- a/projects/ngx-ol/src/lib/interactions/draw.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/draw.component.ts
@@ -1,4 +1,13 @@
-import { Component, OnDestroy, OnInit, input, output, signal } from '@angular/core';
+import {
+  Component,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  input,
+  output,
+  signal,
+} from '@angular/core';
 import { MapComponent } from '../map.component';
 import Draw from 'ol/interaction/Draw';
 import Collection from 'ol/Collection';
@@ -17,7 +26,7 @@ import { FlatStyleLike } from 'ol/style/flat';
   selector: 'aol-interaction-draw',
   template: '',
 })
-export class DrawInteractionComponent implements OnInit, OnDestroy {
+export class DrawInteractionComponent implements OnInit, OnChanges, OnDestroy {
   clickTolerance = input<number>();
   features = input<Collection<Feature>>();
   source = input<Vector>();
@@ -76,6 +85,12 @@ export class DrawInteractionComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.map.instance.removeInteraction(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.instance && changes.trace?.currentValue !== undefined) {
+      this.instance.setTrace(changes.trace.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/interactions/draw.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/draw.component.ts
@@ -72,7 +72,43 @@ export class DrawInteractionComponent implements OnInit, OnChanges, OnDestroy {
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
+    this.initializeInstance();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    const liveUpdateKeys = ['trace'];
+    const requiresReload = Object.keys(changes).some(
+      (key) => !liveUpdateKeys.includes(key) && !changes[key].firstChange,
+    );
+
+    if (this.instance && requiresReload) {
+      this.reloadInstance();
+      return;
+    }
+
+    if (this.instance && changes.trace?.currentValue !== undefined) {
+      this.instance.setTrace(changes.trace.currentValue);
+    }
+  }
+
+  ngOnDestroy() {
+    if (this.instance) {
+      this.map.instance.removeInteraction(this.instance);
+    }
+  }
+
+  private initializeInstance() {
     this.setInstance(new Draw(this.createOptions()));
+    this.bindInstanceEvents();
+    this.map.instance.addInteraction(this.instance);
+  }
+
+  private reloadInstance() {
+    this.map.instance.removeInteraction(this.instance);
+    this.initializeInstance();
+  }
+
+  private bindInstanceEvents() {
     this.instance.on('change', (event: BaseEvent) => this.olChange.emit(event));
     this.instance.on('change:active', (event: ObjectEvent) => this.changeActive.emit(event));
     this.instance.on('drawabort', (event: DrawEvent) => this.drawAbort.emit(event));
@@ -80,17 +116,6 @@ export class DrawInteractionComponent implements OnInit, OnChanges, OnDestroy {
     this.instance.on('drawstart', (event: DrawEvent) => this.drawStart.emit(event));
     this.instance.on('error', (event: BaseEvent) => this.olError.emit(event));
     this.instance.on('propertychange', (event: ObjectEvent) => this.propertyChange.emit(event));
-    this.map.instance.addInteraction(this.instance);
-  }
-
-  ngOnDestroy() {
-    this.map.instance.removeInteraction(this.instance);
-  }
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (this.instance && changes.trace?.currentValue !== undefined) {
-      this.instance.setTrace(changes.trace.currentValue);
-    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/interactions/draw.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/draw.component.ts
@@ -83,7 +83,7 @@ export class DrawInteractionComponent implements OnInit, OnChanges, OnDestroy {
     );
 
     if (this.instance && requiresReload) {
-      this.reloadInstance();
+      this.replaceInstance();
       return;
     }
 
@@ -104,7 +104,7 @@ export class DrawInteractionComponent implements OnInit, OnChanges, OnDestroy {
     this.map.instance.addInteraction(this.instance);
   }
 
-  private reloadInstance() {
+  private replaceInstance() {
     this.map.instance.removeInteraction(this.instance);
     this.initializeInstance();
   }

--- a/projects/ngx-ol/src/lib/interactions/draw.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/draw.component.ts
@@ -7,6 +7,7 @@ import {
   input,
   output,
   signal,
+  inject,
 } from '@angular/core';
 import { MapComponent } from '../map.component';
 import Draw from 'ol/interaction/Draw';
@@ -69,7 +70,7 @@ export class DrawInteractionComponent implements OnInit, OnChanges, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.initializeInstance();

--- a/projects/ngx-ol/src/lib/interactions/draw.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/draw.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, EventEmitter, Output } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, output, signal } from '@angular/core';
 import { MapComponent } from '../map.component';
 import Draw from 'ol/interaction/Draw';
 import Collection from 'ol/Collection';
@@ -18,68 +18,52 @@ import { FlatStyleLike } from 'ol/style/flat';
   template: '',
 })
 export class DrawInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  clickTolerance?: number;
-  @Input()
-  features?: Collection<Feature>;
-  @Input()
-  source?: Vector;
-  @Input()
-  dragVertexDelay?: number;
-  @Input()
-  snapTolerance?: number;
-  @Input()
-  stopClick?: boolean;
-  @Input()
-  type: Type;
-  @Input()
-  maxPoints?: number;
-  @Input()
-  minPoints?: number;
-  @Input()
-  finishCondition?: Condition;
-  @Input()
-  style?: StyleLike | FlatStyleLike | undefined;
-  @Input()
-  geometryFunction?: GeometryFunction;
-  @Input()
-  geometryName?: string;
-  @Input()
-  condition?: Condition;
-  @Input()
-  freehandCondition?: Condition;
-  @Input()
-  freehand?: boolean;
-  @Input()
-  trace?: boolean | Condition;
-  @Input()
-  traceSource?: Vector;
-  @Input()
-  wrapX?: boolean;
-  @Input()
-  geometryLayout?: GeometryLayout;
+  clickTolerance = input<number>();
+  features = input<Collection<Feature>>();
+  source = input<Vector>();
+  dragVertexDelay = input<number>();
+  snapTolerance = input<number>();
+  stopClick = input<boolean>();
+  type = input.required<Type>();
+  maxPoints = input<number>();
+  minPoints = input<number>();
+  finishCondition = input<Condition>();
+  style = input<StyleLike | FlatStyleLike | undefined>();
+  geometryFunction = input<GeometryFunction>();
+  geometryName = input<string>();
+  condition = input<Condition>();
+  freehandCondition = input<Condition>();
+  freehand = input<boolean>();
+  trace = input<boolean | Condition>();
+  traceSource = input<Vector>();
+  wrapX = input<boolean>();
+  geometryLayout = input<GeometryLayout>();
 
-  @Output()
-  olChange = new EventEmitter<BaseEvent>();
-  @Output()
-  changeActive = new EventEmitter<ObjectEvent>();
-  @Output()
-  drawAbort = new EventEmitter<DrawEvent>();
-  @Output()
-  drawEnd = new EventEmitter<DrawEvent>();
-  @Output()
-  drawStart = new EventEmitter<DrawEvent>();
-  @Output()
-  olError = new EventEmitter<BaseEvent>();
-  @Output()
-  propertyChange = new EventEmitter<ObjectEvent>();
+  olChange = output<BaseEvent>();
+  changeActive = output<ObjectEvent>();
+  drawAbort = output<DrawEvent>();
+  drawEnd = output<DrawEvent>();
+  drawStart = output<DrawEvent>();
+  olError = output<BaseEvent>();
+  propertyChange = output<ObjectEvent>();
 
   instance: Draw;
 
+  protected readonly _instanceSignal = signal<Draw | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Draw): Draw {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new Draw(this.createOptions());
+    this.setInstance(new Draw(this.createOptions()));
     this.instance.on('change', (event: BaseEvent) => this.olChange.emit(event));
     this.instance.on('change:active', (event: ObjectEvent) => this.changeActive.emit(event));
     this.instance.on('drawabort', (event: DrawEvent) => this.drawAbort.emit(event));
@@ -96,26 +80,26 @@ export class DrawInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      clickTolerance: this.clickTolerance,
-      features: this.features,
-      source: this.source,
-      dragVertexDelay: this.dragVertexDelay,
-      snapTolerance: this.snapTolerance,
-      stopClick: this.stopClick,
-      type: this.type,
-      maxPoints: this.maxPoints,
-      minPoints: this.minPoints,
-      finishCondition: this.finishCondition,
-      style: this.style,
-      geometryFunction: this.geometryFunction,
-      geometryName: this.geometryName,
-      condition: this.condition,
-      freehandCondition: this.freehandCondition,
-      freehand: this.freehand,
-      trace: this.trace,
-      traceSource: this.traceSource,
-      wrapX: this.wrapX,
-      geometryLayout: this.geometryLayout,
+      clickTolerance: this.clickTolerance(),
+      features: this.features(),
+      source: this.source(),
+      dragVertexDelay: this.dragVertexDelay(),
+      snapTolerance: this.snapTolerance(),
+      stopClick: this.stopClick(),
+      type: this.type(),
+      maxPoints: this.maxPoints(),
+      minPoints: this.minPoints(),
+      finishCondition: this.finishCondition(),
+      style: this.style(),
+      geometryFunction: this.geometryFunction(),
+      geometryName: this.geometryName(),
+      condition: this.condition(),
+      freehandCondition: this.freehandCondition(),
+      freehand: this.freehand(),
+      trace: this.trace(),
+      traceSource: this.traceSource(),
+      wrapX: this.wrapX(),
+      geometryLayout: this.geometryLayout(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/extent.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/extent.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -24,11 +24,9 @@ class ExtentInteractionHostComponent {
   extent: [number, number, number, number] = [-5, -5, 5, 5];
   extentChanged = vi.fn();
 
-  @ViewChild(ExtentInteractionComponent)
-  interaction!: ExtentInteractionComponent;
+  readonly interaction = viewChild.required<ExtentInteractionComponent>(ExtentInteractionComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('ExtentInteractionComponent', () => {
@@ -50,9 +48,9 @@ describe('ExtentInteractionComponent', () => {
   it('adds an extent interaction to the map and forwards extent change events', () => {
     const host = fixture.componentInstance;
 
-    expect(host.map.instance.getInteractions().getArray()).toContain(host.interaction.instance);
+    expect(host.map().instance.getInteractions().getArray()).toContain(host.interaction().instance);
 
-    host.interaction.instance.dispatchEvent('extentchanged');
+    host.interaction().instance.dispatchEvent('extentchanged');
 
     expect(host.extentChanged).toHaveBeenCalledOnce();
   });

--- a/projects/ngx-ol/src/lib/interactions/extent.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/extent.component.ts
@@ -7,6 +7,7 @@ import {
   input,
   output,
   signal,
+  inject,
 } from '@angular/core';
 import type { Condition } from 'ol/events/condition';
 import type { Extent as ExtentType } from 'ol/extent';
@@ -47,7 +48,7 @@ export class ExtentInteractionComponent implements OnInit, OnChanges, OnDestroy 
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new ExtentInteraction(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/extent.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/extent.component.ts
@@ -1,4 +1,13 @@
-import { Component, OnDestroy, OnInit, input, output, signal } from '@angular/core';
+import {
+  Component,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  input,
+  output,
+  signal,
+} from '@angular/core';
 import type { Condition } from 'ol/events/condition';
 import type { Extent as ExtentType } from 'ol/extent';
 import ExtentInteraction, { ExtentEvent } from 'ol/interaction/Extent';
@@ -10,7 +19,7 @@ import { MapComponent } from '../map.component';
   selector: 'aol-interaction-extent',
   template: '',
 })
-export class ExtentInteractionComponent implements OnInit, OnDestroy {
+export class ExtentInteractionComponent implements OnInit, OnChanges, OnDestroy {
   condition = input<Condition>();
 
   extent = input<ExtentType>();
@@ -48,6 +57,12 @@ export class ExtentInteractionComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.map.instance.removeInteraction(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.instance && changes.extent) {
+      this.instance.setExtent(changes.extent.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/interactions/extent.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/extent.component.ts
@@ -21,19 +21,19 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class ExtentInteractionComponent implements OnInit, OnChanges, OnDestroy {
-  condition = input<Condition>();
+  readonly condition = input<Condition>();
 
-  extent = input<ExtentType>();
+  readonly extent = input<ExtentType>();
 
-  boxStyle = input<StyleLike>();
+  readonly boxStyle = input<StyleLike>();
 
-  pixelTolerance = input<number>();
+  readonly pixelTolerance = input<number>();
 
-  pointerStyle = input<StyleLike>();
+  readonly pointerStyle = input<StyleLike>();
 
-  wrapX = input<boolean>();
+  readonly wrapX = input<boolean>();
 
-  extentChanged = output<ExtentEvent>();
+  readonly extentChanged = output<ExtentEvent>();
 
   instance: ExtentInteraction;
 

--- a/projects/ngx-ol/src/lib/interactions/extent.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/extent.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, output, signal } from '@angular/core';
 import type { Condition } from 'ol/events/condition';
 import type { Extent as ExtentType } from 'ol/extent';
 import ExtentInteraction, { ExtentEvent } from 'ol/interaction/Extent';
@@ -11,33 +11,37 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class ExtentInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  condition?: Condition;
+  condition = input<Condition>();
 
-  @Input()
-  extent?: ExtentType;
+  extent = input<ExtentType>();
 
-  @Input()
-  boxStyle?: StyleLike;
+  boxStyle = input<StyleLike>();
 
-  @Input()
-  pixelTolerance?: number;
+  pixelTolerance = input<number>();
 
-  @Input()
-  pointerStyle?: StyleLike;
+  pointerStyle = input<StyleLike>();
 
-  @Input()
-  wrapX?: boolean;
+  wrapX = input<boolean>();
 
-  @Output()
-  extentChanged = new EventEmitter<ExtentEvent>();
+  extentChanged = output<ExtentEvent>();
 
   instance: ExtentInteraction;
 
+  protected readonly _instanceSignal = signal<ExtentInteraction | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: ExtentInteraction): ExtentInteraction {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new ExtentInteraction(this.createOptions());
+    this.setInstance(new ExtentInteraction(this.createOptions()));
     this.instance.on('extentchanged', (event) => this.extentChanged.emit(event));
     this.map.instance.addInteraction(this.instance);
   }
@@ -48,12 +52,12 @@ export class ExtentInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      condition: this.condition,
-      extent: this.extent,
-      boxStyle: this.boxStyle,
-      pixelTolerance: this.pixelTolerance,
-      pointerStyle: this.pointerStyle,
-      wrapX: this.wrapX,
+      condition: this.condition(),
+      extent: this.extent(),
+      boxStyle: this.boxStyle(),
+      pixelTolerance: this.pixelTolerance(),
+      pointerStyle: this.pointerStyle(),
+      wrapX: this.wrapX(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/keyboardpan.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/keyboardpan.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -20,11 +20,11 @@ class KeyboardPanInteractionHostComponent {
   zoom = 2;
   pixelDelta = 64;
 
-  @ViewChild(KeyboardPanInteractionComponent)
-  interaction!: KeyboardPanInteractionComponent;
+  readonly interaction = viewChild.required<KeyboardPanInteractionComponent>(
+    KeyboardPanInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('KeyboardPanInteractionComponent', () => {
@@ -45,8 +45,8 @@ describe('KeyboardPanInteractionComponent', () => {
 
   it('adds and removes a keyboard-pan interaction with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interaction = host.interaction.instance;
+    const map = host.map().instance;
+    const interaction = host.interaction().instance;
 
     expect(map.getInteractions().getArray()).toContain(interaction);
 

--- a/projects/ngx-ol/src/lib/interactions/keyboardpan.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/keyboardpan.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import KeyboardPan from 'ol/interaction/KeyboardPan';
 import { Options } from 'ol/interaction/KeyboardPan';
 import { MapComponent } from '../map.component';
@@ -8,17 +8,26 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class KeyboardPanInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  duration?: number;
-  @Input()
-  pixelDelta?: number;
+  duration = input<number>();
+  pixelDelta = input<number>();
 
   instance: KeyboardPan;
 
+  protected readonly _instanceSignal = signal<KeyboardPan | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: KeyboardPan): KeyboardPan {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new KeyboardPan(this.createOptions());
+    this.setInstance(new KeyboardPan(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -28,8 +37,8 @@ export class KeyboardPanInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      duration: this.duration,
-      pixelDelta: this.pixelDelta,
+      duration: this.duration(),
+      pixelDelta: this.pixelDelta(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/keyboardpan.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/keyboardpan.component.ts
@@ -8,8 +8,8 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class KeyboardPanInteractionComponent implements OnInit, OnDestroy {
-  duration = input<number>();
-  pixelDelta = input<number>();
+  readonly duration = input<number>();
+  readonly pixelDelta = input<number>();
 
   instance: KeyboardPan;
 

--- a/projects/ngx-ol/src/lib/interactions/keyboardpan.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/keyboardpan.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import KeyboardPan from 'ol/interaction/KeyboardPan';
 import { Options } from 'ol/interaction/KeyboardPan';
 import { MapComponent } from '../map.component';
@@ -24,7 +24,7 @@ export class KeyboardPanInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new KeyboardPan(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/keyboardzoom.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/keyboardzoom.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -20,11 +20,11 @@ class KeyboardZoomInteractionHostComponent {
   zoom = 2;
   delta = 2;
 
-  @ViewChild(KeyboardZoomInteractionComponent)
-  interaction!: KeyboardZoomInteractionComponent;
+  readonly interaction = viewChild.required<KeyboardZoomInteractionComponent>(
+    KeyboardZoomInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('KeyboardZoomInteractionComponent', () => {
@@ -45,8 +45,8 @@ describe('KeyboardZoomInteractionComponent', () => {
 
   it('adds and removes a keyboard-zoom interaction with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interaction = host.interaction.instance;
+    const map = host.map().instance;
+    const interaction = host.interaction().instance;
 
     expect(map.getInteractions().getArray()).toContain(interaction);
 

--- a/projects/ngx-ol/src/lib/interactions/keyboardzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/keyboardzoom.component.ts
@@ -8,8 +8,8 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class KeyboardZoomInteractionComponent implements OnInit, OnDestroy {
-  duration = input<number>();
-  delta = input<number>();
+  readonly duration = input<number>();
+  readonly delta = input<number>();
 
   instance: KeyboardZoom;
 

--- a/projects/ngx-ol/src/lib/interactions/keyboardzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/keyboardzoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import KeyboardZoom from 'ol/interaction/KeyboardZoom';
 import { Options } from 'ol/interaction/KeyboardZoom';
 import { MapComponent } from '../map.component';
@@ -24,7 +24,7 @@ export class KeyboardZoomInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new KeyboardZoom(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/keyboardzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/keyboardzoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import KeyboardZoom from 'ol/interaction/KeyboardZoom';
 import { Options } from 'ol/interaction/KeyboardZoom';
 import { MapComponent } from '../map.component';
@@ -8,17 +8,26 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class KeyboardZoomInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  duration?: number;
-  @Input()
-  delta?: number;
+  duration = input<number>();
+  delta = input<number>();
 
   instance: KeyboardZoom;
 
+  protected readonly _instanceSignal = signal<KeyboardZoom | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: KeyboardZoom): KeyboardZoom {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new KeyboardZoom(this.createOptions());
+    this.setInstance(new KeyboardZoom(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -28,8 +37,8 @@ export class KeyboardZoomInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      duration: this.duration,
-      delta: this.delta,
+      duration: this.duration(),
+      delta: this.delta(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/link.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/link.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { Params } from 'ol/interaction/Link';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -27,11 +27,9 @@ class LinkInteractionHostComponent {
   prefix = 'demo';
   params: Params[] = ['x', 'y', 'z', 'r'];
 
-  @ViewChild(LinkInteractionComponent)
-  interaction!: LinkInteractionComponent;
+  readonly interaction = viewChild.required<LinkInteractionComponent>(LinkInteractionComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('LinkInteractionComponent', () => {
@@ -52,8 +50,8 @@ describe('LinkInteractionComponent', () => {
 
   it('adds and removes a link interaction with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interaction = host.interaction.instance;
+    const map = host.map().instance;
+    const interaction = host.interaction().instance;
 
     expect(map.getInteractions().getArray()).toContain(interaction);
 

--- a/projects/ngx-ol/src/lib/interactions/link.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/link.component.ts
@@ -9,13 +9,13 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class LinkInteractionComponent implements OnInit, OnDestroy {
-  animate = input<boolean | AnimationOptions>();
+  readonly animate = input<boolean | AnimationOptions>();
 
-  params = input<Params[]>();
+  readonly params = input<Params[]>();
 
-  replace = input<boolean>();
+  readonly replace = input<boolean>();
 
-  prefix = input<string>();
+  readonly prefix = input<string>();
 
   instance: Link;
 

--- a/projects/ngx-ol/src/lib/interactions/link.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/link.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import Link from 'ol/interaction/Link';
 import type { Options, Params } from 'ol/interaction/Link';
 import type { AnimationOptions } from 'ol/View';
@@ -9,24 +9,31 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class LinkInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  animate?: boolean | AnimationOptions;
+  animate = input<boolean | AnimationOptions>();
 
-  @Input()
-  params?: Params[];
+  params = input<Params[]>();
 
-  @Input()
-  replace?: boolean;
+  replace = input<boolean>();
 
-  @Input()
-  prefix?: string;
+  prefix = input<string>();
 
   instance: Link;
 
+  protected readonly _instanceSignal = signal<Link | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Link): Link {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new Link(this.createOptions());
+    this.setInstance(new Link(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -36,10 +43,10 @@ export class LinkInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      animate: this.animate,
-      params: this.params,
-      replace: this.replace,
-      prefix: this.prefix,
+      animate: this.animate(),
+      params: this.params(),
+      replace: this.replace(),
+      prefix: this.prefix(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/link.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/link.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import Link from 'ol/interaction/Link';
 import type { Options, Params } from 'ol/interaction/Link';
 import type { AnimationOptions } from 'ol/View';
@@ -30,7 +30,7 @@ export class LinkInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new Link(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/modify.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/modify.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
@@ -38,11 +38,9 @@ class ModifyInteractionHostComponent {
   error = vi.fn();
   propertyChange = vi.fn();
 
-  @ViewChild(ModifyInteractionComponent)
-  interaction!: ModifyInteractionComponent;
+  readonly interaction = viewChild.required<ModifyInteractionComponent>(ModifyInteractionComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('ModifyInteractionComponent', () => {
@@ -64,14 +62,14 @@ describe('ModifyInteractionComponent', () => {
   it('adds a modify interaction to the map and forwards OpenLayers events', () => {
     const host = fixture.componentInstance;
 
-    expect(host.map.instance.getInteractions().getArray()).toContain(host.interaction.instance);
+    expect(host.map().instance.getInteractions().getArray()).toContain(host.interaction().instance);
 
-    host.interaction.instance.dispatchEvent('modifystart');
-    host.interaction.instance.dispatchEvent('modifyend');
-    host.interaction.instance.dispatchEvent('change');
-    host.interaction.instance.dispatchEvent('change:active');
-    host.interaction.instance.dispatchEvent('error');
-    host.interaction.instance.dispatchEvent('propertychange');
+    host.interaction().instance.dispatchEvent('modifystart');
+    host.interaction().instance.dispatchEvent('modifyend');
+    host.interaction().instance.dispatchEvent('change');
+    host.interaction().instance.dispatchEvent('change:active');
+    host.interaction().instance.dispatchEvent('error');
+    host.interaction().instance.dispatchEvent('propertychange');
 
     expect(host.modifyStart).toHaveBeenCalledOnce();
     expect(host.modifyEnd).toHaveBeenCalledOnce();

--- a/projects/ngx-ol/src/lib/interactions/modify.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/modify.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, output, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, output, signal, inject } from '@angular/core';
 import { MapComponent } from '../map.component';
 import Modify from 'ol/interaction/Modify';
 import Collection from 'ol/Collection';
@@ -48,7 +48,7 @@ export class ModifyInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new Modify(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/modify.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/modify.component.ts
@@ -17,23 +17,23 @@ import BaseVectorLayer from 'ol/layer/BaseVector';
   template: '',
 })
 export class ModifyInteractionComponent implements OnInit, OnDestroy {
-  condition = input<Condition>();
-  deleteCondition = input<Condition>();
-  insertVertexCondition = input<Condition>();
-  pixelTolerance = input<number>();
-  style = input<StyleLike | FlatStyleLike | undefined>();
-  features = input<Collection<Feature>>();
-  wrapX = input<boolean>();
-  source = input<Vector>();
-  hitDetection = input<boolean | BaseVectorLayer<any, any, any>>();
-  snapToPointer = input<boolean>();
+  readonly condition = input<Condition>();
+  readonly deleteCondition = input<Condition>();
+  readonly insertVertexCondition = input<Condition>();
+  readonly pixelTolerance = input<number>();
+  readonly style = input<StyleLike | FlatStyleLike | undefined>();
+  readonly features = input<Collection<Feature>>();
+  readonly wrapX = input<boolean>();
+  readonly source = input<Vector>();
+  readonly hitDetection = input<boolean | BaseVectorLayer<any, any, any>>();
+  readonly snapToPointer = input<boolean>();
 
-  olChange = output<BaseEvent>();
-  changeActive = output<ObjectEvent>();
-  olError = output<BaseEvent>();
-  modifyEnd = output<ModifyEvent>();
-  modifyStart = output<ModifyEvent>();
-  propertyChange = output<ObjectEvent>();
+  readonly olChange = output<BaseEvent>();
+  readonly changeActive = output<ObjectEvent>();
+  readonly olError = output<BaseEvent>();
+  readonly modifyEnd = output<ModifyEvent>();
+  readonly modifyStart = output<ModifyEvent>();
+  readonly propertyChange = output<ObjectEvent>();
 
   instance: Modify;
 

--- a/projects/ngx-ol/src/lib/interactions/modify.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/modify.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, output, signal } from '@angular/core';
 import { MapComponent } from '../map.component';
 import Modify from 'ol/interaction/Modify';
 import Collection from 'ol/Collection';
@@ -17,46 +17,41 @@ import BaseVectorLayer from 'ol/layer/BaseVector';
   template: '',
 })
 export class ModifyInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  condition?: Condition;
-  @Input()
-  deleteCondition?: Condition;
-  @Input()
-  insertVertexCondition?: Condition;
-  @Input()
-  pixelTolerance?: number;
-  @Input()
-  style?: StyleLike | FlatStyleLike | undefined;
-  @Input()
-  features?: Collection<Feature>;
-  @Input()
-  wrapX?: boolean;
-  @Input()
-  source?: Vector;
-  @Input()
-  hitDetection?: boolean | BaseVectorLayer<any, any, any>;
-  @Input()
-  snapToPointer?: boolean;
+  condition = input<Condition>();
+  deleteCondition = input<Condition>();
+  insertVertexCondition = input<Condition>();
+  pixelTolerance = input<number>();
+  style = input<StyleLike | FlatStyleLike | undefined>();
+  features = input<Collection<Feature>>();
+  wrapX = input<boolean>();
+  source = input<Vector>();
+  hitDetection = input<boolean | BaseVectorLayer<any, any, any>>();
+  snapToPointer = input<boolean>();
 
-  @Output()
-  olChange = new EventEmitter<BaseEvent>();
-  @Output()
-  changeActive = new EventEmitter<ObjectEvent>();
-  @Output()
-  olError = new EventEmitter<BaseEvent>();
-  @Output()
-  modifyEnd = new EventEmitter<ModifyEvent>();
-  @Output()
-  modifyStart = new EventEmitter<ModifyEvent>();
-  @Output()
-  propertyChange = new EventEmitter<ObjectEvent>();
+  olChange = output<BaseEvent>();
+  changeActive = output<ObjectEvent>();
+  olError = output<BaseEvent>();
+  modifyEnd = output<ModifyEvent>();
+  modifyStart = output<ModifyEvent>();
+  propertyChange = output<ObjectEvent>();
 
   instance: Modify;
 
+  protected readonly _instanceSignal = signal<Modify | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Modify): Modify {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new Modify(this.createOptions());
+    this.setInstance(new Modify(this.createOptions()));
     this.instance.on('change', (event: BaseEvent) => this.olChange.emit(event));
     this.instance.on('change:active', (event: ObjectEvent) => this.changeActive.emit(event));
     this.instance.on('error', (event: BaseEvent) => this.olError.emit(event));
@@ -72,16 +67,16 @@ export class ModifyInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      condition: this.condition,
-      deleteCondition: this.deleteCondition,
-      insertVertexCondition: this.insertVertexCondition,
-      pixelTolerance: this.pixelTolerance,
-      style: this.style,
-      features: this.features,
-      wrapX: this.wrapX,
-      source: this.source,
-      hitDetection: this.hitDetection,
-      snapToPointer: this.snapToPointer,
+      condition: this.condition(),
+      deleteCondition: this.deleteCondition(),
+      insertVertexCondition: this.insertVertexCondition(),
+      pixelTolerance: this.pixelTolerance(),
+      style: this.style(),
+      features: this.features(),
+      wrapX: this.wrapX(),
+      source: this.source(),
+      hitDetection: this.hitDetection(),
+      snapToPointer: this.snapToPointer(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/mousewheelzoom.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/mousewheelzoom.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -9,9 +9,7 @@ import { MouseWheelZoomInteractionComponent } from './mousewheelzoom.component';
   template: `
     <aol-map width="320px" height="240px">
       <aol-view [center]="center" [zoom]="zoom"></aol-view>
-      <aol-interaction-mousewheelzoom
-        [duration]="duration"
-      ></aol-interaction-mousewheelzoom>
+      <aol-interaction-mousewheelzoom [duration]="duration"></aol-interaction-mousewheelzoom>
     </aol-map>
   `,
   standalone: true,
@@ -22,11 +20,11 @@ class MouseWheelZoomInteractionHostComponent {
   zoom = 2;
   duration = 100;
 
-  @ViewChild(MouseWheelZoomInteractionComponent)
-  interaction!: MouseWheelZoomInteractionComponent;
+  readonly interaction = viewChild.required<MouseWheelZoomInteractionComponent>(
+    MouseWheelZoomInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('MouseWheelZoomInteractionComponent', () => {
@@ -47,8 +45,8 @@ describe('MouseWheelZoomInteractionComponent', () => {
 
   it('adds and removes a mouse-wheel zoom interaction with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interaction = host.interaction.instance;
+    const map = host.map().instance;
+    const interaction = host.interaction().instance;
 
     expect(map.getInteractions().getArray()).toContain(interaction);
 

--- a/projects/ngx-ol/src/lib/interactions/mousewheelzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/mousewheelzoom.component.ts
@@ -6,6 +6,7 @@ import {
   SimpleChanges,
   input,
   signal,
+  inject,
 } from '@angular/core';
 import MouseWheelZoom from 'ol/interaction/MouseWheelZoom';
 import { Options } from 'ol/interaction/MouseWheelZoom';
@@ -33,7 +34,7 @@ export class MouseWheelZoomInteractionComponent implements OnInit, OnChanges, On
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new MouseWheelZoom(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/mousewheelzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/mousewheelzoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import MouseWheelZoom from 'ol/interaction/MouseWheelZoom';
 import { Options } from 'ol/interaction/MouseWheelZoom';
 import { MapComponent } from '../map.component';
@@ -8,19 +8,27 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class MouseWheelZoomInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  duration?: number;
-  @Input()
-  timeout?: number;
-  @Input()
-  useAnchor?: boolean;
+  duration = input<number>();
+  timeout = input<number>();
+  useAnchor = input<boolean>();
 
   instance: MouseWheelZoom;
 
+  protected readonly _instanceSignal = signal<MouseWheelZoom | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: MouseWheelZoom): MouseWheelZoom {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new MouseWheelZoom(this.createOptions());
+    this.setInstance(new MouseWheelZoom(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -30,9 +38,9 @@ export class MouseWheelZoomInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      duration: this.duration,
-      timeout: this.timeout,
-      useAnchor: this.useAnchor,
+      duration: this.duration(),
+      timeout: this.timeout(),
+      useAnchor: this.useAnchor(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/mousewheelzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/mousewheelzoom.component.ts
@@ -17,9 +17,9 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class MouseWheelZoomInteractionComponent implements OnInit, OnChanges, OnDestroy {
-  duration = input<number>();
-  timeout = input<number>();
-  useAnchor = input<boolean>();
+  readonly duration = input<number>();
+  readonly timeout = input<number>();
+  readonly useAnchor = input<boolean>();
 
   instance: MouseWheelZoom;
 

--- a/projects/ngx-ol/src/lib/interactions/mousewheelzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/mousewheelzoom.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import {
+  Component,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import MouseWheelZoom from 'ol/interaction/MouseWheelZoom';
 import { Options } from 'ol/interaction/MouseWheelZoom';
 import { MapComponent } from '../map.component';
@@ -7,7 +15,7 @@ import { MapComponent } from '../map.component';
   selector: 'aol-interaction-mousewheelzoom',
   template: '',
 })
-export class MouseWheelZoomInteractionComponent implements OnInit, OnDestroy {
+export class MouseWheelZoomInteractionComponent implements OnInit, OnChanges, OnDestroy {
   duration = input<number>();
   timeout = input<number>();
   useAnchor = input<boolean>();
@@ -34,6 +42,12 @@ export class MouseWheelZoomInteractionComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.map.instance.removeInteraction(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.instance && changes.useAnchor?.currentValue !== undefined) {
+      this.instance.setMouseAnchor(changes.useAnchor.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/interactions/pinchrotate.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/pinchrotate.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -20,11 +20,11 @@ class PinchRotateInteractionHostComponent {
   zoom = 2;
   threshold = 0.3;
 
-  @ViewChild(PinchRotateInteractionComponent)
-  interaction!: PinchRotateInteractionComponent;
+  readonly interaction = viewChild.required<PinchRotateInteractionComponent>(
+    PinchRotateInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('PinchRotateInteractionComponent', () => {
@@ -45,8 +45,8 @@ describe('PinchRotateInteractionComponent', () => {
 
   it('adds and removes a pinch-rotate interaction with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interaction = host.interaction.instance;
+    const map = host.map().instance;
+    const interaction = host.interaction().instance;
 
     expect(map.getInteractions().getArray()).toContain(interaction);
 

--- a/projects/ngx-ol/src/lib/interactions/pinchrotate.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/pinchrotate.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import PinchRotate from 'ol/interaction/PinchRotate';
 import type { Options } from 'ol/interaction/PinchRotate';
 import { MapComponent } from '../map.component';
@@ -25,7 +25,7 @@ export class PinchRotateInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new PinchRotate(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/pinchrotate.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/pinchrotate.component.ts
@@ -8,9 +8,9 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class PinchRotateInteractionComponent implements OnInit, OnDestroy {
-  duration = input<number>();
+  readonly duration = input<number>();
 
-  threshold = input<number>();
+  readonly threshold = input<number>();
 
   instance: PinchRotate;
 

--- a/projects/ngx-ol/src/lib/interactions/pinchrotate.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/pinchrotate.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import PinchRotate from 'ol/interaction/PinchRotate';
 import type { Options } from 'ol/interaction/PinchRotate';
 import { MapComponent } from '../map.component';
@@ -8,18 +8,27 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class PinchRotateInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  duration?: number;
+  duration = input<number>();
 
-  @Input()
-  threshold?: number;
+  threshold = input<number>();
 
   instance: PinchRotate;
 
+  protected readonly _instanceSignal = signal<PinchRotate | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: PinchRotate): PinchRotate {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new PinchRotate(this.createOptions());
+    this.setInstance(new PinchRotate(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -29,8 +38,8 @@ export class PinchRotateInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      duration: this.duration,
-      threshold: this.threshold,
+      duration: this.duration(),
+      threshold: this.threshold(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/pinchzoom.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/pinchzoom.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -20,11 +20,11 @@ class PinchZoomInteractionHostComponent {
   zoom = 2;
   duration = 100;
 
-  @ViewChild(PinchZoomInteractionComponent)
-  interaction!: PinchZoomInteractionComponent;
+  readonly interaction = viewChild.required<PinchZoomInteractionComponent>(
+    PinchZoomInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('PinchZoomInteractionComponent', () => {
@@ -45,8 +45,8 @@ describe('PinchZoomInteractionComponent', () => {
 
   it('adds and removes a pinch-zoom interaction with the host map lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const interaction = host.interaction.instance;
+    const map = host.map().instance;
+    const interaction = host.interaction().instance;
 
     expect(map.getInteractions().getArray()).toContain(interaction);
 

--- a/projects/ngx-ol/src/lib/interactions/pinchzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/pinchzoom.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class PinchZoomInteractionComponent implements OnInit, OnDestroy {
-  duration = input<number>();
+  readonly duration = input<number>();
 
   instance: PinchZoom;
 

--- a/projects/ngx-ol/src/lib/interactions/pinchzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/pinchzoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, Input } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
 import PinchZoom from 'ol/interaction/PinchZoom';
 import { Options } from 'ol/interaction/PinchZoom';
 import { MapComponent } from '../map.component';
@@ -8,15 +8,25 @@ import { MapComponent } from '../map.component';
   template: '',
 })
 export class PinchZoomInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  duration?: number;
+  duration = input<number>();
 
   instance: PinchZoom;
 
+  protected readonly _instanceSignal = signal<PinchZoom | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: PinchZoom): PinchZoom {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new PinchZoom(this.createOptions());
+    this.setInstance(new PinchZoom(this.createOptions()));
     this.map.instance.addInteraction(this.instance);
   }
 
@@ -26,7 +36,7 @@ export class PinchZoomInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      duration: this.duration,
+      duration: this.duration(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/pinchzoom.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/pinchzoom.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, signal, inject } from '@angular/core';
 import PinchZoom from 'ol/interaction/PinchZoom';
 import { Options } from 'ol/interaction/PinchZoom';
 import { MapComponent } from '../map.component';
@@ -23,7 +23,7 @@ export class PinchZoomInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new PinchZoom(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/select.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/select.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
@@ -36,11 +36,9 @@ class SelectInteractionHostComponent {
   error = vi.fn();
   propertyChange = vi.fn();
 
-  @ViewChild(SelectInteractionComponent)
-  interaction!: SelectInteractionComponent;
+  readonly interaction = viewChild.required<SelectInteractionComponent>(SelectInteractionComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('SelectInteractionComponent', () => {
@@ -62,13 +60,13 @@ describe('SelectInteractionComponent', () => {
   it('adds a select interaction to the map and forwards OpenLayers events', () => {
     const host = fixture.componentInstance;
 
-    expect(host.map.instance.getInteractions().getArray()).toContain(host.interaction.instance);
+    expect(host.map().instance.getInteractions().getArray()).toContain(host.interaction().instance);
 
-    host.interaction.instance.dispatchEvent('select');
-    host.interaction.instance.dispatchEvent('change');
-    host.interaction.instance.dispatchEvent('change:active');
-    host.interaction.instance.dispatchEvent('error');
-    host.interaction.instance.dispatchEvent('propertychange');
+    host.interaction().instance.dispatchEvent('select');
+    host.interaction().instance.dispatchEvent('change');
+    host.interaction().instance.dispatchEvent('change:active');
+    host.interaction().instance.dispatchEvent('error');
+    host.interaction().instance.dispatchEvent('propertychange');
 
     expect(host.select).toHaveBeenCalledOnce();
     expect(host.change).toHaveBeenCalledOnce();

--- a/projects/ngx-ol/src/lib/interactions/select.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/select.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, output, signal } from '@angular/core';
 import { MapComponent } from '../map.component';
 import Select from 'ol/interaction/Select';
 import Layer from 'ol/layer/Layer';
@@ -15,44 +15,40 @@ import BaseEvent from 'ol/events/Event';
   template: '',
 })
 export class SelectInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  addCondition?: Condition;
-  @Input()
-  condition?: Condition;
-  @Input()
-  layers?: Layer[] | ((layer: Layer) => boolean);
-  @Input()
-  style?: StyleLike | null | undefined;
-  @Input()
-  removeCondition?: Condition;
-  @Input()
-  toggleCondition?: Condition;
-  @Input()
-  multi?: boolean;
-  @Input()
-  features?: Collection<Feature>;
-  @Input()
-  filter?: FilterFunction;
-  @Input()
-  hitTolerance?: number;
+  addCondition = input<Condition>();
+  condition = input<Condition>();
+  layers = input<Layer[] | ((layer: Layer) => boolean)>();
+  style = input<StyleLike | null | undefined>();
+  removeCondition = input<Condition>();
+  toggleCondition = input<Condition>();
+  multi = input<boolean>();
+  features = input<Collection<Feature>>();
+  filter = input<FilterFunction>();
+  hitTolerance = input<number>();
 
-  @Output()
-  olChange = new EventEmitter<BaseEvent>();
-  @Output()
-  changeActive = new EventEmitter<ObjectEvent>();
-  @Output()
-  olError = new EventEmitter<BaseEvent>();
-  @Output()
-  propertyChange = new EventEmitter<ObjectEvent>();
-  @Output()
-  olSelect = new EventEmitter<SelectEvent>();
+  olChange = output<BaseEvent>();
+  changeActive = output<ObjectEvent>();
+  olError = output<BaseEvent>();
+  propertyChange = output<ObjectEvent>();
+  olSelect = output<SelectEvent>();
 
   instance: Select;
 
+  protected readonly _instanceSignal = signal<Select | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Select): Select {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new Select(this.createOptions());
+    this.setInstance(new Select(this.createOptions()));
 
     this.instance.on('change', (event: BaseEvent) => this.olChange.emit(event));
     this.instance.on('change:active', (event: ObjectEvent) => this.changeActive.emit(event));
@@ -68,16 +64,16 @@ export class SelectInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      addCondition: this.addCondition,
-      condition: this.condition,
-      layers: this.layers,
-      style: this.style,
-      removeCondition: this.removeCondition,
-      toggleCondition: this.toggleCondition,
-      multi: this.multi,
-      features: this.features,
-      filter: this.filter,
-      hitTolerance: this.hitTolerance,
+      addCondition: this.addCondition(),
+      condition: this.condition(),
+      layers: this.layers(),
+      style: this.style(),
+      removeCondition: this.removeCondition(),
+      toggleCondition: this.toggleCondition(),
+      multi: this.multi(),
+      features: this.features(),
+      filter: this.filter(),
+      hitTolerance: this.hitTolerance(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/select.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/select.component.ts
@@ -25,22 +25,22 @@ import BaseEvent from 'ol/events/Event';
   template: '',
 })
 export class SelectInteractionComponent implements OnInit, OnChanges, OnDestroy {
-  addCondition = input<Condition>();
-  condition = input<Condition>();
-  layers = input<Layer[] | ((layer: Layer) => boolean)>();
-  style = input<StyleLike | null | undefined>();
-  removeCondition = input<Condition>();
-  toggleCondition = input<Condition>();
-  multi = input<boolean>();
-  features = input<Collection<Feature>>();
-  filter = input<FilterFunction>();
-  hitTolerance = input<number>();
+  readonly addCondition = input<Condition>();
+  readonly condition = input<Condition>();
+  readonly layers = input<Layer[] | ((layer: Layer) => boolean)>();
+  readonly style = input<StyleLike | null | undefined>();
+  readonly removeCondition = input<Condition>();
+  readonly toggleCondition = input<Condition>();
+  readonly multi = input<boolean>();
+  readonly features = input<Collection<Feature>>();
+  readonly filter = input<FilterFunction>();
+  readonly hitTolerance = input<number>();
 
-  olChange = output<BaseEvent>();
-  changeActive = output<ObjectEvent>();
-  olError = output<BaseEvent>();
-  propertyChange = output<ObjectEvent>();
-  olSelect = output<SelectEvent>();
+  readonly olChange = output<BaseEvent>();
+  readonly changeActive = output<ObjectEvent>();
+  readonly olError = output<BaseEvent>();
+  readonly propertyChange = output<ObjectEvent>();
+  readonly olSelect = output<SelectEvent>();
 
   instance: Select;
 

--- a/projects/ngx-ol/src/lib/interactions/select.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/select.component.ts
@@ -7,6 +7,7 @@ import {
   input,
   output,
   signal,
+  inject,
 } from '@angular/core';
 import { MapComponent } from '../map.component';
 import Select from 'ol/interaction/Select';
@@ -54,7 +55,7 @@ export class SelectInteractionComponent implements OnInit, OnChanges, OnDestroy 
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new Select(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/select.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/select.component.ts
@@ -1,4 +1,13 @@
-import { Component, OnDestroy, OnInit, input, output, signal } from '@angular/core';
+import {
+  Component,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  input,
+  output,
+  signal,
+} from '@angular/core';
 import { MapComponent } from '../map.component';
 import Select from 'ol/interaction/Select';
 import Layer from 'ol/layer/Layer';
@@ -14,7 +23,7 @@ import BaseEvent from 'ol/events/Event';
   selector: 'aol-interaction-select',
   template: '',
 })
-export class SelectInteractionComponent implements OnInit, OnDestroy {
+export class SelectInteractionComponent implements OnInit, OnChanges, OnDestroy {
   addCondition = input<Condition>();
   condition = input<Condition>();
   layers = input<Layer[] | ((layer: Layer) => boolean)>();
@@ -60,6 +69,12 @@ export class SelectInteractionComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.map.instance.removeInteraction(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.instance && changes.hitTolerance?.currentValue !== undefined) {
+      this.instance.setHitTolerance(changes.hitTolerance.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/interactions/snap.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/snap.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
@@ -36,11 +36,9 @@ class SnapInteractionHostComponent {
   error = vi.fn();
   propertyChange = vi.fn();
 
-  @ViewChild(SnapInteractionComponent)
-  interaction!: SnapInteractionComponent;
+  readonly interaction = viewChild.required<SnapInteractionComponent>(SnapInteractionComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('SnapInteractionComponent', () => {
@@ -62,13 +60,13 @@ describe('SnapInteractionComponent', () => {
   it('adds a snap interaction to the map and forwards OpenLayers events', () => {
     const host = fixture.componentInstance;
 
-    expect(host.map.instance.getInteractions().getArray()).toContain(host.interaction.instance);
+    expect(host.map().instance.getInteractions().getArray()).toContain(host.interaction().instance);
 
-    host.interaction.instance.dispatchEvent('snap');
-    host.interaction.instance.dispatchEvent('change');
-    host.interaction.instance.dispatchEvent('change:active');
-    host.interaction.instance.dispatchEvent('error');
-    host.interaction.instance.dispatchEvent('propertychange');
+    host.interaction().instance.dispatchEvent('snap');
+    host.interaction().instance.dispatchEvent('change');
+    host.interaction().instance.dispatchEvent('change:active');
+    host.interaction().instance.dispatchEvent('error');
+    host.interaction().instance.dispatchEvent('propertychange');
 
     expect(host.snap).toHaveBeenCalledOnce();
     expect(host.change).toHaveBeenCalledOnce();

--- a/projects/ngx-ol/src/lib/interactions/snap.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/snap.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, input, output, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, output, signal, inject } from '@angular/core';
 import BaseEvent from 'ol/events/Event';
 import { SnapEvent } from 'ol/events/SnapEvent';
 import Snap from 'ol/interaction/Snap';
@@ -39,7 +39,7 @@ export class SnapInteractionComponent implements OnInit, OnDestroy {
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new Snap(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/snap.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/snap.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, output, signal } from '@angular/core';
 import BaseEvent from 'ol/events/Event';
 import { SnapEvent } from 'ol/events/SnapEvent';
 import Snap from 'ol/interaction/Snap';
@@ -14,34 +14,35 @@ import Vector from 'ol/source/Vector';
   template: '',
 })
 export class SnapInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  features?: Collection<Feature>;
-  @Input()
-  edge?: boolean;
-  @Input()
-  vertex?: boolean;
-  @Input()
-  pixelTolerance?: number;
-  @Input()
-  source?: Vector;
+  features = input<Collection<Feature>>();
+  edge = input<boolean>();
+  vertex = input<boolean>();
+  pixelTolerance = input<number>();
+  source = input<Vector>();
 
-  @Output()
-  olChange = new EventEmitter<BaseEvent>();
-  @Output()
-  changeActive = new EventEmitter<ObjectEvent>();
-  @Output()
-  olError = new EventEmitter<BaseEvent>();
-  @Output()
-  propertyChange = new EventEmitter<ObjectEvent>();
-  @Output()
-  snap = new EventEmitter<SnapEvent>();
+  olChange = output<BaseEvent>();
+  changeActive = output<ObjectEvent>();
+  olError = output<BaseEvent>();
+  propertyChange = output<ObjectEvent>();
+  snap = output<SnapEvent>();
 
   instance: Snap;
 
+  protected readonly _instanceSignal = signal<Snap | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Snap): Snap {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new Snap(this.createOptions());
+    this.setInstance(new Snap(this.createOptions()));
 
     this.instance.on('change', (event: BaseEvent) => this.olChange.emit(event));
     this.instance.on('change:active', (event: ObjectEvent) => this.changeActive.emit(event));
@@ -57,11 +58,11 @@ export class SnapInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      features: this.features,
-      edge: this.edge,
-      vertex: this.vertex,
-      pixelTolerance: this.pixelTolerance,
-      source: this.source,
+      features: this.features(),
+      edge: this.edge(),
+      vertex: this.vertex(),
+      pixelTolerance: this.pixelTolerance(),
+      source: this.source(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/interactions/snap.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/snap.component.ts
@@ -14,17 +14,17 @@ import Vector from 'ol/source/Vector';
   template: '',
 })
 export class SnapInteractionComponent implements OnInit, OnDestroy {
-  features = input<Collection<Feature>>();
-  edge = input<boolean>();
-  vertex = input<boolean>();
-  pixelTolerance = input<number>();
-  source = input<Vector>();
+  readonly features = input<Collection<Feature>>();
+  readonly edge = input<boolean>();
+  readonly vertex = input<boolean>();
+  readonly pixelTolerance = input<number>();
+  readonly source = input<Vector>();
 
-  olChange = output<BaseEvent>();
-  changeActive = output<ObjectEvent>();
-  olError = output<BaseEvent>();
-  propertyChange = output<ObjectEvent>();
-  snap = output<SnapEvent>();
+  readonly olChange = output<BaseEvent>();
+  readonly changeActive = output<ObjectEvent>();
+  readonly olError = output<BaseEvent>();
+  readonly propertyChange = output<ObjectEvent>();
+  readonly snap = output<SnapEvent>();
 
   instance: Snap;
 

--- a/projects/ngx-ol/src/lib/interactions/translate.component.spec.ts
+++ b/projects/ngx-ol/src/lib/interactions/translate.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
@@ -40,11 +40,11 @@ class TranslateInteractionHostComponent {
   error = vi.fn();
   propertyChange = vi.fn();
 
-  @ViewChild(TranslateInteractionComponent)
-  interaction!: TranslateInteractionComponent;
+  readonly interaction = viewChild.required<TranslateInteractionComponent>(
+    TranslateInteractionComponent,
+  );
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('TranslateInteractionComponent', () => {
@@ -66,15 +66,15 @@ describe('TranslateInteractionComponent', () => {
   it('adds a translate interaction to the map and forwards OpenLayers events', () => {
     const host = fixture.componentInstance;
 
-    expect(host.map.instance.getInteractions().getArray()).toContain(host.interaction.instance);
+    expect(host.map().instance.getInteractions().getArray()).toContain(host.interaction().instance);
 
-    host.interaction.instance.dispatchEvent('translatestart');
-    host.interaction.instance.dispatchEvent('translating');
-    host.interaction.instance.dispatchEvent('translateend');
-    host.interaction.instance.dispatchEvent('change');
-    host.interaction.instance.dispatchEvent('change:active');
-    host.interaction.instance.dispatchEvent('error');
-    host.interaction.instance.dispatchEvent('propertychange');
+    host.interaction().instance.dispatchEvent('translatestart');
+    host.interaction().instance.dispatchEvent('translating');
+    host.interaction().instance.dispatchEvent('translateend');
+    host.interaction().instance.dispatchEvent('change');
+    host.interaction().instance.dispatchEvent('change:active');
+    host.interaction().instance.dispatchEvent('error');
+    host.interaction().instance.dispatchEvent('propertychange');
 
     expect(host.translateStart).toHaveBeenCalledOnce();
     expect(host.translating).toHaveBeenCalledOnce();

--- a/projects/ngx-ol/src/lib/interactions/translate.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/translate.component.ts
@@ -7,6 +7,7 @@ import {
   input,
   output,
   signal,
+  inject,
 } from '@angular/core';
 import Translate from 'ol/interaction/Translate';
 import Collection from 'ol/Collection';
@@ -51,7 +52,7 @@ export class TranslateInteractionComponent implements OnInit, OnChanges, OnDestr
 
     return instance;
   }
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     this.setInstance(new Translate(this.createOptions()));

--- a/projects/ngx-ol/src/lib/interactions/translate.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/translate.component.ts
@@ -1,4 +1,13 @@
-import { Component, OnDestroy, OnInit, input, output, signal } from '@angular/core';
+import {
+  Component,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  input,
+  output,
+  signal,
+} from '@angular/core';
 import Translate from 'ol/interaction/Translate';
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
@@ -14,7 +23,7 @@ import { FilterFunction } from 'ol/interaction/Select';
   selector: 'aol-interaction-translate',
   template: '',
 })
-export class TranslateInteractionComponent implements OnInit, OnDestroy {
+export class TranslateInteractionComponent implements OnInit, OnChanges, OnDestroy {
   condition = input<Condition>();
   features = input<Collection<Feature>>();
   layers = input<Layer[] | ((layer: Layer) => boolean)>();
@@ -60,6 +69,12 @@ export class TranslateInteractionComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.map.instance.removeInteraction(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.instance && changes.hitTolerance?.currentValue !== undefined) {
+      this.instance.setHitTolerance(changes.hitTolerance.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/interactions/translate.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/translate.component.ts
@@ -25,19 +25,19 @@ import { FilterFunction } from 'ol/interaction/Select';
   template: '',
 })
 export class TranslateInteractionComponent implements OnInit, OnChanges, OnDestroy {
-  condition = input<Condition>();
-  features = input<Collection<Feature>>();
-  layers = input<Layer[] | ((layer: Layer) => boolean)>();
-  filter = input<FilterFunction>();
-  hitTolerance = input<number>();
+  readonly condition = input<Condition>();
+  readonly features = input<Collection<Feature>>();
+  readonly layers = input<Layer[] | ((layer: Layer) => boolean)>();
+  readonly filter = input<FilterFunction>();
+  readonly hitTolerance = input<number>();
 
-  olChange = output<BaseEvent>();
-  changeActive = output<ObjectEvent>();
-  olError = output<BaseEvent>();
-  propertyChange = output<ObjectEvent>();
-  translateEnd = output<TranslateEvent>();
-  translateStart = output<TranslateEvent>();
-  translating = output<TranslateEvent>();
+  readonly olChange = output<BaseEvent>();
+  readonly changeActive = output<ObjectEvent>();
+  readonly olError = output<BaseEvent>();
+  readonly propertyChange = output<ObjectEvent>();
+  readonly translateEnd = output<TranslateEvent>();
+  readonly translateStart = output<TranslateEvent>();
+  readonly translating = output<TranslateEvent>();
 
   instance: Translate;
 

--- a/projects/ngx-ol/src/lib/interactions/translate.component.ts
+++ b/projects/ngx-ol/src/lib/interactions/translate.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnDestroy, OnInit, input, output, signal } from '@angular/core';
 import Translate from 'ol/interaction/Translate';
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
@@ -15,38 +15,37 @@ import { FilterFunction } from 'ol/interaction/Select';
   template: '',
 })
 export class TranslateInteractionComponent implements OnInit, OnDestroy {
-  @Input()
-  condition?: Condition;
-  @Input()
-  features?: Collection<Feature>;
-  @Input()
-  layers?: Layer[] | ((layer: Layer) => boolean);
-  @Input()
-  filter?: FilterFunction;
-  @Input()
-  hitTolerance?: number;
+  condition = input<Condition>();
+  features = input<Collection<Feature>>();
+  layers = input<Layer[] | ((layer: Layer) => boolean)>();
+  filter = input<FilterFunction>();
+  hitTolerance = input<number>();
 
-  @Output()
-  olChange = new EventEmitter<BaseEvent>();
-  @Output()
-  changeActive = new EventEmitter<ObjectEvent>();
-  @Output()
-  olError = new EventEmitter<BaseEvent>();
-  @Output()
-  propertyChange = new EventEmitter<ObjectEvent>();
-  @Output()
-  translateEnd = new EventEmitter<TranslateEvent>();
-  @Output()
-  translateStart = new EventEmitter<TranslateEvent>();
-  @Output()
-  translating = new EventEmitter<TranslateEvent>();
+  olChange = output<BaseEvent>();
+  changeActive = output<ObjectEvent>();
+  olError = output<BaseEvent>();
+  propertyChange = output<ObjectEvent>();
+  translateEnd = output<TranslateEvent>();
+  translateStart = output<TranslateEvent>();
+  translating = output<TranslateEvent>();
 
   instance: Translate;
 
+  protected readonly _instanceSignal = signal<Translate | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Translate): Translate {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = new Translate(this.createOptions());
+    this.setInstance(new Translate(this.createOptions()));
 
     this.instance.on('change', (event: BaseEvent) => this.olChange.emit(event));
     this.instance.on('change:active', (event: ObjectEvent) => this.changeActive.emit(event));
@@ -65,11 +64,11 @@ export class TranslateInteractionComponent implements OnInit, OnDestroy {
 
   private createOptions(): Options {
     return {
-      condition: this.condition,
-      features: this.features,
-      layers: this.layers,
-      filter: this.filter,
-      hitTolerance: this.hitTolerance,
+      condition: this.condition(),
+      features: this.features(),
+      layers: this.layers(),
+      filter: this.filter(),
+      hitTolerance: this.hitTolerance(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/layers/layer.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layer.component.ts
@@ -80,7 +80,6 @@ export abstract class LayerComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    const properties: { [index: string]: any } = {};
     if (!this.instance) {
       return;
     }
@@ -103,6 +102,10 @@ export abstract class LayerComponent implements OnInit, OnChanges, OnDestroy {
           if (value) {
             this.instance.on('postrender', value);
           }
+          continue;
+        }
+        if (key === 'properties') {
+          this.syncProperties(value, changes[key].previousValue);
           continue;
         }
         switch (key) {
@@ -131,12 +134,25 @@ export abstract class LayerComponent implements OnInit, OnChanges, OnDestroy {
             this.instance.setZIndex(value);
             continue;
           default:
-            properties[key] = value;
             break;
         }
       }
     }
-    // console.log('changes detected in aol-layer, setting new properties: ', properties);
-    this.instance.setProperties(properties, false);
+  }
+
+  private syncProperties(
+    nextProperties?: Record<string, any>,
+    previousProperties?: Record<string, any>,
+  ) {
+    if (previousProperties) {
+      const nextKeys = new Set(Object.keys(nextProperties ?? {}));
+      Object.keys(previousProperties)
+        .filter((key) => !nextKeys.has(key))
+        .forEach((key) => this.instance.unset(key, false));
+    }
+
+    if (nextProperties) {
+      this.instance.setProperties(nextProperties, false);
+    }
   }
 }

--- a/projects/ngx-ol/src/lib/layers/layer.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layer.component.ts
@@ -1,4 +1,12 @@
-import { OnDestroy, OnInit, OnChanges, Input, SimpleChanges, Directive } from '@angular/core';
+import {
+  OnDestroy,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+  Directive,
+  input,
+  signal,
+} from '@angular/core';
 import Event from 'ol/events/Event';
 import { MapComponent } from '../map.component';
 import { LayerGroupComponent } from './layergroup.component';
@@ -8,63 +16,61 @@ import { RenderFunction } from 'ol/layer/Layer';
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export abstract class LayerComponent implements OnInit, OnChanges, OnDestroy {
-  @Input()
-  id: string | number;
-  @Input()
-  className: string;
-  @Input()
-  opacity: number;
-  @Input()
-  visible: boolean;
-  @Input()
-  extent?: Extent;
-  @Input()
-  zIndex?: number;
-  @Input()
-  minResolution?: number;
-  @Input()
-  maxResolution?: number;
-  @Input()
-  minZoom?: number;
-  @Input()
-  maxZoom?: number;
-  @Input()
-  render?: RenderFunction;
-  @Input()
-  properties?: Record<string, any>;
+  id = input<string | number>();
+  className = input<string>();
+  opacity = input<number>();
+  visible = input<boolean>();
+  extent = input<Extent>();
+  zIndex = input<number>();
+  minResolution = input<number>();
+  maxResolution = input<number>();
+  minZoom = input<number>();
+  maxZoom = input<number>();
+  render = input<RenderFunction>();
+  properties = input<Record<string, any>>();
 
-  @Input()
-  prerender: (evt: Event) => void;
-  @Input()
-  postrender: (evt: Event) => void;
+  prerender = input<(evt: Event) => void>();
+  postrender = input<(evt: Event) => void>();
 
   public instance: any;
+
+  protected readonly _instanceSignal = signal<any | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: any): any {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   public componentType = 'layer';
 
   protected constructor(protected host: MapComponent | LayerGroupComponent) {}
 
   protected createLayerOptions() {
     return {
-      className: this.className,
-      opacity: this.opacity,
-      visible: this.visible,
-      extent: this.extent,
-      zIndex: this.zIndex,
-      minResolution: this.minResolution,
-      maxResolution: this.maxResolution,
-      minZoom: this.minZoom,
-      maxZoom: this.maxZoom,
-      render: this.render,
-      properties: this.properties,
+      className: this.className(),
+      opacity: this.opacity(),
+      visible: this.visible(),
+      extent: this.extent(),
+      zIndex: this.zIndex(),
+      minResolution: this.minResolution(),
+      maxResolution: this.maxResolution(),
+      minZoom: this.minZoom(),
+      maxZoom: this.maxZoom(),
+      render: this.render(),
+      properties: this.properties(),
     };
   }
 
   ngOnInit() {
-    if (this.prerender !== null && this.prerender !== undefined) {
-      this.instance.on('prerender', this.prerender);
+    if (this.prerender() !== null && this.prerender() !== undefined) {
+      this.instance.on('prerender', this.prerender());
     }
-    if (this.postrender !== null && this.postrender !== undefined) {
-      this.instance.on('postrender', this.postrender);
+    if (this.postrender() !== null && this.postrender() !== undefined) {
+      this.instance.on('postrender', this.postrender());
     }
     this.host.instance.getLayers().push(this.instance);
   }

--- a/projects/ngx-ol/src/lib/layers/layer.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layer.component.ts
@@ -16,21 +16,21 @@ import { RenderFunction } from 'ol/layer/Layer';
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export abstract class LayerComponent implements OnInit, OnChanges, OnDestroy {
-  id = input<string | number>();
-  className = input<string>();
-  opacity = input<number>();
-  visible = input<boolean>();
-  extent = input<Extent>();
-  zIndex = input<number>();
-  minResolution = input<number>();
-  maxResolution = input<number>();
-  minZoom = input<number>();
-  maxZoom = input<number>();
-  render = input<RenderFunction>();
-  properties = input<Record<string, any>>();
+  readonly id = input<string | number>();
+  readonly className = input<string>();
+  readonly opacity = input<number>();
+  readonly visible = input<boolean>();
+  readonly extent = input<Extent>();
+  readonly zIndex = input<number>();
+  readonly minResolution = input<number>();
+  readonly maxResolution = input<number>();
+  readonly minZoom = input<number>();
+  readonly maxZoom = input<number>();
+  readonly render = input<RenderFunction>();
+  readonly properties = input<Record<string, any>>();
 
-  prerender = input<(evt: Event) => void>();
-  postrender = input<(evt: Event) => void>();
+  readonly prerender = input<(evt: Event) => void>();
+  readonly postrender = input<(evt: Event) => void>();
 
   public instance: any;
 
@@ -45,9 +45,9 @@ export abstract class LayerComponent implements OnInit, OnChanges, OnDestroy {
 
     return instance;
   }
-  public componentType = 'layer';
+  readonly componentType: string = 'layer';
 
-  protected constructor(protected host: MapComponent | LayerGroupComponent) {}
+  protected constructor(protected readonly host: MapComponent | LayerGroupComponent) {}
 
   protected createLayerOptions() {
     return {

--- a/projects/ngx-ol/src/lib/layers/layer.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layer.component.ts
@@ -86,14 +86,53 @@ export abstract class LayerComponent implements OnInit, OnChanges, OnDestroy {
     }
     for (const key in changes) {
       if (changes.hasOwnProperty(key)) {
-        properties[key] = changes[key].currentValue;
+        const value = changes[key].currentValue;
         if (key === 'prerender') {
-          this.instance.un('prerender', changes[key].previousValue);
-          this.instance.on('prerender', changes[key].currentValue);
+          if (changes[key].previousValue) {
+            this.instance.un('prerender', changes[key].previousValue);
+          }
+          if (value) {
+            this.instance.on('prerender', value);
+          }
+          continue;
         }
         if (key === 'postrender') {
-          this.instance.un('postrender', changes[key].previousValue);
-          this.instance.on('postrender', changes[key].currentValue);
+          if (changes[key].previousValue) {
+            this.instance.un('postrender', changes[key].previousValue);
+          }
+          if (value) {
+            this.instance.on('postrender', value);
+          }
+          continue;
+        }
+        switch (key) {
+          case 'extent':
+            this.instance.setExtent(value);
+            continue;
+          case 'maxResolution':
+            this.instance.setMaxResolution(value);
+            continue;
+          case 'minResolution':
+            this.instance.setMinResolution(value);
+            continue;
+          case 'maxZoom':
+            this.instance.setMaxZoom(value);
+            continue;
+          case 'minZoom':
+            this.instance.setMinZoom(value);
+            continue;
+          case 'opacity':
+            this.instance.setOpacity(value);
+            continue;
+          case 'visible':
+            this.instance.setVisible(value);
+            continue;
+          case 'zIndex':
+            this.instance.setZIndex(value);
+            continue;
+          default:
+            properties[key] = value;
+            break;
         }
       }
     }

--- a/projects/ngx-ol/src/lib/layers/layergroup.component.spec.ts
+++ b/projects/ngx-ol/src/lib/layers/layergroup.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -22,11 +22,9 @@ class LayerGroupHostComponent {
   zoom = 2;
   opacity = signal(0.7);
 
-  @ViewChild(LayerGroupComponent)
-  layerGroup!: LayerGroupComponent;
+  readonly layerGroup = viewChild.required<LayerGroupComponent>(LayerGroupComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('LayerGroupComponent', () => {
@@ -48,15 +46,15 @@ describe('LayerGroupComponent', () => {
   it('creates a layer group from template inputs', () => {
     const host = fixture!.componentInstance;
 
-    expect(host.layerGroup.instance.getOpacity()).toBe(0.7);
-    expect(host.layerGroup.instance.getLayers().getLength()).toBe(1);
-    expect(host.map.instance.getLayers().getArray()).toContain(host.layerGroup.instance);
+    expect(host.layerGroup().instance.getOpacity()).toBe(0.7);
+    expect(host.layerGroup().instance.getLayers().getLength()).toBe(1);
+    expect(host.map().instance.getLayers().getArray()).toContain(host.layerGroup().instance);
   });
 
   it('updates and removes the OpenLayers group through Angular bindings and lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const layerGroup = host.layerGroup.instance;
+    const map = host.map().instance;
+    const layerGroup = host.layerGroup().instance;
 
     host.opacity.set(0.4);
     fixture!.detectChanges();

--- a/projects/ngx-ol/src/lib/layers/layergroup.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layergroup.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, SkipSelf, Optional, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
 import Group from 'ol/layer/Group';
 import { Options } from 'ol/layer/Group';
 import { LayerComponent } from './layer.component';
@@ -19,13 +19,8 @@ export class LayerGroupComponent extends LayerComponent implements OnInit, OnDes
     this._instanceSignal.set(instance);
     return instance;
   }
-  constructor(
-    map: MapComponent,
-    @SkipSelf()
-    @Optional()
-    group?: LayerGroupComponent,
-  ) {
-    super(group || map);
+  constructor() {
+    super(inject(LayerGroupComponent, { optional: true, skipSelf: true }) || inject(MapComponent));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/layers/layergroup.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layergroup.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, SkipSelf, Optional } from '@angular/core';
+import { Component, OnDestroy, OnInit, SkipSelf, Optional, signal } from '@angular/core';
 import Group from 'ol/layer/Group';
 import { Options } from 'ol/layer/Group';
 import { LayerComponent } from './layer.component';
@@ -11,6 +11,14 @@ import { MapComponent } from '../map.component';
 export class LayerGroupComponent extends LayerComponent implements OnInit, OnDestroy {
   public instance: Group;
 
+  protected readonly _instanceSignal = signal<Group | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Group): Group {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   constructor(
     map: MapComponent,
     @SkipSelf()
@@ -22,7 +30,7 @@ export class LayerGroupComponent extends LayerComponent implements OnInit, OnDes
 
   ngOnInit() {
     // console.log(`creating ol.layer.Group instance with:`, this);
-    this.instance = new Group(this.createOptions());
+    this.setInstance(new Group(this.createOptions()));
     super.ngOnInit();
   }
 

--- a/projects/ngx-ol/src/lib/layers/layerheatmap.component.spec.ts
+++ b/projects/ngx-ol/src/lib/layers/layerheatmap.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -26,11 +26,9 @@ class LayerHeatmapHostComponent {
   gradient = signal(['#000000', '#ffffff']);
   radius = signal(8);
 
-  @ViewChild(LayerHeatmapComponent)
-  layer!: LayerHeatmapComponent;
+  readonly layer = viewChild.required<LayerHeatmapComponent>(LayerHeatmapComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('LayerHeatmapComponent', () => {
@@ -52,16 +50,16 @@ describe('LayerHeatmapComponent', () => {
   it('creates a heatmap layer from template inputs', () => {
     const host = fixture!.componentInstance;
 
-    expect(host.layer.instance.getBlur()).toBe(12);
-    expect(host.layer.instance.getGradient()).toEqual(['#000000', '#ffffff']);
-    expect(host.layer.instance.getRadius()).toBe(8);
-    expect(host.map.instance.getLayers().getArray()).toContain(host.layer.instance);
+    expect(host.layer().instance.getBlur()).toBe(12);
+    expect(host.layer().instance.getGradient()).toEqual(['#000000', '#ffffff']);
+    expect(host.layer().instance.getRadius()).toBe(8);
+    expect(host.map().instance.getLayers().getArray()).toContain(host.layer().instance);
   });
 
   it('updates and removes the OpenLayers heatmap layer through bindings and lifecycle', () => {
     const host = fixture!.componentInstance;
-    const map = host.map.instance;
-    const layer = host.layer.instance;
+    const map = host.map().instance;
+    const layer = host.layer().instance;
 
     host.blur.set(16);
     host.gradient.set(['#ff0000', '#00ff00']);

--- a/projects/ngx-ol/src/lib/layers/layerheatmap.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layerheatmap.component.ts
@@ -3,10 +3,10 @@ import {
   OnChanges,
   OnDestroy,
   OnInit,
-  Optional,
   SimpleChanges,
   input,
   signal,
+  inject,
 } from '@angular/core';
 import type { FeatureLike } from 'ol/Feature';
 import Heatmap from 'ol/layer/Heatmap';
@@ -50,8 +50,8 @@ export class LayerHeatmapComponent extends LayerComponent implements OnInit, OnD
 
     return instance;
   }
-  constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
-    super(group || map);
+  constructor() {
+    super(inject(LayerGroupComponent, { optional: true }) || inject(MapComponent));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/layers/layerheatmap.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layerheatmap.component.ts
@@ -77,6 +77,9 @@ export class LayerHeatmapComponent extends LayerComponent implements OnInit, OnD
     if (changes.blur?.currentValue !== undefined) {
       this.instance.setBlur(changes.blur.currentValue);
     }
+    if (changes.source) {
+      this.instance.setSource(changes.source.currentValue);
+    }
   }
 
   private createOptions(): Options<FeatureLike, VectorSource<FeatureLike>> {

--- a/projects/ngx-ol/src/lib/layers/layerheatmap.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layerheatmap.component.ts
@@ -1,11 +1,12 @@
 import {
   Component,
-  Input,
   OnChanges,
   OnDestroy,
   OnInit,
   Optional,
   SimpleChanges,
+  input,
+  signal,
 } from '@angular/core';
 import type { FeatureLike } from 'ol/Feature';
 import Heatmap from 'ol/layer/Heatmap';
@@ -20,32 +21,41 @@ import { LayerGroupComponent } from './layergroup.component';
   template: ` <ng-content></ng-content> `,
 })
 export class LayerHeatmapComponent extends LayerComponent implements OnInit, OnDestroy, OnChanges {
-  @Input()
-  gradient?: string[];
+  gradient = input<string[]>();
 
-  @Input()
-  radius?: number;
+  radius = input<number>();
 
-  @Input()
-  blur?: number;
+  blur = input<number>();
 
-  @Input()
-  weight?: string | ((feature: FeatureLike) => number);
+  weight = input<string | ((feature: FeatureLike) => number)>();
 
-  @Input()
-  source?: VectorSource<FeatureLike>;
+  source = input<VectorSource<FeatureLike>>();
 
-  @Input()
-  properties?: Record<string, any>;
+  properties = input<Record<string, any>>();
 
   instance: Heatmap<FeatureLike, VectorSource<FeatureLike>>;
 
+  protected readonly _instanceSignal = signal<
+    Heatmap<FeatureLike, VectorSource<FeatureLike>> | undefined
+  >(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(
+    instance: Heatmap<FeatureLike, VectorSource<FeatureLike>>,
+  ): Heatmap<FeatureLike, VectorSource<FeatureLike>> {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
     super(group || map);
   }
 
   ngOnInit() {
-    this.instance = new Heatmap(this.createOptions());
+    this.setInstance(new Heatmap(this.createOptions()));
     super.ngOnInit();
   }
 
@@ -72,12 +82,12 @@ export class LayerHeatmapComponent extends LayerComponent implements OnInit, OnD
   private createOptions(): Options<FeatureLike, VectorSource<FeatureLike>> {
     return {
       ...this.createLayerOptions(),
-      gradient: this.gradient,
-      radius: this.radius,
-      blur: this.blur,
-      weight: this.weight,
-      source: this.source,
-      properties: this.properties,
+      gradient: this.gradient(),
+      radius: this.radius(),
+      blur: this.blur(),
+      weight: this.weight(),
+      source: this.source(),
+      properties: this.properties(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/layers/layerheatmap.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layerheatmap.component.ts
@@ -21,17 +21,17 @@ import { LayerGroupComponent } from './layergroup.component';
   template: ` <ng-content></ng-content> `,
 })
 export class LayerHeatmapComponent extends LayerComponent implements OnInit, OnDestroy, OnChanges {
-  gradient = input<string[]>();
+  readonly gradient = input<string[]>();
 
-  radius = input<number>();
+  readonly radius = input<number>();
 
-  blur = input<number>();
+  readonly blur = input<number>();
 
-  weight = input<string | ((feature: FeatureLike) => number)>();
+  readonly weight = input<string | ((feature: FeatureLike) => number)>();
 
-  source = input<VectorSource<FeatureLike>>();
+  readonly source = input<VectorSource<FeatureLike>>();
 
-  properties = input<Record<string, any>>();
+  readonly properties = input<Record<string, any>>();
 
   instance: Heatmap<FeatureLike, VectorSource<FeatureLike>>;
 

--- a/projects/ngx-ol/src/lib/layers/layerimage.component.spec.ts
+++ b/projects/ngx-ol/src/lib/layers/layerimage.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -19,8 +19,7 @@ class LayerImageHostComponent {
   zoom = 2;
   opacity = 0.5;
 
-  @ViewChild(LayerImageComponent)
-  layer!: LayerImageComponent;
+  readonly layer = viewChild.required<LayerImageComponent>(LayerImageComponent);
 }
 
 describe('LayerImageComponent', () => {
@@ -40,6 +39,6 @@ describe('LayerImageComponent', () => {
   });
 
   it('creates an image layer from template inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getOpacity()).toBe(0.5);
+    expect(fixture.componentInstance.layer().instance.getOpacity()).toBe(0.5);
   });
 });

--- a/projects/ngx-ol/src/lib/layers/layerimage.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layerimage.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, Optional, SimpleChanges } from '@angular/core';
+import { Component, OnChanges, OnInit, Optional, SimpleChanges, input } from '@angular/core';
 import Image from 'ol/layer/Image';
 import { Options } from 'ol/layer/BaseImage';
 import { MapComponent } from '../map.component';
@@ -11,15 +11,14 @@ import ImageSource from 'ol/source/Image';
   template: ` <ng-content></ng-content> `,
 })
 export class LayerImageComponent extends LayerComponent implements OnInit, OnChanges {
-  @Input()
-  source?: ImageSource;
+  source = input<ImageSource>();
 
   constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
     super(group || map);
   }
 
   ngOnInit() {
-    this.instance = new Image(this.createOptions());
+    this.setInstance(new Image(this.createOptions()));
     super.ngOnInit();
   }
 
@@ -30,7 +29,7 @@ export class LayerImageComponent extends LayerComponent implements OnInit, OnCha
   private createOptions(): Options<ImageSource> {
     return {
       ...this.createLayerOptions(),
-      source: this.source,
+      source: this.source(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/layers/layerimage.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layerimage.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, OnInit, Optional, SimpleChanges, input } from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges, input, inject } from '@angular/core';
 import Image from 'ol/layer/Image';
 import { Options } from 'ol/layer/BaseImage';
 import { MapComponent } from '../map.component';
@@ -13,8 +13,8 @@ import ImageSource from 'ol/source/Image';
 export class LayerImageComponent extends LayerComponent implements OnInit, OnChanges {
   source = input<ImageSource>();
 
-  constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
-    super(group || map);
+  constructor() {
+    super(inject(LayerGroupComponent, { optional: true }) || inject(MapComponent));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/layers/layerimage.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layerimage.component.ts
@@ -11,7 +11,7 @@ import ImageSource from 'ol/source/Image';
   template: ` <ng-content></ng-content> `,
 })
 export class LayerImageComponent extends LayerComponent implements OnInit, OnChanges {
-  source = input<ImageSource>();
+  readonly source = input<ImageSource>();
 
   constructor() {
     super(inject(LayerGroupComponent, { optional: true }) || inject(MapComponent));

--- a/projects/ngx-ol/src/lib/layers/layertile.component.spec.ts
+++ b/projects/ngx-ol/src/lib/layers/layertile.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -19,8 +19,7 @@ class LayerTileHostComponent {
   zoom = 2;
   opacity = 0.4;
 
-  @ViewChild(LayerTileComponent)
-  layer!: LayerTileComponent;
+  readonly layer = viewChild.required<LayerTileComponent>(LayerTileComponent);
 }
 
 describe('LayerTileComponent', () => {
@@ -40,6 +39,6 @@ describe('LayerTileComponent', () => {
   });
 
   it('creates a tile layer from template inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getOpacity()).toBe(0.4);
+    expect(fixture.componentInstance.layer().instance.getOpacity()).toBe(0.4);
   });
 });

--- a/projects/ngx-ol/src/lib/layers/layertile.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layertile.component.ts
@@ -2,10 +2,10 @@ import {
   Component,
   OnDestroy,
   OnInit,
-  Optional,
   OnChanges,
   SimpleChanges,
   input,
+  inject,
 } from '@angular/core';
 import Tile from 'ol/layer/Tile';
 import { Options } from 'ol/layer/BaseTile';
@@ -24,8 +24,8 @@ export class LayerTileComponent extends LayerComponent implements OnInit, OnDest
   cacheSize = input<number>();
   source = input<TileSource>();
 
-  constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
-    super(group || map);
+  constructor() {
+    super(inject(LayerGroupComponent, { optional: true }) || inject(MapComponent));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/layers/layertile.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layertile.component.ts
@@ -36,6 +36,18 @@ export class LayerTileComponent extends LayerComponent implements OnInit, OnDest
 
   ngOnChanges(changes: SimpleChanges) {
     super.ngOnChanges(changes);
+    if (!this.instance) {
+      return;
+    }
+    if (changes.preload?.currentValue !== undefined) {
+      this.instance.setPreload(changes.preload.currentValue);
+    }
+    if (changes.useInterimTilesOnError?.currentValue !== undefined) {
+      this.instance.setUseInterimTilesOnError(changes.useInterimTilesOnError.currentValue);
+    }
+    if (changes.source) {
+      this.instance.setSource(changes.source.currentValue);
+    }
   }
 
   private createOptions(): Options<TileSource> {

--- a/projects/ngx-ol/src/lib/layers/layertile.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layertile.component.ts
@@ -19,10 +19,10 @@ import TileSource from 'ol/source/Tile';
   template: ` <ng-content></ng-content> `,
 })
 export class LayerTileComponent extends LayerComponent implements OnInit, OnDestroy, OnChanges {
-  preload = input<number>();
-  useInterimTilesOnError = input<boolean>();
-  cacheSize = input<number>();
-  source = input<TileSource>();
+  readonly preload = input<number>();
+  readonly useInterimTilesOnError = input<boolean>();
+  readonly cacheSize = input<number>();
+  readonly source = input<TileSource>();
 
   constructor() {
     super(inject(LayerGroupComponent, { optional: true }) || inject(MapComponent));

--- a/projects/ngx-ol/src/lib/layers/layertile.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layertile.component.ts
@@ -2,10 +2,10 @@ import {
   Component,
   OnDestroy,
   OnInit,
-  Input,
   Optional,
   OnChanges,
   SimpleChanges,
+  input,
 } from '@angular/core';
 import Tile from 'ol/layer/Tile';
 import { Options } from 'ol/layer/BaseTile';
@@ -19,14 +19,10 @@ import TileSource from 'ol/source/Tile';
   template: ` <ng-content></ng-content> `,
 })
 export class LayerTileComponent extends LayerComponent implements OnInit, OnDestroy, OnChanges {
-  @Input()
-  preload?: number;
-  @Input()
-  useInterimTilesOnError?: boolean;
-  @Input()
-  cacheSize?: number;
-  @Input()
-  source?: TileSource;
+  preload = input<number>();
+  useInterimTilesOnError = input<boolean>();
+  cacheSize = input<number>();
+  source = input<TileSource>();
 
   constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
     super(group || map);
@@ -34,7 +30,7 @@ export class LayerTileComponent extends LayerComponent implements OnInit, OnDest
 
   ngOnInit() {
     // console.log('creating ol.layer.Tile instance with:', this);
-    this.instance = new Tile(this.createOptions());
+    this.setInstance(new Tile(this.createOptions()));
     super.ngOnInit();
   }
 
@@ -45,10 +41,10 @@ export class LayerTileComponent extends LayerComponent implements OnInit, OnDest
   private createOptions(): Options<TileSource> {
     return {
       ...this.createLayerOptions(),
-      preload: this.preload,
-      useInterimTilesOnError: this.useInterimTilesOnError,
-      cacheSize: this.cacheSize,
-      source: this.source,
+      preload: this.preload(),
+      useInterimTilesOnError: this.useInterimTilesOnError(),
+      cacheSize: this.cacheSize(),
+      source: this.source(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/layers/layervector.component.spec.ts
+++ b/projects/ngx-ol/src/lib/layers/layervector.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -32,11 +32,9 @@ class LayerVectorHostComponent {
   visible = signal(true);
   zIndex = signal(1);
 
-  @ViewChild(LayerVectorComponent)
-  layer!: LayerVectorComponent;
+  readonly layer = viewChild.required<LayerVectorComponent>(LayerVectorComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('LayerVectorComponent', () => {
@@ -56,13 +54,13 @@ describe('LayerVectorComponent', () => {
   });
 
   it('creates a vector layer from template inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getOpacity()).toBe(0.6);
-    expect(fixture.componentInstance.layer.instance.getVisible()).toBe(true);
-    expect(fixture.componentInstance.layer.instance.getZIndex()).toBe(1);
-    expect(fixture.componentInstance.layer.instance.get('name')).toBe('roads');
-    expect(fixture.componentInstance.layer.instance.get('category')).toBe('transport');
-    expect(fixture.componentInstance.map.instance.getLayers().getArray()).toContain(
-      fixture.componentInstance.layer.instance,
+    expect(fixture.componentInstance.layer().instance.getOpacity()).toBe(0.6);
+    expect(fixture.componentInstance.layer().instance.getVisible()).toBe(true);
+    expect(fixture.componentInstance.layer().instance.getZIndex()).toBe(1);
+    expect(fixture.componentInstance.layer().instance.get('name')).toBe('roads');
+    expect(fixture.componentInstance.layer().instance.get('category')).toBe('transport');
+    expect(fixture.componentInstance.map().instance.getLayers().getArray()).toContain(
+      fixture.componentInstance.layer().instance,
     );
   });
 
@@ -73,9 +71,9 @@ describe('LayerVectorComponent', () => {
 
     fixture.detectChanges();
 
-    expect(fixture.componentInstance.layer.instance.getOpacity()).toBe(0.25);
-    expect(fixture.componentInstance.layer.instance.getVisible()).toBe(false);
-    expect(fixture.componentInstance.layer.instance.getZIndex()).toBe(5);
+    expect(fixture.componentInstance.layer().instance.getOpacity()).toBe(0.25);
+    expect(fixture.componentInstance.layer().instance.getVisible()).toBe(false);
+    expect(fixture.componentInstance.layer().instance.getZIndex()).toBe(5);
   });
 
   it('updates and removes explicit OpenLayers layer properties when bindings change', () => {
@@ -83,8 +81,8 @@ describe('LayerVectorComponent', () => {
 
     fixture.detectChanges();
 
-    expect(fixture.componentInstance.layer.instance.get('name')).toBeUndefined();
-    expect(fixture.componentInstance.layer.instance.get('category')).toBe('water');
+    expect(fixture.componentInstance.layer().instance.get('name')).toBeUndefined();
+    expect(fixture.componentInstance.layer().instance.get('category')).toBe('water');
   });
 
   it('updates render event handlers when template bindings change', () => {
@@ -93,8 +91,8 @@ describe('LayerVectorComponent', () => {
     const nextPrerender = vi.fn();
     const nextPostrender = vi.fn();
 
-    fixture.componentInstance.layer.instance.dispatchEvent('prerender');
-    fixture.componentInstance.layer.instance.dispatchEvent('postrender');
+    fixture.componentInstance.layer().instance.dispatchEvent('prerender');
+    fixture.componentInstance.layer().instance.dispatchEvent('postrender');
 
     expect(originalPrerender).toHaveBeenCalledOnce();
     expect(originalPostrender).toHaveBeenCalledOnce();
@@ -104,8 +102,8 @@ describe('LayerVectorComponent', () => {
 
     fixture.detectChanges();
 
-    fixture.componentInstance.layer.instance.dispatchEvent('prerender');
-    fixture.componentInstance.layer.instance.dispatchEvent('postrender');
+    fixture.componentInstance.layer().instance.dispatchEvent('prerender');
+    fixture.componentInstance.layer().instance.dispatchEvent('postrender');
 
     expect(originalPrerender).toHaveBeenCalledOnce();
     expect(originalPostrender).toHaveBeenCalledOnce();

--- a/projects/ngx-ol/src/lib/layers/layervector.component.spec.ts
+++ b/projects/ngx-ol/src/lib/layers/layervector.component.spec.ts
@@ -13,6 +13,7 @@ import { LayerVectorComponent } from './layervector.component';
         [opacity]="opacity()"
         [postrender]="postrender()"
         [prerender]="prerender()"
+        [properties]="properties()"
         [visible]="visible()"
         [zIndex]="zIndex()"
       ></aol-layer-vector>
@@ -27,6 +28,7 @@ class LayerVectorHostComponent {
   opacity = signal(0.6);
   postrender = signal(vi.fn());
   prerender = signal(vi.fn());
+  properties = signal<Record<string, string>>({ name: 'roads', category: 'transport' });
   visible = signal(true);
   zIndex = signal(1);
 
@@ -57,6 +59,8 @@ describe('LayerVectorComponent', () => {
     expect(fixture.componentInstance.layer.instance.getOpacity()).toBe(0.6);
     expect(fixture.componentInstance.layer.instance.getVisible()).toBe(true);
     expect(fixture.componentInstance.layer.instance.getZIndex()).toBe(1);
+    expect(fixture.componentInstance.layer.instance.get('name')).toBe('roads');
+    expect(fixture.componentInstance.layer.instance.get('category')).toBe('transport');
     expect(fixture.componentInstance.map.instance.getLayers().getArray()).toContain(
       fixture.componentInstance.layer.instance,
     );
@@ -72,6 +76,15 @@ describe('LayerVectorComponent', () => {
     expect(fixture.componentInstance.layer.instance.getOpacity()).toBe(0.25);
     expect(fixture.componentInstance.layer.instance.getVisible()).toBe(false);
     expect(fixture.componentInstance.layer.instance.getZIndex()).toBe(5);
+  });
+
+  it('updates and removes explicit OpenLayers layer properties when bindings change', () => {
+    fixture.componentInstance.properties.set({ category: 'water' });
+
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.layer.instance.get('name')).toBeUndefined();
+    expect(fixture.componentInstance.layer.instance.get('category')).toBe('water');
   });
 
   it('updates render event handlers when template bindings change', () => {

--- a/projects/ngx-ol/src/lib/layers/layervector.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layervector.component.ts
@@ -23,23 +23,23 @@ import VectorSource from 'ol/source/Vector';
   template: ` <ng-content></ng-content> `,
 })
 export class LayerVectorComponent extends LayerComponent implements OnInit, OnDestroy, OnChanges {
-  renderOrder = input<OrderFunction>();
+  readonly renderOrder = input<OrderFunction>();
 
-  renderBuffer = input<number>();
+  readonly renderBuffer = input<number>();
 
-  style = input<StyleLike | FlatStyleLike | null | undefined>();
+  readonly style = input<StyleLike | FlatStyleLike | null | undefined>();
 
-  updateWhileAnimating = input<boolean>();
+  readonly updateWhileAnimating = input<boolean>();
 
-  updateWhileInteracting = input<boolean>();
+  readonly updateWhileInteracting = input<boolean>();
 
-  declutter = input<boolean | string | number>();
+  readonly declutter = input<boolean | string | number>();
 
-  background = input<BackgroundColor>();
+  readonly background = input<BackgroundColor>();
 
-  properties = input<Record<string, any>>();
+  readonly properties = input<Record<string, any>>();
 
-  source = input<VectorSource>();
+  readonly source = input<VectorSource>();
 
   constructor() {
     super(inject(LayerGroupComponent, { optional: true }) || inject(MapComponent));

--- a/projects/ngx-ol/src/lib/layers/layervector.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layervector.component.ts
@@ -57,6 +57,12 @@ export class LayerVectorComponent extends LayerComponent implements OnInit, OnDe
     if (style && this.instance) {
       this.instance.setStyle(style.currentValue);
     }
+    if (this.instance && changes.renderOrder) {
+      this.instance.setRenderOrder(changes.renderOrder.currentValue);
+    }
+    if (this.instance && changes.source) {
+      this.instance.setSource(changes.source.currentValue);
+    }
   }
 
   private createOptions(): Options<any, VectorSource<any>> {

--- a/projects/ngx-ol/src/lib/layers/layervector.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layervector.component.ts
@@ -2,10 +2,10 @@ import {
   Component,
   OnDestroy,
   OnInit,
-  Optional,
   OnChanges,
   SimpleChanges,
   input,
+  inject,
 } from '@angular/core';
 import { MapComponent } from '../map.component';
 import Vector from 'ol/layer/Vector';
@@ -41,8 +41,8 @@ export class LayerVectorComponent extends LayerComponent implements OnInit, OnDe
 
   source = input<VectorSource>();
 
-  constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
-    super(group || map);
+  constructor() {
+    super(inject(LayerGroupComponent, { optional: true }) || inject(MapComponent));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/layers/layervector.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layervector.component.ts
@@ -2,10 +2,10 @@ import {
   Component,
   OnDestroy,
   OnInit,
-  Input,
   Optional,
   OnChanges,
   SimpleChanges,
+  input,
 } from '@angular/core';
 import { MapComponent } from '../map.component';
 import Vector from 'ol/layer/Vector';
@@ -23,32 +23,23 @@ import VectorSource from 'ol/source/Vector';
   template: ` <ng-content></ng-content> `,
 })
 export class LayerVectorComponent extends LayerComponent implements OnInit, OnDestroy, OnChanges {
-  @Input()
-  renderOrder?: OrderFunction;
+  renderOrder = input<OrderFunction>();
 
-  @Input()
-  renderBuffer: number;
+  renderBuffer = input<number>();
 
-  @Input()
-  style: StyleLike | FlatStyleLike | null | undefined;
+  style = input<StyleLike | FlatStyleLike | null | undefined>();
 
-  @Input()
-  updateWhileAnimating: boolean;
+  updateWhileAnimating = input<boolean>();
 
-  @Input()
-  updateWhileInteracting: boolean;
+  updateWhileInteracting = input<boolean>();
 
-  @Input()
-  declutter: boolean | string | number;
+  declutter = input<boolean | string | number>();
 
-  @Input()
-  background?: BackgroundColor;
+  background = input<BackgroundColor>();
 
-  @Input()
-  properties: Record<string, any>;
+  properties = input<Record<string, any>>();
 
-  @Input()
-  source?: VectorSource;
+  source = input<VectorSource>();
 
   constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
     super(group || map);
@@ -56,7 +47,7 @@ export class LayerVectorComponent extends LayerComponent implements OnInit, OnDe
 
   ngOnInit() {
     // console.log('creating ol.layer.Vector instance with:', this);
-    this.instance = new Vector(this.createOptions());
+    this.setInstance(new Vector(this.createOptions()));
     super.ngOnInit();
   }
 
@@ -71,15 +62,15 @@ export class LayerVectorComponent extends LayerComponent implements OnInit, OnDe
   private createOptions(): Options<any, VectorSource<any>> {
     return {
       ...this.createLayerOptions(),
-      renderOrder: this.renderOrder,
-      renderBuffer: this.renderBuffer,
-      style: this.style,
-      updateWhileAnimating: this.updateWhileAnimating,
-      updateWhileInteracting: this.updateWhileInteracting,
-      declutter: this.declutter,
-      background: this.background,
-      properties: this.properties,
-      source: this.source,
+      renderOrder: this.renderOrder(),
+      renderBuffer: this.renderBuffer(),
+      style: this.style(),
+      updateWhileAnimating: this.updateWhileAnimating(),
+      updateWhileInteracting: this.updateWhileInteracting(),
+      declutter: this.declutter(),
+      background: this.background(),
+      properties: this.properties(),
+      source: this.source(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/layers/layervectorimage.component.spec.ts
+++ b/projects/ngx-ol/src/lib/layers/layervectorimage.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Feature from 'ol/Feature';
 import Geometry from 'ol/geom/Geometry';
@@ -27,8 +27,7 @@ class LayerVectorImageHostComponent {
   }) as VectorSource;
   style: Style | null = new Style();
 
-  @ViewChild(LayerVectorImageComponent)
-  layer!: LayerVectorImageComponent;
+  readonly layer = viewChild.required<LayerVectorImageComponent>(LayerVectorImageComponent);
 }
 
 describe('LayerVectorImageComponent', () => {
@@ -48,10 +47,10 @@ describe('LayerVectorImageComponent', () => {
   });
 
   it('binds its source and style through Angular inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
       fixture.componentInstance.source,
     );
-    expect(fixture.componentInstance.layer.instance.getStyle()).toBe(
+    expect(fixture.componentInstance.layer().instance.getStyle()).toBe(
       fixture.componentInstance.style,
     );
   });

--- a/projects/ngx-ol/src/lib/layers/layervectorimage.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layervectorimage.component.ts
@@ -2,10 +2,10 @@ import {
   Component,
   OnDestroy,
   OnInit,
-  Optional,
   OnChanges,
   SimpleChanges,
   input,
+  inject,
 } from '@angular/core';
 import { MapComponent } from '../map.component';
 import VectorImage from 'ol/layer/VectorImage';
@@ -39,8 +39,8 @@ export class LayerVectorImageComponent
 
   source = input<VectorSource>();
 
-  constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
-    super(group || map);
+  constructor() {
+    super(inject(LayerGroupComponent, { optional: true }) || inject(MapComponent));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/layers/layervectorimage.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layervectorimage.component.ts
@@ -25,19 +25,19 @@ export class LayerVectorImageComponent
   extends LayerComponent
   implements OnInit, OnDestroy, OnChanges
 {
-  renderBuffer = input<number>();
+  readonly renderBuffer = input<number>();
 
-  style = input<StyleLike | FlatStyleLike | null | undefined>();
+  readonly style = input<StyleLike | FlatStyleLike | null | undefined>();
 
-  declutter = input<boolean | string | number>();
+  readonly declutter = input<boolean | string | number>();
 
-  background = input<BackgroundColor>();
+  readonly background = input<BackgroundColor>();
 
-  imageRatio = input<number>();
+  readonly imageRatio = input<number>();
 
-  properties = input<Record<string, any>>();
+  readonly properties = input<Record<string, any>>();
 
-  source = input<VectorSource>();
+  readonly source = input<VectorSource>();
 
   constructor() {
     super(inject(LayerGroupComponent, { optional: true }) || inject(MapComponent));

--- a/projects/ngx-ol/src/lib/layers/layervectorimage.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layervectorimage.component.ts
@@ -2,10 +2,10 @@ import {
   Component,
   OnDestroy,
   OnInit,
-  Input,
   Optional,
   OnChanges,
   SimpleChanges,
+  input,
 } from '@angular/core';
 import { MapComponent } from '../map.component';
 import VectorImage from 'ol/layer/VectorImage';
@@ -25,26 +25,19 @@ export class LayerVectorImageComponent
   extends LayerComponent
   implements OnInit, OnDestroy, OnChanges
 {
-  @Input()
-  renderBuffer: number;
+  renderBuffer = input<number>();
 
-  @Input()
-  style: StyleLike | FlatStyleLike | null | undefined;
+  style = input<StyleLike | FlatStyleLike | null | undefined>();
 
-  @Input()
-  declutter: boolean | string | number;
+  declutter = input<boolean | string | number>();
 
-  @Input()
-  background?: BackgroundColor;
+  background = input<BackgroundColor>();
 
-  @Input()
-  imageRatio: number;
+  imageRatio = input<number>();
 
-  @Input()
-  properties: Record<string, any>;
+  properties = input<Record<string, any>>();
 
-  @Input()
-  source?: VectorSource;
+  source = input<VectorSource>();
 
   constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
     super(group || map);
@@ -52,7 +45,7 @@ export class LayerVectorImageComponent
 
   ngOnInit() {
     // console.log('creating ol.layer.Vector instance with:', this);
-    this.instance = new VectorImage(this.createOptions());
+    this.setInstance(new VectorImage(this.createOptions()));
     super.ngOnInit();
   }
 
@@ -67,13 +60,13 @@ export class LayerVectorImageComponent
   private createOptions(): Options<any, VectorSource<any>> & { imageRatio?: number } {
     return {
       ...this.createLayerOptions(),
-      renderBuffer: this.renderBuffer,
-      style: this.style,
-      declutter: this.declutter,
-      background: this.background,
-      imageRatio: this.imageRatio,
-      properties: this.properties,
-      source: this.source,
+      renderBuffer: this.renderBuffer(),
+      style: this.style(),
+      declutter: this.declutter(),
+      background: this.background(),
+      imageRatio: this.imageRatio(),
+      properties: this.properties(),
+      source: this.source(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/layers/layervectorimage.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layervectorimage.component.ts
@@ -55,6 +55,9 @@ export class LayerVectorImageComponent
     if (style && this.instance) {
       this.instance.setStyle(style.currentValue);
     }
+    if (this.instance && changes.source) {
+      this.instance.setSource(changes.source.currentValue);
+    }
   }
 
   private createOptions(): Options<any, VectorSource<any>> & { imageRatio?: number } {

--- a/projects/ngx-ol/src/lib/layers/layervectortile.component.spec.ts
+++ b/projects/ngx-ol/src/lib/layers/layervectortile.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import MVT from 'ol/format/MVT';
 import Style from 'ol/style/Style';
@@ -26,8 +26,7 @@ class LayerVectorTileHostComponent {
   });
   style: Style | null = new Style();
 
-  @ViewChild(LayerVectorTileComponent)
-  layer!: LayerVectorTileComponent;
+  readonly layer = viewChild.required<LayerVectorTileComponent>(LayerVectorTileComponent);
 }
 
 describe('LayerVectorTileComponent', () => {
@@ -47,10 +46,10 @@ describe('LayerVectorTileComponent', () => {
   });
 
   it('binds its vector tile source and style through Angular inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
       fixture.componentInstance.source,
     );
-    expect(fixture.componentInstance.layer.instance.getStyle()).toBe(
+    expect(fixture.componentInstance.layer().instance.getStyle()).toBe(
       fixture.componentInstance.style,
     );
   });

--- a/projects/ngx-ol/src/lib/layers/layervectortile.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layervectortile.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Optional, SimpleChanges, OnChanges, input } from '@angular/core';
+import { Component, OnInit, SimpleChanges, OnChanges, input, inject } from '@angular/core';
 import VectorTile from 'ol/layer/VectorTile';
 import { MapComponent } from '../map.component';
 import { LayerComponent } from './layer.component';
@@ -24,8 +24,8 @@ export class LayerVectorTileComponent extends LayerComponent implements OnInit, 
   visible = input<boolean>();
   source = input<VectorTileSource>();
 
-  constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
-    super(group || map);
+  constructor() {
+    super(inject(LayerGroupComponent, { optional: true }) || inject(MapComponent));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/layers/layervectortile.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layervectortile.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Optional, SimpleChanges, OnChanges } from '@angular/core';
+import { Component, OnInit, Optional, SimpleChanges, OnChanges, input } from '@angular/core';
 import VectorTile from 'ol/layer/VectorTile';
 import { MapComponent } from '../map.component';
 import { LayerComponent } from './layer.component';
@@ -14,24 +14,15 @@ import VectorTileSource from 'ol/source/VectorTile';
   template: ` <ng-content></ng-content> `,
 })
 export class LayerVectorTileComponent extends LayerComponent implements OnInit, OnChanges {
-  @Input()
-  renderBuffer: number;
-  @Input()
-  renderMode?: VectorTileRenderType;
-  @Input()
-  renderOrder?: OrderFunction;
-  @Input()
-  style: StyleLike | StyleFunction | null | undefined;
-  @Input()
-  background?: BackgroundColor;
-  @Input()
-  updateWhileAnimating: boolean;
-  @Input()
-  updateWhileInteracting: boolean;
-  @Input()
-  visible: boolean;
-  @Input()
-  source?: VectorTileSource;
+  renderBuffer = input<number>();
+  renderMode = input<VectorTileRenderType>();
+  renderOrder = input<OrderFunction>();
+  style = input<StyleLike | StyleFunction | null | undefined>();
+  background = input<BackgroundColor>();
+  updateWhileAnimating = input<boolean>();
+  updateWhileInteracting = input<boolean>();
+  visible = input<boolean>();
+  source = input<VectorTileSource>();
 
   constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
     super(group || map);
@@ -39,7 +30,7 @@ export class LayerVectorTileComponent extends LayerComponent implements OnInit, 
 
   ngOnInit() {
     // console.log('creating ol.layer.VectorTile instance with:', this);
-    this.instance = new VectorTile(this.createOptions());
+    this.setInstance(new VectorTile(this.createOptions()));
     super.ngOnInit();
   }
 
@@ -54,15 +45,15 @@ export class LayerVectorTileComponent extends LayerComponent implements OnInit, 
   private createOptions(): Options<VectorTileSource> {
     return {
       ...this.createLayerOptions(),
-      renderBuffer: this.renderBuffer,
-      renderMode: this.renderMode,
-      renderOrder: this.renderOrder,
-      style: this.style,
-      background: this.background,
-      updateWhileAnimating: this.updateWhileAnimating,
-      updateWhileInteracting: this.updateWhileInteracting,
-      visible: this.visible,
-      source: this.source,
+      renderBuffer: this.renderBuffer(),
+      renderMode: this.renderMode(),
+      renderOrder: this.renderOrder(),
+      style: this.style(),
+      background: this.background(),
+      updateWhileAnimating: this.updateWhileAnimating(),
+      updateWhileInteracting: this.updateWhileInteracting(),
+      visible: this.visible(),
+      source: this.source(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/layers/layervectortile.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layervectortile.component.ts
@@ -14,15 +14,15 @@ import VectorTileSource from 'ol/source/VectorTile';
   template: ` <ng-content></ng-content> `,
 })
 export class LayerVectorTileComponent extends LayerComponent implements OnInit, OnChanges {
-  renderBuffer = input<number>();
-  renderMode = input<VectorTileRenderType>();
-  renderOrder = input<OrderFunction>();
-  style = input<StyleLike | StyleFunction | null | undefined>();
-  background = input<BackgroundColor>();
-  updateWhileAnimating = input<boolean>();
-  updateWhileInteracting = input<boolean>();
-  visible = input<boolean>();
-  source = input<VectorTileSource>();
+  readonly renderBuffer = input<number>();
+  readonly renderMode = input<VectorTileRenderType>();
+  readonly renderOrder = input<OrderFunction>();
+  readonly style = input<StyleLike | StyleFunction | null | undefined>();
+  readonly background = input<BackgroundColor>();
+  readonly updateWhileAnimating = input<boolean>();
+  readonly updateWhileInteracting = input<boolean>();
+  readonly visible = input<boolean>();
+  readonly source = input<VectorTileSource>();
 
   constructor() {
     super(inject(LayerGroupComponent, { optional: true }) || inject(MapComponent));

--- a/projects/ngx-ol/src/lib/layers/layervectortile.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layervectortile.component.ts
@@ -40,6 +40,12 @@ export class LayerVectorTileComponent extends LayerComponent implements OnInit, 
     if (style && this.instance) {
       this.instance.setStyle(style.currentValue);
     }
+    if (this.instance && changes.renderOrder) {
+      this.instance.setRenderOrder(changes.renderOrder.currentValue);
+    }
+    if (this.instance && changes.source) {
+      this.instance.setSource(changes.source.currentValue);
+    }
   }
 
   private createOptions(): Options<VectorTileSource> {

--- a/projects/ngx-ol/src/lib/layers/layerwebgltile.component.spec.ts
+++ b/projects/ngx-ol/src/lib/layers/layerwebgltile.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import DataTileSource from 'ol/source/DataTile';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -22,8 +22,7 @@ class LayerWebGLTileHostComponent {
     loader: () => new Uint8Array([0, 0, 0, 255]),
   });
 
-  @ViewChild(LayerWebGLTileComponent)
-  layer!: LayerWebGLTileComponent;
+  readonly layer = viewChild.required<LayerWebGLTileComponent>(LayerWebGLTileComponent);
 }
 
 describe('LayerWebGLTileComponent', () => {
@@ -43,7 +42,7 @@ describe('LayerWebGLTileComponent', () => {
   });
 
   it('binds its WebGL tile source through Angular inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
       fixture.componentInstance.source,
     );
   });

--- a/projects/ngx-ol/src/lib/layers/layerwebgltile.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layerwebgltile.component.ts
@@ -25,21 +25,21 @@ export class LayerWebGLTileComponent
   extends LayerComponent
   implements OnInit, OnDestroy, OnChanges
 {
-  style = input<Style>();
+  readonly style = input<Style>();
 
-  preload = input<number>();
+  readonly preload = input<number>();
 
-  source = input<DataTileSource<DataTile>>();
+  readonly source = input<DataTileSource<DataTile>>();
 
-  sources = input<
+  readonly sources = input<
     DataTileSource<DataTile>[] | ((extent: Extent, resolution: number) => SourceType[])
   >();
 
-  map = input<MapComponent['instance']>();
+  readonly map = input<MapComponent['instance']>();
 
-  useInterimTilesOnError = input<boolean>();
+  readonly useInterimTilesOnError = input<boolean>();
 
-  cacheSize = input<number>();
+  readonly cacheSize = input<number>();
 
   instance: WebGLTileLayer;
 

--- a/projects/ngx-ol/src/lib/layers/layerwebgltile.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layerwebgltile.component.ts
@@ -69,6 +69,9 @@ export class LayerWebGLTileComponent
     if (this.instance && changes.style?.currentValue) {
       this.instance.setStyle(changes.style.currentValue);
     }
+    if (this.instance && changes.source) {
+      this.instance.setSource(changes.source.currentValue);
+    }
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/layers/layerwebgltile.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layerwebgltile.component.ts
@@ -1,4 +1,13 @@
-import { Component, Input, OnChanges, OnDestroy, OnInit, Optional, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Optional,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import WebGLTileLayer from 'ol/layer/WebGLTile';
 import type { Options, SourceType, Style } from 'ol/layer/WebGLTile';
 import type DataTileSource from 'ol/source/DataTile';
@@ -12,36 +21,45 @@ import { LayerGroupComponent } from './layergroup.component';
   selector: 'aol-layer-webgltile',
   template: ` <ng-content></ng-content> `,
 })
-export class LayerWebGLTileComponent extends LayerComponent implements OnInit, OnDestroy, OnChanges {
-  @Input()
-  style?: Style;
+export class LayerWebGLTileComponent
+  extends LayerComponent
+  implements OnInit, OnDestroy, OnChanges
+{
+  style = input<Style>();
 
-  @Input()
-  preload?: number;
+  preload = input<number>();
 
-  @Input()
-  source?: DataTileSource<DataTile>;
+  source = input<DataTileSource<DataTile>>();
 
-  @Input()
-  sources?: DataTileSource<DataTile>[] | ((extent: Extent, resolution: number) => SourceType[]);
+  sources = input<
+    DataTileSource<DataTile>[] | ((extent: Extent, resolution: number) => SourceType[])
+  >();
 
-  @Input()
-  map?: MapComponent['instance'];
+  map = input<MapComponent['instance']>();
 
-  @Input()
-  useInterimTilesOnError?: boolean;
+  useInterimTilesOnError = input<boolean>();
 
-  @Input()
-  cacheSize?: number;
+  cacheSize = input<number>();
 
   instance: WebGLTileLayer;
 
+  protected readonly _instanceSignal = signal<WebGLTileLayer | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: WebGLTileLayer): WebGLTileLayer {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
     super(group || map);
   }
 
   ngOnInit() {
-    this.instance = new WebGLTileLayer(this.createOptions());
+    this.setInstance(new WebGLTileLayer(this.createOptions()));
     super.ngOnInit();
   }
 
@@ -56,13 +74,13 @@ export class LayerWebGLTileComponent extends LayerComponent implements OnInit, O
   private createOptions(): Options {
     return {
       ...this.createLayerOptions(),
-      style: this.style,
-      preload: this.preload,
-      source: this.source,
-      sources: this.sources,
-      map: this.map,
-      useInterimTilesOnError: this.useInterimTilesOnError,
-      cacheSize: this.cacheSize,
+      style: this.style(),
+      preload: this.preload(),
+      source: this.source(),
+      sources: this.sources(),
+      map: this.map(),
+      useInterimTilesOnError: this.useInterimTilesOnError(),
+      cacheSize: this.cacheSize(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/layers/layerwebgltile.component.ts
+++ b/projects/ngx-ol/src/lib/layers/layerwebgltile.component.ts
@@ -3,10 +3,10 @@ import {
   OnChanges,
   OnDestroy,
   OnInit,
-  Optional,
   SimpleChanges,
   input,
   signal,
+  inject,
 } from '@angular/core';
 import WebGLTileLayer from 'ol/layer/WebGLTile';
 import type { Options, SourceType, Style } from 'ol/layer/WebGLTile';
@@ -54,8 +54,8 @@ export class LayerWebGLTileComponent
 
     return instance;
   }
-  constructor(map: MapComponent, @Optional() group?: LayerGroupComponent) {
-    super(group || map);
+  constructor() {
+    super(inject(LayerGroupComponent, { optional: true }) || inject(MapComponent));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/map.component.spec.ts
+++ b/projects/ngx-ol/src/lib/map.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Feature from 'ol/Feature';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -80,11 +80,9 @@ class MapHostComponent {
   propertyChange = vi.fn();
   mapSingleClick = vi.fn();
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 
-  @ViewChild(FeatureComponent)
-  featureComponent!: FeatureComponent;
+  readonly featureComponent = viewChild.required<FeatureComponent>(FeatureComponent);
 
   onOlClick() {
     this.olClick();
@@ -112,8 +110,7 @@ class RunOutsideAngularMapHostComponent {
   center = [0, 0];
   zoom = 2;
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('MapComponent', () => {
@@ -135,38 +132,38 @@ describe('MapComponent', () => {
   it('creates the OpenLayers map from bound host inputs', () => {
     const mapTarget = fixture.nativeElement.querySelector('aol-map > div') as HTMLDivElement;
 
-    expect(fixture.componentInstance.map.instance).toBeDefined();
+    expect(fixture.componentInstance.map().instance).toBeDefined();
     expect(mapTarget.style.width).toBe('320px');
     expect(mapTarget.style.height).toBe('240px');
   });
 
   it('creates the map when runOutsideAngular is disabled', () => {
-    expect(fixture.componentInstance.map.instance).toBeDefined();
+    expect(fixture.componentInstance.map().instance).toBeDefined();
   });
 
   it('creates the map through the default runOutsideAngular path', () => {
     const outsideAngularFixture = TestBed.createComponent(RunOutsideAngularMapHostComponent);
     outsideAngularFixture.detectChanges();
 
-    expect(outsideAngularFixture.componentInstance.map.instance).toBeDefined();
+    expect(outsideAngularFixture.componentInstance.map().instance).toBeDefined();
 
     outsideAngularFixture.destroy();
   });
 
   it('emits feature click outputs for clickable features', () => {
-    vi.spyOn(fixture.componentInstance.map.instance, 'forEachFeatureAtPixel').mockImplementation(
+    vi.spyOn(fixture.componentInstance.map().instance, 'forEachFeatureAtPixel').mockImplementation(
       (_pixel, callback) => {
         callback(fixture.componentInstance.feature, null as any, null as any);
         return fixture.componentInstance.feature;
       },
     );
 
-    fixture.componentInstance.map.instance.dispatchEvent({ type: 'click', pixel: [1, 1] } as any);
-    fixture.componentInstance.map.instance.dispatchEvent({
+    fixture.componentInstance.map().instance.dispatchEvent({ type: 'click', pixel: [1, 1] } as any);
+    fixture.componentInstance.map().instance.dispatchEvent({
       type: 'singleclick',
       pixel: [1, 1],
     } as any);
-    fixture.componentInstance.map.instance.dispatchEvent({
+    fixture.componentInstance.map().instance.dispatchEvent({
       type: 'dblclick',
       pixel: [1, 1],
     } as any);
@@ -182,22 +179,22 @@ describe('MapComponent', () => {
   it('forwards OpenLayers map events through Angular outputs', () => {
     vi.clearAllMocks();
 
-    fixture.componentInstance.map.instance.dispatchEvent('change');
-    fixture.componentInstance.map.instance.dispatchEvent('change:layergroup');
-    fixture.componentInstance.map.instance.dispatchEvent('change:size');
-    fixture.componentInstance.map.instance.dispatchEvent('change:target');
-    fixture.componentInstance.map.instance.dispatchEvent('change:view');
-    fixture.componentInstance.map.instance.dispatchEvent('error');
-    fixture.componentInstance.map.instance.dispatchEvent('loadend');
-    fixture.componentInstance.map.instance.dispatchEvent('loadstart');
-    fixture.componentInstance.map.instance.dispatchEvent('moveend');
-    fixture.componentInstance.map.instance.dispatchEvent('movestart');
-    fixture.componentInstance.map.instance.dispatchEvent('pointerdrag');
-    fixture.componentInstance.map.instance.dispatchEvent('pointermove');
-    fixture.componentInstance.map.instance.dispatchEvent('postcompose');
-    fixture.componentInstance.map.instance.dispatchEvent('postrender');
-    fixture.componentInstance.map.instance.dispatchEvent('precompose');
-    fixture.componentInstance.map.instance.dispatchEvent('propertychange');
+    fixture.componentInstance.map().instance.dispatchEvent('change');
+    fixture.componentInstance.map().instance.dispatchEvent('change:layergroup');
+    fixture.componentInstance.map().instance.dispatchEvent('change:size');
+    fixture.componentInstance.map().instance.dispatchEvent('change:target');
+    fixture.componentInstance.map().instance.dispatchEvent('change:view');
+    fixture.componentInstance.map().instance.dispatchEvent('error');
+    fixture.componentInstance.map().instance.dispatchEvent('loadend');
+    fixture.componentInstance.map().instance.dispatchEvent('loadstart');
+    fixture.componentInstance.map().instance.dispatchEvent('moveend');
+    fixture.componentInstance.map().instance.dispatchEvent('movestart');
+    fixture.componentInstance.map().instance.dispatchEvent('pointerdrag');
+    fixture.componentInstance.map().instance.dispatchEvent('pointermove');
+    fixture.componentInstance.map().instance.dispatchEvent('postcompose');
+    fixture.componentInstance.map().instance.dispatchEvent('postrender');
+    fixture.componentInstance.map().instance.dispatchEvent('precompose');
+    fixture.componentInstance.map().instance.dispatchEvent('propertychange');
 
     expect(fixture.componentInstance.mapChange).toHaveBeenCalledOnce();
     expect(fixture.componentInstance.mapChangeLayerGroup).toHaveBeenCalledOnce();

--- a/projects/ngx-ol/src/lib/map.component.ts
+++ b/projects/ngx-ol/src/lib/map.component.ts
@@ -2,13 +2,13 @@ import {
   Component,
   OnInit,
   ElementRef,
-  Input,
-  Output,
-  EventEmitter,
   AfterViewInit,
   SimpleChanges,
   OnChanges,
   NgZone,
+  input,
+  output,
+  signal,
 } from '@angular/core';
 import Map from 'ol/Map';
 import type { MapOptions } from 'ol/Map';
@@ -23,66 +23,52 @@ import BaseEvent from 'ol/events/Event';
 @Component({
   selector: 'aol-map',
   template: `
-    <div [style.width]="width" [style.height]="height"></div>
+    <div [style.width]="width()" [style.height]="height()"></div>
     <ng-content></ng-content>
   `,
 })
 export class MapComponent implements OnInit, AfterViewInit, OnChanges {
-  @Input()
-  width = '100%';
-  @Input()
-  height = '100%';
-  @Input()
-  pixelRatio: number;
-  @Input()
-  keyboardEventTarget: HTMLElement | string;
-  @Input()
-  maxTilesLoading: number;
-  @Input()
-  moveTolerance: number;
-  @Input()
-  runOutsideAngular = true;
+  width = input('100%');
+  height = input('100%');
+  pixelRatio = input<number>();
+  keyboardEventTarget = input<HTMLElement | string>();
+  maxTilesLoading = input<number>();
+  moveTolerance = input<number>();
+  runOutsideAngular = input(true);
 
-  @Output()
-  olChange = new EventEmitter<BaseEvent>();
-  @Output()
-  changeLayerGroup = new EventEmitter<ObjectEvent>();
-  @Output()
-  changeSize = new EventEmitter<ObjectEvent>();
-  @Output()
-  changeTarget = new EventEmitter<ObjectEvent>();
-  @Output()
-  changeView = new EventEmitter<ObjectEvent>();
-  @Output()
-  olClick = new EventEmitter<MapBrowserEvent<MouseEvent> | any>();
-  @Output()
-  dblClick = new EventEmitter<MapBrowserEvent<MouseEvent> | any>();
-  @Output()
-  olError = new EventEmitter<BaseEvent>();
-  @Output()
-  loadEnd = new EventEmitter<MapEvent>();
-  @Output()
-  loadStart = new EventEmitter<MapEvent>();
-  @Output()
-  moveEnd = new EventEmitter<MapEvent>();
-  @Output()
-  moveStart = new EventEmitter<MapEvent>();
-  @Output()
-  pointerDrag = new EventEmitter<MapBrowserEvent<MouseEvent> | any>();
-  @Output()
-  pointerMove = new EventEmitter<MapBrowserEvent<MouseEvent> | any>();
-  @Output()
-  postCompose = new EventEmitter<RenderEvent>();
-  @Output()
-  postRender = new EventEmitter<MapEvent>();
-  @Output()
-  preCompose = new EventEmitter<RenderEvent>();
-  @Output()
-  propertyChange = new EventEmitter<ObjectEvent>();
-  @Output()
-  singleClick = new EventEmitter<MapBrowserEvent<MouseEvent> | any>();
+  olChange = output<BaseEvent>();
+  changeLayerGroup = output<ObjectEvent>();
+  changeSize = output<ObjectEvent>();
+  changeTarget = output<ObjectEvent>();
+  changeView = output<ObjectEvent>();
+  olClick = output<MapBrowserEvent<MouseEvent> | any>();
+  dblClick = output<MapBrowserEvent<MouseEvent> | any>();
+  olError = output<BaseEvent>();
+  loadEnd = output<MapEvent>();
+  loadStart = output<MapEvent>();
+  moveEnd = output<MapEvent>();
+  moveStart = output<MapEvent>();
+  pointerDrag = output<MapBrowserEvent<MouseEvent> | any>();
+  pointerMove = output<MapBrowserEvent<MouseEvent> | any>();
+  postCompose = output<RenderEvent>();
+  postRender = output<MapEvent>();
+  preCompose = output<RenderEvent>();
+  propertyChange = output<ObjectEvent>();
+  singleClick = output<MapBrowserEvent<MouseEvent> | any>();
 
   public instance: Map;
+
+  protected readonly _instanceSignal = signal<Map | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Map): Map {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   public componentType = 'map';
 
   // we pass empty arrays to not get default controls/interactions because we have our own directives
@@ -96,7 +82,7 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
 
   ngOnInit() {
     const initMap = () => {
-      this.instance = new Map(this.createOptions());
+      this.setInstance(new Map(this.createOptions()));
       this.instance.setTarget(this.host.nativeElement.firstElementChild);
       this.instance.on('change', (event: BaseEvent) => this.olChange.emit(event));
       this.instance.on('change:layergroup', (event: ObjectEvent) =>
@@ -146,7 +132,7 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
       });
     };
 
-    if (this.runOutsideAngular) {
+    if (this.runOutsideAngular()) {
       this.ngZone.runOutsideAngular(initMap);
     } else {
       initMap();
@@ -171,10 +157,10 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
     return {
       controls: this.controls,
       interactions: this.interactions,
-      keyboardEventTarget: this.keyboardEventTarget,
-      maxTilesLoading: this.maxTilesLoading,
-      moveTolerance: this.moveTolerance,
-      pixelRatio: this.pixelRatio,
+      keyboardEventTarget: this.keyboardEventTarget(),
+      maxTilesLoading: this.maxTilesLoading(),
+      moveTolerance: this.moveTolerance(),
+      pixelRatio: this.pixelRatio(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/map.component.ts
+++ b/projects/ngx-ol/src/lib/map.component.ts
@@ -5,6 +5,7 @@ import {
   AfterViewInit,
   SimpleChanges,
   OnChanges,
+  OnDestroy,
   NgZone,
   input,
   output,
@@ -19,6 +20,8 @@ import RenderEvent from 'ol/render/Event';
 import Control from 'ol/control/Control';
 import Interaction from 'ol/interaction/Interaction';
 import BaseEvent from 'ol/events/Event';
+import type { EventsKey } from 'ol/events';
+import { unByKey } from 'ol/Observable';
 
 @Component({
   selector: 'aol-map',
@@ -27,7 +30,7 @@ import BaseEvent from 'ol/events/Event';
     <ng-content></ng-content>
   `,
 })
-export class MapComponent implements OnInit, AfterViewInit, OnChanges {
+export class MapComponent implements OnInit, AfterViewInit, OnChanges, OnDestroy {
   readonly width = input('100%');
   readonly height = input('100%');
   readonly pixelRatio = input<number>();
@@ -74,6 +77,7 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
   // we pass empty arrays to not get default controls/interactions because we have our own directives
   readonly controls: Control[] = [];
   readonly interactions: Interaction[] = [];
+  private eventKeys: EventsKey[] = [];
 
   constructor(
     private readonly host: ElementRef,
@@ -84,28 +88,6 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
     const initMap = () => {
       this.setInstance(new Map(this.createOptions()));
       this.instance.setTarget(this.host.nativeElement.firstElementChild);
-      this.instance.on('change', (event: BaseEvent) => this.olChange.emit(event));
-      this.instance.on('change:layergroup', (event: ObjectEvent) =>
-        this.changeLayerGroup.emit(event),
-      );
-      this.instance.on('change:size', (event: ObjectEvent) => this.changeSize.emit(event));
-      this.instance.on('change:target', (event: ObjectEvent) => this.changeTarget.emit(event));
-      this.instance.on('change:view', (event: ObjectEvent) => this.changeView.emit(event));
-      this.instance.on('error', (event: BaseEvent) => this.olError.emit(event));
-      this.instance.on('loadend', (event: MapEvent) => this.loadEnd.emit(event));
-      this.instance.on('loadstart', (event: MapEvent) => this.loadStart.emit(event));
-      this.instance.on('moveend', (event: MapEvent) => this.moveEnd.emit(event));
-      this.instance.on('movestart', (event: MapEvent) => this.moveStart.emit(event));
-      this.instance.on('pointerdrag', (event: MapBrowserEvent<MouseEvent> | any) =>
-        this.pointerDrag.emit(event),
-      );
-      this.instance.on('pointermove', (event: MapBrowserEvent<MouseEvent> | any) =>
-        this.pointerMove.emit(event),
-      );
-      this.instance.on('postcompose', (event: RenderEvent) => this.postCompose.emit(event));
-      this.instance.on('postrender', (event: MapEvent) => this.postRender.emit(event));
-      this.instance.on('precompose', (event: RenderEvent) => this.preCompose.emit(event));
-      this.instance.on('propertychange', (event: ObjectEvent) => this.propertyChange.emit(event));
 
       const handleFeatureClick = (
         event: MapBrowserEvent<MouseEvent> | any,
@@ -118,18 +100,42 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
           }
         });
       };
-      this.instance.on('click', (event: MapBrowserEvent<MouseEvent> | any) => {
-        this.olClick.emit(event);
-        handleFeatureClick(event, 'olClick');
-      });
-      this.instance.on('singleclick', (event: MapBrowserEvent<MouseEvent> | any) => {
-        this.singleClick.emit(event);
-        handleFeatureClick(event, 'singleClick');
-      });
-      this.instance.on('dblclick', (event: MapBrowserEvent<MouseEvent> | any) => {
-        this.dblClick.emit(event);
-        handleFeatureClick(event, 'dblClick');
-      });
+      this.eventKeys = [
+        this.instance.on('change', (event: BaseEvent) => this.olChange.emit(event)),
+        this.instance.on('change:layergroup', (event: ObjectEvent) =>
+          this.changeLayerGroup.emit(event),
+        ),
+        this.instance.on('change:size', (event: ObjectEvent) => this.changeSize.emit(event)),
+        this.instance.on('change:target', (event: ObjectEvent) => this.changeTarget.emit(event)),
+        this.instance.on('change:view', (event: ObjectEvent) => this.changeView.emit(event)),
+        this.instance.on('error', (event: BaseEvent) => this.olError.emit(event)),
+        this.instance.on('loadend', (event: MapEvent) => this.loadEnd.emit(event)),
+        this.instance.on('loadstart', (event: MapEvent) => this.loadStart.emit(event)),
+        this.instance.on('moveend', (event: MapEvent) => this.moveEnd.emit(event)),
+        this.instance.on('movestart', (event: MapEvent) => this.moveStart.emit(event)),
+        this.instance.on('pointerdrag', (event: MapBrowserEvent<MouseEvent> | any) =>
+          this.pointerDrag.emit(event),
+        ),
+        this.instance.on('pointermove', (event: MapBrowserEvent<MouseEvent> | any) =>
+          this.pointerMove.emit(event),
+        ),
+        this.instance.on('postcompose', (event: RenderEvent) => this.postCompose.emit(event)),
+        this.instance.on('postrender', (event: MapEvent) => this.postRender.emit(event)),
+        this.instance.on('precompose', (event: RenderEvent) => this.preCompose.emit(event)),
+        this.instance.on('propertychange', (event: ObjectEvent) => this.propertyChange.emit(event)),
+        this.instance.on('click', (event: MapBrowserEvent<MouseEvent> | any) => {
+          this.olClick.emit(event);
+          handleFeatureClick(event, 'olClick');
+        }),
+        this.instance.on('singleclick', (event: MapBrowserEvent<MouseEvent> | any) => {
+          this.singleClick.emit(event);
+          handleFeatureClick(event, 'singleClick');
+        }),
+        this.instance.on('dblclick', (event: MapBrowserEvent<MouseEvent> | any) => {
+          this.dblClick.emit(event);
+          handleFeatureClick(event, 'dblClick');
+        }),
+      ];
     };
 
     if (this.runOutsideAngular()) {
@@ -151,6 +157,15 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
 
   ngAfterViewInit() {
     this.instance.updateSize();
+  }
+
+  ngOnDestroy() {
+    if (this.eventKeys.length) {
+      unByKey(this.eventKeys);
+      this.eventKeys = [];
+    }
+
+    this.instance.setTarget(undefined);
   }
 
   private createOptions(): MapOptions {

--- a/projects/ngx-ol/src/lib/map.component.ts
+++ b/projects/ngx-ol/src/lib/map.component.ts
@@ -28,33 +28,33 @@ import BaseEvent from 'ol/events/Event';
   `,
 })
 export class MapComponent implements OnInit, AfterViewInit, OnChanges {
-  width = input('100%');
-  height = input('100%');
-  pixelRatio = input<number>();
-  keyboardEventTarget = input<HTMLElement | string>();
-  maxTilesLoading = input<number>();
-  moveTolerance = input<number>();
-  runOutsideAngular = input(true);
+  readonly width = input('100%');
+  readonly height = input('100%');
+  readonly pixelRatio = input<number>();
+  readonly keyboardEventTarget = input<HTMLElement | string>();
+  readonly maxTilesLoading = input<number>();
+  readonly moveTolerance = input<number>();
+  readonly runOutsideAngular = input(true);
 
-  olChange = output<BaseEvent>();
-  changeLayerGroup = output<ObjectEvent>();
-  changeSize = output<ObjectEvent>();
-  changeTarget = output<ObjectEvent>();
-  changeView = output<ObjectEvent>();
-  olClick = output<MapBrowserEvent<MouseEvent> | any>();
-  dblClick = output<MapBrowserEvent<MouseEvent> | any>();
-  olError = output<BaseEvent>();
-  loadEnd = output<MapEvent>();
-  loadStart = output<MapEvent>();
-  moveEnd = output<MapEvent>();
-  moveStart = output<MapEvent>();
-  pointerDrag = output<MapBrowserEvent<MouseEvent> | any>();
-  pointerMove = output<MapBrowserEvent<MouseEvent> | any>();
-  postCompose = output<RenderEvent>();
-  postRender = output<MapEvent>();
-  preCompose = output<RenderEvent>();
-  propertyChange = output<ObjectEvent>();
-  singleClick = output<MapBrowserEvent<MouseEvent> | any>();
+  readonly olChange = output<BaseEvent>();
+  readonly changeLayerGroup = output<ObjectEvent>();
+  readonly changeSize = output<ObjectEvent>();
+  readonly changeTarget = output<ObjectEvent>();
+  readonly changeView = output<ObjectEvent>();
+  readonly olClick = output<MapBrowserEvent<MouseEvent> | any>();
+  readonly dblClick = output<MapBrowserEvent<MouseEvent> | any>();
+  readonly olError = output<BaseEvent>();
+  readonly loadEnd = output<MapEvent>();
+  readonly loadStart = output<MapEvent>();
+  readonly moveEnd = output<MapEvent>();
+  readonly moveStart = output<MapEvent>();
+  readonly pointerDrag = output<MapBrowserEvent<MouseEvent> | any>();
+  readonly pointerMove = output<MapBrowserEvent<MouseEvent> | any>();
+  readonly postCompose = output<RenderEvent>();
+  readonly postRender = output<MapEvent>();
+  readonly preCompose = output<RenderEvent>();
+  readonly propertyChange = output<ObjectEvent>();
+  readonly singleClick = output<MapBrowserEvent<MouseEvent> | any>();
 
   public instance: Map;
 
@@ -69,15 +69,15 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
 
     return instance;
   }
-  public componentType = 'map';
+  readonly componentType: string = 'map';
 
   // we pass empty arrays to not get default controls/interactions because we have our own directives
-  controls: Control[] = [];
-  interactions: Interaction[] = [];
+  readonly controls: Control[] = [];
+  readonly interactions: Interaction[] = [];
 
   constructor(
-    private host: ElementRef,
-    private ngZone: NgZone,
+    private readonly host: ElementRef,
+    private readonly ngZone: NgZone,
   ) {}
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/overlay.component.spec.ts
+++ b/projects/ngx-ol/src/lib/overlay.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../public-api';
@@ -21,8 +21,7 @@ class OverlayHostComponent {
   zoom = 2;
   position: [number, number] = [1, 2];
 
-  @ViewChild(OverlayComponent)
-  overlay!: OverlayComponent;
+  readonly overlay = viewChild.required<OverlayComponent>(OverlayComponent);
 }
 
 describe('OverlayComponent', () => {
@@ -42,6 +41,6 @@ describe('OverlayComponent', () => {
   });
 
   it('creates an overlay and binds its position from the template', () => {
-    expect(fixture.componentInstance.overlay.instance.getPosition()).toEqual([1, 2]);
+    expect(fixture.componentInstance.overlay().instance.getPosition()).toEqual([1, 2]);
   });
 });

--- a/projects/ngx-ol/src/lib/overlay.component.ts
+++ b/projects/ngx-ol/src/lib/overlay.component.ts
@@ -59,10 +59,16 @@ export class OverlayComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    const { position } = changes;
+    const { offset, position, positioning } = changes;
 
     if (position && this.instance) {
       this.instance.setPosition(position.currentValue);
+    }
+    if (offset && this.instance) {
+      this.instance.setOffset(offset.currentValue);
+    }
+    if (positioning && this.instance) {
+      this.instance.setPositioning(positioning.currentValue);
     }
   }
 

--- a/projects/ngx-ol/src/lib/overlay.component.ts
+++ b/projects/ngx-ol/src/lib/overlay.component.ts
@@ -1,11 +1,12 @@
 import {
   Component,
   ContentChild,
-  Input,
   OnChanges,
   OnDestroy,
   OnInit,
   SimpleChanges,
+  input,
+  signal,
 } from '@angular/core';
 import { MapComponent } from './map.component';
 import Overlay, { Options, PanIntoViewOptions, Positioning } from 'ol/Overlay';
@@ -20,25 +21,25 @@ export class OverlayComponent implements OnInit, OnDestroy, OnChanges {
   @ContentChild(ContentComponent, { static: true })
   content: ContentComponent;
 
-  @Input()
-  id?: number | string | undefined;
-  @Input()
-  offset?: number[];
-  @Input()
-  positioning?: Positioning;
-  @Input()
-  stopEvent?: boolean;
-  @Input()
-  insertFirst?: boolean;
-  @Input()
-  autoPan?: boolean | PanIntoViewOptions;
-  @Input()
-  position?: Coordinate | undefined;
-  @Input()
-  className?: string;
+  id = input<number | string | undefined>();
+  offset = input<number[]>();
+  positioning = input<Positioning>();
+  stopEvent = input<boolean>();
+  insertFirst = input<boolean>();
+  autoPan = input<boolean | PanIntoViewOptions>();
+  position = input<Coordinate | undefined>();
+  className = input<string>();
 
   componentType = 'overlay';
   instance: Overlay;
+  protected readonly _instanceSignal = signal<Overlay | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Overlay): Overlay {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   element: HTMLElement;
 
   constructor(private map: MapComponent) {}
@@ -46,7 +47,7 @@ export class OverlayComponent implements OnInit, OnDestroy, OnChanges {
   ngOnInit() {
     if (this.content) {
       this.element = this.content.elementRef.nativeElement;
-      this.instance = new Overlay(this.createOptions());
+      this.setInstance(new Overlay(this.createOptions()));
       this.map.instance.addOverlay(this.instance);
     }
   }
@@ -67,15 +68,15 @@ export class OverlayComponent implements OnInit, OnDestroy, OnChanges {
 
   private createOptions(): Options {
     return {
-      autoPan: this.autoPan,
-      className: this.className,
+      autoPan: this.autoPan(),
+      className: this.className(),
       element: this.element,
-      id: this.id,
-      insertFirst: this.insertFirst,
-      offset: this.offset,
-      position: this.position,
-      positioning: this.positioning,
-      stopEvent: this.stopEvent,
+      id: this.id(),
+      insertFirst: this.insertFirst(),
+      offset: this.offset(),
+      position: this.position(),
+      positioning: this.positioning(),
+      stopEvent: this.stopEvent(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/overlay.component.ts
+++ b/projects/ngx-ol/src/lib/overlay.component.ts
@@ -21,16 +21,16 @@ import { Coordinate } from 'ol/coordinate';
 export class OverlayComponent implements OnInit, OnDestroy, OnChanges {
   protected readonly content = contentChild(ContentComponent);
 
-  id = input<number | string | undefined>();
-  offset = input<number[]>();
-  positioning = input<Positioning>();
-  stopEvent = input<boolean>();
-  insertFirst = input<boolean>();
-  autoPan = input<boolean | PanIntoViewOptions>();
-  position = input<Coordinate | undefined>();
-  className = input<string>();
+  readonly id = input<number | string | undefined>();
+  readonly offset = input<number[]>();
+  readonly positioning = input<Positioning>();
+  readonly stopEvent = input<boolean>();
+  readonly insertFirst = input<boolean>();
+  readonly autoPan = input<boolean | PanIntoViewOptions>();
+  readonly position = input<Coordinate | undefined>();
+  readonly className = input<string>();
 
-  componentType = 'overlay';
+  readonly componentType: string = 'overlay';
   instance: Overlay;
   protected readonly _instanceSignal = signal<Overlay | undefined>(undefined);
   readonly instanceSignal = this._instanceSignal.asReadonly();

--- a/projects/ngx-ol/src/lib/overlay.component.ts
+++ b/projects/ngx-ol/src/lib/overlay.component.ts
@@ -7,6 +7,7 @@ import {
   contentChild,
   input,
   signal,
+  inject,
 } from '@angular/core';
 import { MapComponent } from './map.component';
 import Overlay, { Options, PanIntoViewOptions, Positioning } from 'ol/Overlay';
@@ -41,7 +42,7 @@ export class OverlayComponent implements OnInit, OnDestroy, OnChanges {
   }
   element: HTMLElement;
 
-  constructor(private map: MapComponent) {}
+  private readonly map = inject(MapComponent);
 
   ngOnInit() {
     const content = this.content();

--- a/projects/ngx-ol/src/lib/overlay.component.ts
+++ b/projects/ngx-ol/src/lib/overlay.component.ts
@@ -1,10 +1,10 @@
 import {
   Component,
-  ContentChild,
   OnChanges,
   OnDestroy,
   OnInit,
   SimpleChanges,
+  contentChild,
   input,
   signal,
 } from '@angular/core';
@@ -18,8 +18,7 @@ import { Coordinate } from 'ol/coordinate';
   template: '<ng-content></ng-content>',
 })
 export class OverlayComponent implements OnInit, OnDestroy, OnChanges {
-  @ContentChild(ContentComponent, { static: true })
-  content: ContentComponent;
+  protected readonly content = contentChild(ContentComponent);
 
   id = input<number | string | undefined>();
   offset = input<number[]>();
@@ -45,8 +44,10 @@ export class OverlayComponent implements OnInit, OnDestroy, OnChanges {
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    if (this.content) {
-      this.element = this.content.elementRef.nativeElement;
+    const content = this.content();
+
+    if (content) {
+      this.element = content.elementRef.nativeElement;
       this.setInstance(new Overlay(this.createOptions()));
       this.map.instance.addOverlay(this.instance);
     }

--- a/projects/ngx-ol/src/lib/sources/bingmaps.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/bingmaps.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -26,16 +26,13 @@ class SourceBingMapsHostComponent {
   center = [0, 0];
   zoom = 2;
   apiKey = 'test-key';
-  imagerySet: 'Road' | 'Aerial' | 'AerialWithLabels' | 'collinsBart' | 'ordnanceSurvey' =
-    'Road';
+  imagerySet: 'Road' | 'Aerial' | 'AerialWithLabels' | 'collinsBart' | 'ordnanceSurvey' = 'Road';
   culture = 'en-IE';
   hidpi = true;
 
-  @ViewChild(SourceBingmapsComponent)
-  source!: SourceBingmapsComponent;
+  readonly source = viewChild.required<SourceBingmapsComponent>(SourceBingmapsComponent);
 
-  @ViewChild(LayerTileComponent)
-  layer!: LayerTileComponent;
+  readonly layer = viewChild.required<LayerTileComponent>(LayerTileComponent);
 }
 
 describe('SourceBingmapsComponent', () => {
@@ -78,11 +75,11 @@ describe('SourceBingmapsComponent', () => {
   });
 
   it('binds Bing Maps options into the tile layer through Angular inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
-    expect(fixture.componentInstance.source.instance.getApiKey()).toBe('test-key');
-    expect(fixture.componentInstance.source.instance.getImagerySet()).toBe('Road');
+    expect(fixture.componentInstance.source().instance.getApiKey()).toBe('test-key');
+    expect(fixture.componentInstance.source().instance.getImagerySet()).toBe('Road');
     expect(globalThis.fetch).toHaveBeenCalledOnce();
   });
 });

--- a/projects/ngx-ol/src/lib/sources/bingmaps.component.ts
+++ b/projects/ngx-ol/src/lib/sources/bingmaps.component.ts
@@ -1,4 +1,4 @@
-import { Component, Host, Input, OnInit, forwardRef } from '@angular/core';
+import { Component, Host, OnInit, forwardRef, input, signal } from '@angular/core';
 import BingMaps from 'ol/source/BingMaps';
 import { Options } from 'ol/source/BingMaps';
 import { SourceComponent } from './source.component';
@@ -12,59 +12,59 @@ import { NearestDirectionFunction } from 'ol/array';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceBingmapsComponent) }],
 })
 export class SourceBingmapsComponent extends SourceComponent implements OnInit {
-  @Input()
-  cacheSize?: number;
-  @Input()
-  hidpi?: boolean;
-  @Input()
-  culture?: string;
-  @Input()
-  key: string;
-  @Input()
-  imagerySet: 'Road' | 'Aerial' | 'AerialWithLabels' | 'collinsBart' | 'ordnanceSurvey' = 'Aerial';
-  @Input()
-  maxZoom?: number;
-  @Input()
-  reprojectionErrorThreshold?: number;
-  @Input()
-  tileLoadFunction?: LoadFunction;
-  @Input()
-  wrapX?: boolean;
-  @Input()
-  interpolate?: boolean;
-  @Input()
-  placeholderTiles?: boolean;
-  @Input()
-  transition?: number;
-  @Input()
-  zDirection?: number | NearestDirectionFunction;
+  cacheSize = input<number>();
+  hidpi = input<boolean>();
+  culture = input<string>();
+  key = input.required<string>();
+  imagerySet = input<'Road' | 'Aerial' | 'AerialWithLabels' | 'collinsBart' | 'ordnanceSurvey'>(
+    'Aerial',
+  );
+  maxZoom = input<number>();
+  reprojectionErrorThreshold = input<number>();
+  tileLoadFunction = input<LoadFunction>();
+  wrapX = input<boolean>();
+  interpolate = input<boolean>();
+  placeholderTiles = input<boolean>();
+  transition = input<number>();
+  zDirection = input<number | NearestDirectionFunction>();
 
   instance: BingMaps;
 
+  protected readonly _instanceSignal = signal<BingMaps | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: BingMaps): BingMaps {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Host() layer: LayerTileComponent) {
     super(layer);
   }
 
   ngOnInit() {
-    this.instance = new BingMaps(this.createOptions());
+    this.setInstance(new BingMaps(this.createOptions()));
     this.host.instance.setSource(this.instance);
   }
 
   private createOptions(): Options {
     return {
-      cacheSize: this.cacheSize,
-      hidpi: this.hidpi,
-      culture: this.culture,
-      key: this.key,
-      imagerySet: this.imagerySet,
-      maxZoom: this.maxZoom,
-      reprojectionErrorThreshold: this.reprojectionErrorThreshold,
-      tileLoadFunction: this.tileLoadFunction,
-      wrapX: this.wrapX,
-      interpolate: this.interpolate,
-      placeholderTiles: this.placeholderTiles,
-      transition: this.transition,
-      zDirection: this.zDirection,
+      cacheSize: this.cacheSize(),
+      hidpi: this.hidpi(),
+      culture: this.culture(),
+      key: this.key(),
+      imagerySet: this.imagerySet(),
+      maxZoom: this.maxZoom(),
+      reprojectionErrorThreshold: this.reprojectionErrorThreshold(),
+      tileLoadFunction: this.tileLoadFunction(),
+      wrapX: this.wrapX(),
+      interpolate: this.interpolate(),
+      placeholderTiles: this.placeholderTiles(),
+      transition: this.transition(),
+      zDirection: this.zDirection(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/bingmaps.component.ts
+++ b/projects/ngx-ol/src/lib/sources/bingmaps.component.ts
@@ -1,4 +1,4 @@
-import { Component, Host, OnInit, forwardRef, input, signal } from '@angular/core';
+import { Component, OnInit, forwardRef, input, signal, inject } from '@angular/core';
 import BingMaps from 'ol/source/BingMaps';
 import { Options } from 'ol/source/BingMaps';
 import { SourceComponent } from './source.component';
@@ -41,8 +41,8 @@ export class SourceBingmapsComponent extends SourceComponent implements OnInit {
 
     return instance;
   }
-  constructor(@Host() layer: LayerTileComponent) {
-    super(layer);
+  constructor() {
+    super(inject(LayerTileComponent, { host: true }));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/sources/bingmaps.component.ts
+++ b/projects/ngx-ol/src/lib/sources/bingmaps.component.ts
@@ -12,21 +12,21 @@ import { NearestDirectionFunction } from 'ol/array';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceBingmapsComponent) }],
 })
 export class SourceBingmapsComponent extends SourceComponent implements OnInit {
-  cacheSize = input<number>();
-  hidpi = input<boolean>();
-  culture = input<string>();
-  key = input.required<string>();
-  imagerySet = input<'Road' | 'Aerial' | 'AerialWithLabels' | 'collinsBart' | 'ordnanceSurvey'>(
-    'Aerial',
-  );
-  maxZoom = input<number>();
-  reprojectionErrorThreshold = input<number>();
-  tileLoadFunction = input<LoadFunction>();
-  wrapX = input<boolean>();
-  interpolate = input<boolean>();
-  placeholderTiles = input<boolean>();
-  transition = input<number>();
-  zDirection = input<number | NearestDirectionFunction>();
+  readonly cacheSize = input<number>();
+  readonly hidpi = input<boolean>();
+  readonly culture = input<string>();
+  readonly key = input.required<string>();
+  readonly imagerySet = input<
+    'Road' | 'Aerial' | 'AerialWithLabels' | 'collinsBart' | 'ordnanceSurvey'
+  >('Aerial');
+  readonly maxZoom = input<number>();
+  readonly reprojectionErrorThreshold = input<number>();
+  readonly tileLoadFunction = input<LoadFunction>();
+  readonly wrapX = input<boolean>();
+  readonly interpolate = input<boolean>();
+  readonly placeholderTiles = input<boolean>();
+  readonly transition = input<number>();
+  readonly zDirection = input<number | NearestDirectionFunction>();
 
   instance: BingMaps;
 

--- a/projects/ngx-ol/src/lib/sources/cluster.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/cluster.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
@@ -28,14 +28,11 @@ class SourceClusterHostComponent {
   distance = 20;
   features = [new Feature(new Point([0, 0]))];
 
-  @ViewChild(SourceClusterComponent)
-  cluster!: SourceClusterComponent;
+  readonly cluster = viewChild.required<SourceClusterComponent>(SourceClusterComponent);
 
-  @ViewChild(SourceVectorComponent)
-  vectorSource!: SourceVectorComponent;
+  readonly vectorSource = viewChild.required<SourceVectorComponent>(SourceVectorComponent);
 
-  @ViewChild(LayerVectorImageComponent)
-  layer!: LayerVectorImageComponent;
+  readonly layer = viewChild.required<LayerVectorImageComponent>(LayerVectorImageComponent);
 }
 
 describe('SourceClusterComponent', () => {
@@ -55,12 +52,12 @@ describe('SourceClusterComponent', () => {
   });
 
   it('binds the nested vector source into the cluster source through the template', () => {
-    expect(fixture.componentInstance.cluster.instance.getSource()).toBe(
-      fixture.componentInstance.vectorSource.instance,
+    expect(fixture.componentInstance.cluster().instance.getSource()).toBe(
+      fixture.componentInstance.vectorSource().instance,
     );
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.cluster.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.cluster().instance,
     );
-    expect(fixture.componentInstance.cluster.instance.getDistance()).toBe(20);
+    expect(fixture.componentInstance.cluster().instance.getDistance()).toBe(20);
   });
 });

--- a/projects/ngx-ol/src/lib/sources/cluster.component.ts
+++ b/projects/ngx-ol/src/lib/sources/cluster.component.ts
@@ -26,11 +26,11 @@ import { LayerVectorImageComponent } from '../layers/layervectorimage.component'
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceClusterComponent) }],
 })
 export class SourceClusterComponent extends SourceComponent implements AfterContentInit, OnChanges {
-  distance = input<number>();
-  minDistance = input<number>();
-  geometryFunction = input<(feature: Feature) => Point>();
-  wrapX = input<boolean>();
-  createCluster = input<any>();
+  readonly distance = input<number>();
+  readonly minDistance = input<number>();
+  readonly geometryFunction = input<(feature: Feature) => Point>();
+  readonly wrapX = input<boolean>();
+  readonly createCluster = input<any>();
 
   protected readonly sourceVectorComponent = contentChild(SourceVectorComponent);
 

--- a/projects/ngx-ol/src/lib/sources/cluster.component.ts
+++ b/projects/ngx-ol/src/lib/sources/cluster.component.ts
@@ -66,8 +66,16 @@ export class SourceClusterComponent extends SourceComponent implements AfterCont
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    super.ngOnChanges(changes);
     if (this.instance && changes.hasOwnProperty('distance') && this.distance() !== undefined) {
       this.instance.setDistance(this.distance()!);
+    }
+    if (
+      this.instance &&
+      changes.hasOwnProperty('minDistance') &&
+      this.minDistance() !== undefined
+    ) {
+      this.instance.setMinDistance(this.minDistance()!);
     }
   }
 

--- a/projects/ngx-ol/src/lib/sources/cluster.component.ts
+++ b/projects/ngx-ol/src/lib/sources/cluster.component.ts
@@ -1,12 +1,12 @@
 import {
   AfterContentInit,
   Component,
-  ContentChild,
   forwardRef,
   Host,
   OnChanges,
   Optional,
   SimpleChanges,
+  contentChild,
   input,
   signal,
 } from '@angular/core';
@@ -33,8 +33,7 @@ export class SourceClusterComponent extends SourceComponent implements AfterCont
   wrapX = input<boolean>();
   createCluster = input<any>();
 
-  @ContentChild(SourceVectorComponent, { static: false })
-  sourceVectorComponent: SourceVectorComponent;
+  protected readonly sourceVectorComponent = contentChild(SourceVectorComponent);
 
   instance: Cluster<any>;
 
@@ -59,7 +58,11 @@ export class SourceClusterComponent extends SourceComponent implements AfterCont
   }
 
   ngAfterContentInit() {
-    this.source = this.sourceVectorComponent.instance;
+    const sourceVectorComponent = this.sourceVectorComponent();
+
+    if (sourceVectorComponent) {
+      this.source = sourceVectorComponent.instance;
+    }
 
     this.setInstance(new Cluster(this.createOptions()));
     this.host.instance.setSource(this.instance);

--- a/projects/ngx-ol/src/lib/sources/cluster.component.ts
+++ b/projects/ngx-ol/src/lib/sources/cluster.component.ts
@@ -1,12 +1,11 @@
 import {
   AfterContentInit,
   Component,
-  forwardRef,
-  Host,
   OnChanges,
-  Optional,
   SimpleChanges,
   contentChild,
+  forwardRef,
+  inject,
   input,
   signal,
 } from '@angular/core';
@@ -50,11 +49,11 @@ export class SourceClusterComponent extends SourceComponent implements AfterCont
   }
   source: Vector<any>;
 
-  constructor(
-    @Optional() @Host() vectorLayer: LayerVectorComponent,
-    @Optional() @Host() vectorImageLayer: LayerVectorImageComponent,
-  ) {
-    super(vectorLayer || vectorImageLayer);
+  constructor() {
+    super(
+      inject(LayerVectorComponent, { optional: true, host: true }) ||
+        inject(LayerVectorImageComponent, { optional: true, host: true })!,
+    );
   }
 
   ngAfterContentInit() {

--- a/projects/ngx-ol/src/lib/sources/cluster.component.ts
+++ b/projects/ngx-ol/src/lib/sources/cluster.component.ts
@@ -4,10 +4,11 @@ import {
   ContentChild,
   forwardRef,
   Host,
-  Input,
   OnChanges,
   Optional,
   SimpleChanges,
+  input,
+  signal,
 } from '@angular/core';
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
@@ -26,21 +27,28 @@ import { LayerVectorImageComponent } from '../layers/layervectorimage.component'
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceClusterComponent) }],
 })
 export class SourceClusterComponent extends SourceComponent implements AfterContentInit, OnChanges {
-  @Input()
-  distance?: number;
-  @Input()
-  minDistance?: number;
-  @Input()
-  geometryFunction?: (feature: Feature) => Point;
-  @Input()
-  wrapX?: boolean;
-  @Input()
-  createCluster?: any;
+  distance = input<number>();
+  minDistance = input<number>();
+  geometryFunction = input<(feature: Feature) => Point>();
+  wrapX = input<boolean>();
+  createCluster = input<any>();
 
   @ContentChild(SourceVectorComponent, { static: false })
   sourceVectorComponent: SourceVectorComponent;
 
   instance: Cluster<any>;
+
+  protected readonly _instanceSignal = signal<Cluster<any> | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Cluster<any>): Cluster<any> {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   source: Vector<any>;
 
   constructor(
@@ -53,23 +61,23 @@ export class SourceClusterComponent extends SourceComponent implements AfterCont
   ngAfterContentInit() {
     this.source = this.sourceVectorComponent.instance;
 
-    this.instance = new Cluster(this.createOptions());
+    this.setInstance(new Cluster(this.createOptions()));
     this.host.instance.setSource(this.instance);
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.instance && changes.hasOwnProperty('distance') && this.distance !== undefined) {
-      this.instance.setDistance(this.distance);
+    if (this.instance && changes.hasOwnProperty('distance') && this.distance() !== undefined) {
+      this.instance.setDistance(this.distance()!);
     }
   }
 
   private createOptions(): Options<any> {
     return {
-      distance: this.distance,
-      minDistance: this.minDistance,
-      geometryFunction: this.geometryFunction,
-      wrapX: this.wrapX,
-      createCluster: this.createCluster,
+      distance: this.distance(),
+      minDistance: this.minDistance(),
+      geometryFunction: this.geometryFunction(),
+      wrapX: this.wrapX(),
+      createCluster: this.createCluster(),
       source: this.source,
     };
   }

--- a/projects/ngx-ol/src/lib/sources/geojson.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/geojson.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -10,10 +10,7 @@ import { SourceGeoJSONComponent } from './geojson.component';
     <aol-map width="320px" height="240px">
       <aol-view [center]="center" [zoom]="zoom"></aol-view>
       <aol-layer-vectorimage>
-        <aol-source-geojson
-          [url]="url"
-          [geometryName]="geometryName"
-        ></aol-source-geojson>
+        <aol-source-geojson [url]="url" [geometryName]="geometryName"></aol-source-geojson>
       </aol-layer-vectorimage>
     </aol-map>
   `,
@@ -26,11 +23,9 @@ class SourceGeoJsonHostComponent {
   url = 'https://example.com/features.geojson';
   geometryName = 'geom';
 
-  @ViewChild(SourceGeoJSONComponent)
-  source!: SourceGeoJSONComponent;
+  readonly source = viewChild.required<SourceGeoJSONComponent>(SourceGeoJSONComponent);
 
-  @ViewChild(LayerVectorImageComponent)
-  layer!: LayerVectorImageComponent;
+  readonly layer = viewChild.required<LayerVectorImageComponent>(LayerVectorImageComponent);
 }
 
 describe('SourceGeoJSONComponent', () => {
@@ -50,8 +45,8 @@ describe('SourceGeoJSONComponent', () => {
   });
 
   it('binds a GeoJSON-backed vector source into the vector image layer', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/sources/geojson.component.ts
+++ b/projects/ngx-ol/src/lib/sources/geojson.component.ts
@@ -1,4 +1,4 @@
-import { Component, Host, OnInit, Optional, forwardRef, input, signal } from '@angular/core';
+import { Component, OnInit, forwardRef, inject, input, signal } from '@angular/core';
 import { LayerVectorComponent } from '../layers/layervector.component';
 import { SourceComponent } from './source.component';
 import FeatureFormat from 'ol/format/Feature';
@@ -35,11 +35,11 @@ export class SourceGeoJSONComponent extends SourceComponent implements OnInit {
   }
   format: FeatureFormat;
 
-  constructor(
-    @Optional() @Host() vectorLayer: LayerVectorComponent,
-    @Optional() @Host() vectorImageLayer: LayerVectorImageComponent,
-  ) {
-    super(vectorLayer || vectorImageLayer);
+  constructor() {
+    super(
+      inject(LayerVectorComponent, { optional: true, host: true }) ||
+        inject(LayerVectorImageComponent, { optional: true, host: true })!,
+    );
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/sources/geojson.component.ts
+++ b/projects/ngx-ol/src/lib/sources/geojson.component.ts
@@ -15,10 +15,10 @@ import { Options as VectorOptions } from 'ol/source/Vector';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceGeoJSONComponent) }],
 })
 export class SourceGeoJSONComponent extends SourceComponent implements OnInit {
-  defaultDataProjection = input<ProjectionLike>();
-  featureProjection = input<ProjectionLike>();
-  geometryName = input<string>();
-  url = input<string>();
+  readonly defaultDataProjection = input<ProjectionLike>();
+  readonly featureProjection = input<ProjectionLike>();
+  readonly geometryName = input<string>();
+  readonly url = input<string>();
 
   instance: Vector;
 

--- a/projects/ngx-ol/src/lib/sources/geojson.component.ts
+++ b/projects/ngx-ol/src/lib/sources/geojson.component.ts
@@ -1,4 +1,4 @@
-import { Component, Host, Input, OnInit, Optional, forwardRef } from '@angular/core';
+import { Component, Host, OnInit, Optional, forwardRef, input, signal } from '@angular/core';
 import { LayerVectorComponent } from '../layers/layervector.component';
 import { SourceComponent } from './source.component';
 import FeatureFormat from 'ol/format/Feature';
@@ -15,16 +15,24 @@ import { Options as VectorOptions } from 'ol/source/Vector';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceGeoJSONComponent) }],
 })
 export class SourceGeoJSONComponent extends SourceComponent implements OnInit {
-  @Input()
-  defaultDataProjection: ProjectionLike;
-  @Input()
-  featureProjection: ProjectionLike;
-  @Input()
-  geometryName: string;
-  @Input()
-  url: string;
+  defaultDataProjection = input<ProjectionLike>();
+  featureProjection = input<ProjectionLike>();
+  geometryName = input<string>();
+  url = input<string>();
 
   instance: Vector;
+
+  protected readonly _instanceSignal = signal<Vector | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Vector): Vector {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   format: FeatureFormat;
 
   constructor(
@@ -36,23 +44,23 @@ export class SourceGeoJSONComponent extends SourceComponent implements OnInit {
 
   ngOnInit() {
     this.format = new GeoJSON(this.createFormatOptions());
-    this.instance = new Vector(this.createVectorOptions());
+    this.setInstance(new Vector(this.createVectorOptions()));
     this.host.instance.setSource(this.instance);
   }
 
   private createFormatOptions(): GeoJSONOptions {
     return {
-      dataProjection: this.defaultDataProjection,
-      featureProjection: this.featureProjection,
-      geometryName: this.geometryName,
+      dataProjection: this.defaultDataProjection(),
+      featureProjection: this.featureProjection(),
+      geometryName: this.geometryName(),
     };
   }
 
   private createVectorOptions(): VectorOptions {
     return {
-      attributions: this.attributions,
+      attributions: this.attributions(),
       format: this.format,
-      url: this.url,
+      url: this.url(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/iiif.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/iiif.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -23,11 +23,9 @@ class SourceIiifHostComponent {
   url = 'https://example.com/iiif';
   size: [number, number] = [1024, 1024];
 
-  @ViewChild(SourceIIIFComponent)
-  source!: SourceIIIFComponent;
+  readonly source = viewChild.required<SourceIIIFComponent>(SourceIIIFComponent);
 
-  @ViewChild(LayerTileComponent)
-  layer!: LayerTileComponent;
+  readonly layer = viewChild.required<LayerTileComponent>(LayerTileComponent);
 }
 
 describe('SourceIIIFComponent', () => {
@@ -47,8 +45,8 @@ describe('SourceIIIFComponent', () => {
   });
 
   it('binds an IIIF source into the tile layer through template inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/sources/iiif.component.ts
+++ b/projects/ngx-ol/src/lib/sources/iiif.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, Host, OnInit, Optional, input, signal } from '@angular/core';
+import { Component, forwardRef, OnInit, input, signal, inject } from '@angular/core';
 import type { NearestDirectionFunction } from 'ol/array';
 import type { Extent } from 'ol/extent';
 import type { ProjectionLike } from 'ol/proj';
@@ -66,8 +66,8 @@ export class SourceIIIFComponent extends SourceComponent implements OnInit {
 
     return instance;
   }
-  constructor(@Optional() @Host() layer?: LayerTileComponent) {
-    super(layer!);
+  constructor() {
+    super(inject(LayerTileComponent, { optional: true, host: true })!);
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/sources/iiif.component.ts
+++ b/projects/ngx-ol/src/lib/sources/iiif.component.ts
@@ -15,43 +15,43 @@ import { SourceComponent } from './source.component';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceIIIFComponent) }],
 })
 export class SourceIIIFComponent extends SourceComponent implements OnInit {
-  cacheSize = input<number>();
+  readonly cacheSize = input<number>();
 
-  crossOrigin = input<string | null>();
+  readonly crossOrigin = input<string | null>();
 
-  extent = input<Extent>();
+  readonly extent = input<Extent>();
 
-  format = input<string>();
+  readonly format = input<string>();
 
-  interpolate = input<boolean>();
+  readonly interpolate = input<boolean>();
 
-  projection = input<ProjectionLike>();
+  readonly projection = input<ProjectionLike>();
 
-  quality = input<string>();
+  readonly quality = input<string>();
 
-  reprojectionErrorThreshold = input<number>();
+  readonly reprojectionErrorThreshold = input<number>();
 
-  resolutions = input<number[]>();
+  readonly resolutions = input<number[]>();
 
-  size = input.required<Size>();
+  readonly size = input.required<Size>();
 
-  sizes = input<Size[]>();
+  readonly sizes = input<Size[]>();
 
-  state = input<State>();
+  readonly state = input<State>();
 
-  supports = input<string[]>();
+  readonly supports = input<string[]>();
 
-  tilePixelRatio = input<number>();
+  readonly tilePixelRatio = input<number>();
 
-  tileSize = input<number | Size>();
+  readonly tileSize = input<number | Size>();
 
-  transition = input<number>();
+  readonly transition = input<number>();
 
-  url = input<string>();
+  readonly url = input<string>();
 
-  version = input<string>();
+  readonly version = input<string>();
 
-  zDirection = input<number | NearestDirectionFunction>();
+  readonly zDirection = input<number | NearestDirectionFunction>();
 
   instance: IIIF;
 

--- a/projects/ngx-ol/src/lib/sources/iiif.component.ts
+++ b/projects/ngx-ol/src/lib/sources/iiif.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, Host, Input, OnInit, Optional } from '@angular/core';
+import { Component, forwardRef, Host, OnInit, Optional, input, signal } from '@angular/core';
 import type { NearestDirectionFunction } from 'ol/array';
 import type { Extent } from 'ol/extent';
 import type { ProjectionLike } from 'ol/proj';
@@ -15,97 +15,89 @@ import { SourceComponent } from './source.component';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceIIIFComponent) }],
 })
 export class SourceIIIFComponent extends SourceComponent implements OnInit {
-  @Input()
-  cacheSize?: number;
+  cacheSize = input<number>();
 
-  @Input()
-  crossOrigin?: string | null;
+  crossOrigin = input<string | null>();
 
-  @Input()
-  extent?: Extent;
+  extent = input<Extent>();
 
-  @Input()
-  format?: string;
+  format = input<string>();
 
-  @Input()
-  interpolate?: boolean;
+  interpolate = input<boolean>();
 
-  @Input()
-  projection?: ProjectionLike;
+  projection = input<ProjectionLike>();
 
-  @Input()
-  quality?: string;
+  quality = input<string>();
 
-  @Input()
-  reprojectionErrorThreshold?: number;
+  reprojectionErrorThreshold = input<number>();
 
-  @Input()
-  resolutions?: number[];
+  resolutions = input<number[]>();
 
-  @Input()
-  size: Size;
+  size = input.required<Size>();
 
-  @Input()
-  sizes?: Size[];
+  sizes = input<Size[]>();
 
-  @Input()
-  state?: State;
+  state = input<State>();
 
-  @Input()
-  supports?: string[];
+  supports = input<string[]>();
 
-  @Input()
-  tilePixelRatio?: number;
+  tilePixelRatio = input<number>();
 
-  @Input()
-  tileSize?: number | Size;
+  tileSize = input<number | Size>();
 
-  @Input()
-  transition?: number;
+  transition = input<number>();
 
-  @Input()
-  url?: string;
+  url = input<string>();
 
-  @Input()
-  version?: string;
+  version = input<string>();
 
-  @Input()
-  zDirection?: number | NearestDirectionFunction;
+  zDirection = input<number | NearestDirectionFunction>();
 
   instance: IIIF;
 
+  protected readonly _instanceSignal = signal<IIIF | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: IIIF): IIIF {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Optional() @Host() layer?: LayerTileComponent) {
     super(layer!);
   }
 
   ngOnInit() {
-    this.instance = new IIIF(this.createOptions());
+    this.setInstance(new IIIF(this.createOptions()));
     this.register(this.instance);
   }
 
   private createOptions(): Options {
     return {
-      attributions: this.attributions,
-      attributionsCollapsible: this.attributionsCollapsible,
-      cacheSize: this.cacheSize,
-      crossOrigin: this.crossOrigin,
-      extent: this.extent,
-      format: this.format,
-      interpolate: this.interpolate,
-      projection: this.projection,
-      quality: this.quality,
-      reprojectionErrorThreshold: this.reprojectionErrorThreshold,
-      resolutions: this.resolutions,
-      size: this.size,
-      sizes: this.sizes,
-      state: this.state,
-      supports: this.supports,
-      tilePixelRatio: this.tilePixelRatio,
-      tileSize: this.tileSize,
-      transition: this.transition,
-      url: this.url,
-      version: this.version,
-      zDirection: this.zDirection,
+      attributions: this.attributions(),
+      attributionsCollapsible: this.attributionsCollapsible(),
+      cacheSize: this.cacheSize(),
+      crossOrigin: this.crossOrigin(),
+      extent: this.extent(),
+      format: this.format(),
+      interpolate: this.interpolate(),
+      projection: this.projection(),
+      quality: this.quality(),
+      reprojectionErrorThreshold: this.reprojectionErrorThreshold(),
+      resolutions: this.resolutions(),
+      size: this.size(),
+      sizes: this.sizes(),
+      state: this.state(),
+      supports: this.supports(),
+      tilePixelRatio: this.tilePixelRatio(),
+      tileSize: this.tileSize(),
+      transition: this.transition(),
+      url: this.url(),
+      version: this.version(),
+      zDirection: this.zDirection(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.spec.ts
@@ -25,7 +25,7 @@ class SourceImageArcGISRestHostComponent {
   center = [0, 0];
   zoom = 2;
   url = 'https://example.com/arcgis/rest/services/demo/MapServer';
-  params = signal({ LAYERS: 'show:1' });
+  params = signal<Record<string, string>>({ LAYERS: 'show:1', TIME: '2026-01-01' });
   loadStarts = 0;
 
   @ViewChild(SourceImageArcGISRestComponent)
@@ -57,16 +57,39 @@ describe('SourceImageArcGISRestComponent', () => {
     );
     expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
       LAYERS: 'show:1',
+      TIME: '2026-01-01',
     });
 
     fixture.componentInstance.source.instance.dispatchEvent('imageloadstart');
     expect(fixture.componentInstance.loadStarts).toBe(1);
 
-    fixture.componentInstance.params.set({ LAYERS: 'show:2' });
+    fixture.componentInstance.params.set({ LAYERS: 'show:2', TIME: '2026-01-01' });
     fixture.detectChanges(false);
 
     expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
       LAYERS: 'show:2',
+      TIME: '2026-01-01',
     });
+  });
+
+  it('replaces the image ArcGIS source and keeps outputs bound when params are removed', () => {
+    const source = fixture.componentInstance.source.instance;
+
+    fixture.componentInstance.params.set({ LAYERS: 'show:2' });
+    fixture.detectChanges(false);
+
+    expect(fixture.componentInstance.source.instance).not.toBe(source);
+    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
+      fixture.componentInstance.source.instance,
+    );
+    const params = fixture.componentInstance.source.instance.getParams();
+
+    expect(params).toMatchObject({
+      LAYERS: 'show:2',
+    });
+    expect(params['TIME']).toBeUndefined();
+
+    fixture.componentInstance.source.instance.dispatchEvent('imageloadstart');
+    expect(fixture.componentInstance.loadStarts).toBe(1);
   });
 });

--- a/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -28,11 +28,11 @@ class SourceImageArcGISRestHostComponent {
   params = signal<Record<string, string>>({ LAYERS: 'show:1', TIME: '2026-01-01' });
   loadStarts = 0;
 
-  @ViewChild(SourceImageArcGISRestComponent)
-  source!: SourceImageArcGISRestComponent;
+  readonly source = viewChild.required<SourceImageArcGISRestComponent>(
+    SourceImageArcGISRestComponent,
+  );
 
-  @ViewChild(LayerImageComponent)
-  layer!: LayerImageComponent;
+  readonly layer = viewChild.required<LayerImageComponent>(LayerImageComponent);
 }
 
 describe('SourceImageArcGISRestComponent', () => {
@@ -52,44 +52,44 @@ describe('SourceImageArcGISRestComponent', () => {
   });
 
   it('binds ArcGIS image params and emits image load events through Angular bindings', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
-    expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
+    expect(fixture.componentInstance.source().instance.getParams()).toMatchObject({
       LAYERS: 'show:1',
       TIME: '2026-01-01',
     });
 
-    fixture.componentInstance.source.instance.dispatchEvent('imageloadstart');
+    fixture.componentInstance.source().instance.dispatchEvent('imageloadstart');
     expect(fixture.componentInstance.loadStarts).toBe(1);
 
     fixture.componentInstance.params.set({ LAYERS: 'show:2', TIME: '2026-01-01' });
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
+    expect(fixture.componentInstance.source().instance.getParams()).toMatchObject({
       LAYERS: 'show:2',
       TIME: '2026-01-01',
     });
   });
 
   it('replaces the image ArcGIS source and keeps outputs bound when params are removed', () => {
-    const source = fixture.componentInstance.source.instance;
+    const source = fixture.componentInstance.source().instance;
 
     fixture.componentInstance.params.set({ LAYERS: 'show:2' });
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.source.instance).not.toBe(source);
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.source().instance).not.toBe(source);
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
-    const params = fixture.componentInstance.source.instance.getParams();
+    const params = fixture.componentInstance.source().instance.getParams();
 
     expect(params).toMatchObject({
       LAYERS: 'show:2',
     });
     expect(params['TIME']).toBeUndefined();
 
-    fixture.componentInstance.source.instance.dispatchEvent('imageloadstart');
+    fixture.componentInstance.source().instance.dispatchEvent('imageloadstart');
     expect(fixture.componentInstance.loadStarts).toBe(1);
   });
 });

--- a/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.ts
@@ -31,19 +31,19 @@ export class SourceImageArcGISRestComponent
   extends SourceComponent
   implements OnInit, OnChanges, OnDestroy
 {
-  projection = input<ProjectionLike | string>();
-  url = input<string>();
-  crossOrigin = input<string | null>();
-  hidpi = input<boolean>();
-  imageLoadFunction = input<LoadFunction>();
-  interpolate = input<boolean>();
-  params = input<{ [k: string]: any }>();
-  ratio = input<number>(1.5);
-  resolutions = input<number[]>();
+  readonly projection = input<ProjectionLike | string>();
+  readonly url = input<string>();
+  readonly crossOrigin = input<string | null>();
+  readonly hidpi = input<boolean>();
+  readonly imageLoadFunction = input<LoadFunction>();
+  readonly interpolate = input<boolean>();
+  readonly params = input<{ [k: string]: any }>();
+  readonly ratio = input<number>(1.5);
+  readonly resolutions = input<number[]>();
 
-  imageLoadStart = output<ImageSourceEvent>();
-  imageLoadEnd = output<ImageSourceEvent>();
-  imageLoadError = output<ImageSourceEvent>();
+  readonly imageLoadStart = output<ImageSourceEvent>();
+  readonly imageLoadEnd = output<ImageSourceEvent>();
+  readonly imageLoadError = output<ImageSourceEvent>();
 
   instance: ImageArcGISRest;
 

--- a/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.ts
@@ -1,13 +1,13 @@
 import {
   Component,
-  EventEmitter,
   forwardRef,
   Host,
-  Input,
   OnChanges,
   OnInit,
-  Output,
   SimpleChanges,
+  input,
+  output,
+  signal,
 } from '@angular/core';
 import ImageArcGISRest from 'ol/source/ImageArcGISRest';
 import { Options } from 'ol/source/ImageArcGISRest';
@@ -25,32 +25,39 @@ import { ImageSourceEvent } from 'ol/source/Image';
   ],
 })
 export class SourceImageArcGISRestComponent extends SourceComponent implements OnInit, OnChanges {
-  @Input() projection?: ProjectionLike | string;
-  @Input() url?: string;
-  @Input() crossOrigin?: string | null;
-  @Input()
-  hidpi?: boolean;
-  @Input() imageLoadFunction?: LoadFunction;
-  @Input() interpolate?: boolean;
-  @Input() params?: { [k: string]: any };
-  @Input() ratio?: number = 1.5;
-  @Input() resolutions?: number[];
+  projection = input<ProjectionLike | string>();
+  url = input<string>();
+  crossOrigin = input<string | null>();
+  hidpi = input<boolean>();
+  imageLoadFunction = input<LoadFunction>();
+  interpolate = input<boolean>();
+  params = input<{ [k: string]: any }>();
+  ratio = input<number>(1.5);
+  resolutions = input<number[]>();
 
-  @Output()
-  imageLoadStart = new EventEmitter<ImageSourceEvent>();
-  @Output()
-  imageLoadEnd = new EventEmitter<ImageSourceEvent>();
-  @Output()
-  imageLoadError = new EventEmitter<ImageSourceEvent>();
+  imageLoadStart = output<ImageSourceEvent>();
+  imageLoadEnd = output<ImageSourceEvent>();
+  imageLoadError = output<ImageSourceEvent>();
 
   instance: ImageArcGISRest;
 
+  protected readonly _instanceSignal = signal<ImageArcGISRest | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: ImageArcGISRest): ImageArcGISRest {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Host() layer: LayerImageComponent) {
     super(layer);
   }
 
   ngOnInit() {
-    this.instance = new ImageArcGISRest(this.createOptions());
+    this.setInstance(new ImageArcGISRest(this.createOptions()));
     this.host.instance.setSource(this.instance);
     this.instance.on('imageloadstart', (event: ImageSourceEvent) =>
       this.imageLoadStart.emit(event),
@@ -63,22 +70,22 @@ export class SourceImageArcGISRestComponent extends SourceComponent implements O
 
   ngOnChanges(changes: SimpleChanges) {
     if (this.instance && changes.hasOwnProperty('params')) {
-      this.instance.updateParams(this.params);
+      this.instance.updateParams(this.params());
     }
   }
 
   private createOptions(): Options {
     return {
-      attributions: this.attributions,
-      projection: this.projection,
-      url: this.url,
-      crossOrigin: this.crossOrigin,
-      hidpi: this.hidpi,
-      imageLoadFunction: this.imageLoadFunction,
-      interpolate: this.interpolate,
-      params: this.params,
-      ratio: this.ratio,
-      resolutions: this.resolutions,
+      attributions: this.attributions(),
+      projection: this.projection(),
+      url: this.url(),
+      crossOrigin: this.crossOrigin(),
+      hidpi: this.hidpi(),
+      imageLoadFunction: this.imageLoadFunction(),
+      interpolate: this.interpolate(),
+      params: this.params(),
+      ratio: this.ratio(),
+      resolutions: this.resolutions(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.ts
@@ -69,8 +69,18 @@ export class SourceImageArcGISRestComponent extends SourceComponent implements O
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    super.ngOnChanges(changes);
     if (this.instance && changes.hasOwnProperty('params')) {
       this.instance.updateParams(this.params());
+    }
+    if (this.instance && changes.imageLoadFunction?.currentValue) {
+      this.instance.setImageLoadFunction(changes.imageLoadFunction.currentValue);
+    }
+    if (this.instance && changes.url) {
+      this.instance.setUrl(changes.url.currentValue);
+    }
+    if (this.instance && changes.resolutions) {
+      this.instance.setResolutions(changes.resolutions.currentValue);
     }
   }
 

--- a/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.ts
@@ -3,6 +3,7 @@ import {
   forwardRef,
   Host,
   OnChanges,
+  OnDestroy,
   OnInit,
   SimpleChanges,
   input,
@@ -16,6 +17,8 @@ import { SourceComponent } from './source.component';
 import { ProjectionLike } from 'ol/proj';
 import { LoadFunction } from 'ol/Image';
 import { ImageSourceEvent } from 'ol/source/Image';
+import type { EventsKey } from 'ol/events';
+import { unByKey } from 'ol/Observable';
 
 @Component({
   selector: 'aol-source-imagearcgisrest',
@@ -24,7 +27,10 @@ import { ImageSourceEvent } from 'ol/source/Image';
     { provide: SourceComponent, useExisting: forwardRef(() => SourceImageArcGISRestComponent) },
   ],
 })
-export class SourceImageArcGISRestComponent extends SourceComponent implements OnInit, OnChanges {
+export class SourceImageArcGISRestComponent
+  extends SourceComponent
+  implements OnInit, OnChanges, OnDestroy
+{
   projection = input<ProjectionLike | string>();
   url = input<string>();
   crossOrigin = input<string | null>();
@@ -45,6 +51,8 @@ export class SourceImageArcGISRestComponent extends SourceComponent implements O
 
   readonly instanceSignal = this._instanceSignal.asReadonly();
 
+  private eventKeys: EventsKey[] = [];
+
   protected setInstance(instance: ImageArcGISRest): ImageArcGISRest {
     this.instance = instance;
 
@@ -57,21 +65,22 @@ export class SourceImageArcGISRestComponent extends SourceComponent implements O
   }
 
   ngOnInit() {
-    this.setInstance(new ImageArcGISRest(this.createOptions()));
-    this.host.instance.setSource(this.instance);
-    this.instance.on('imageloadstart', (event: ImageSourceEvent) =>
-      this.imageLoadStart.emit(event),
-    );
-    this.instance.on('imageloadend', (event: ImageSourceEvent) => this.imageLoadEnd.emit(event));
-    this.instance.on('imageloaderror', (event: ImageSourceEvent) =>
-      this.imageLoadError.emit(event),
-    );
+    this.setLayerSource();
   }
 
   ngOnChanges(changes: SimpleChanges) {
     super.ngOnChanges(changes);
+    if (!this.instance) {
+      return;
+    }
+
+    if (this.hasRemovedParamKeys(changes)) {
+      this.setLayerSource();
+      return;
+    }
+
     if (this.instance && changes.hasOwnProperty('params')) {
-      this.instance.updateParams(this.params());
+      this.instance.updateParams(this.params() ?? {});
     }
     if (this.instance && changes.imageLoadFunction?.currentValue) {
       this.instance.setImageLoadFunction(changes.imageLoadFunction.currentValue);
@@ -82,6 +91,11 @@ export class SourceImageArcGISRestComponent extends SourceComponent implements O
     if (this.instance && changes.resolutions) {
       this.instance.setResolutions(changes.resolutions.currentValue);
     }
+  }
+
+  ngOnDestroy() {
+    this.unbindInstanceEvents();
+    super.ngOnDestroy();
   }
 
   private createOptions(): Options {
@@ -97,5 +111,46 @@ export class SourceImageArcGISRestComponent extends SourceComponent implements O
       ratio: this.ratio(),
       resolutions: this.resolutions(),
     };
+  }
+
+  private setLayerSource(): void {
+    this.unbindInstanceEvents();
+    this.setInstance(new ImageArcGISRest(this.createOptions()));
+    this.host.instance.setSource(this.instance);
+    this.bindInstanceEvents();
+  }
+
+  private bindInstanceEvents(): void {
+    this.eventKeys = [
+      this.instance.on('imageloadstart', (event: ImageSourceEvent) =>
+        this.imageLoadStart.emit(event),
+      ),
+      this.instance.on('imageloadend', (event: ImageSourceEvent) => this.imageLoadEnd.emit(event)),
+      this.instance.on('imageloaderror', (event: ImageSourceEvent) =>
+        this.imageLoadError.emit(event),
+      ),
+    ];
+  }
+
+  private unbindInstanceEvents(): void {
+    if (!this.eventKeys.length) {
+      return;
+    }
+
+    unByKey(this.eventKeys);
+    this.eventKeys = [];
+  }
+
+  private hasRemovedParamKeys(changes: SimpleChanges): boolean {
+    if (!changes.params || changes.params.firstChange) {
+      return false;
+    }
+
+    const previousParams = changes.params.previousValue ?? {};
+    const nextParams = changes.params.currentValue ?? {};
+
+    return Object.keys(previousParams).some(
+      (key) => !Object.prototype.hasOwnProperty.call(nextParams, key),
+    );
   }
 }

--- a/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.ts
@@ -65,7 +65,7 @@ export class SourceImageArcGISRestComponent
   }
 
   ngOnInit() {
-    this.setLayerSource();
+    this.replaceInstance();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -75,7 +75,7 @@ export class SourceImageArcGISRestComponent
     }
 
     if (this.hasRemovedParamKeys(changes)) {
-      this.setLayerSource();
+      this.replaceInstance();
       return;
     }
 
@@ -113,7 +113,7 @@ export class SourceImageArcGISRestComponent
     };
   }
 
-  private setLayerSource(): void {
+  private replaceInstance(): void {
     this.unbindInstanceEvents();
     this.setInstance(new ImageArcGISRest(this.createOptions()));
     this.host.instance.setSource(this.instance);

--- a/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagearcgisrest.component.ts
@@ -1,7 +1,6 @@
 import {
   Component,
   forwardRef,
-  Host,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -9,6 +8,7 @@ import {
   input,
   output,
   signal,
+  inject,
 } from '@angular/core';
 import ImageArcGISRest from 'ol/source/ImageArcGISRest';
 import { Options } from 'ol/source/ImageArcGISRest';
@@ -60,8 +60,8 @@ export class SourceImageArcGISRestComponent
 
     return instance;
   }
-  constructor(@Host() layer: LayerImageComponent) {
-    super(layer);
+  constructor() {
+    super(inject(LayerImageComponent, { host: true }));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/sources/imagestatic.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/imagestatic.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -32,11 +32,9 @@ class SourceImageStaticHostComponent {
   imageLoadEnd = vi.fn();
   imageLoadError = vi.fn();
 
-  @ViewChild(SourceImageStaticComponent)
-  source!: SourceImageStaticComponent;
+  readonly source = viewChild.required<SourceImageStaticComponent>(SourceImageStaticComponent);
 
-  @ViewChild(LayerImageComponent)
-  layer!: LayerImageComponent;
+  readonly layer = viewChild.required<LayerImageComponent>(LayerImageComponent);
 }
 
 describe('SourceImageStaticComponent', () => {
@@ -58,15 +56,15 @@ describe('SourceImageStaticComponent', () => {
   it('binds an image static source into the image layer through template inputs', () => {
     const host = fixture!.componentInstance;
 
-    expect(host.layer.instance.getSource()).toBe(host.source.instance);
+    expect(host.layer().instance.getSource()).toBe(host.source().instance);
   });
 
   it('forwards image load events through template outputs', () => {
     const host = fixture!.componentInstance;
 
-    host.source.instance.dispatchEvent('imageloadstart');
-    host.source.instance.dispatchEvent('imageloadend');
-    host.source.instance.dispatchEvent('imageloaderror');
+    host.source().instance.dispatchEvent('imageloadstart');
+    host.source().instance.dispatchEvent('imageloadend');
+    host.source().instance.dispatchEvent('imageloaderror');
 
     expect(host.imageLoadStart).toHaveBeenCalledOnce();
     expect(host.imageLoadEnd).toHaveBeenCalledOnce();
@@ -75,21 +73,21 @@ describe('SourceImageStaticComponent', () => {
 
   it('recreates and re-registers the source when the URL binding changes', () => {
     const host = fixture!.componentInstance;
-    const previousSource = host.source.instance;
+    const previousSource = host.source().instance;
 
     host.url.set('https://example.com/updated-image.png');
 
     fixture!.detectChanges();
 
-    expect(host.source.instance).not.toBe(previousSource);
-    expect(host.layer.instance.getSource()).toBe(host.source.instance);
+    expect(host.source().instance).not.toBe(previousSource);
+    expect(host.layer().instance.getSource()).toBe(host.source().instance);
   });
 
   it('clears the image layer source when the source component is destroyed', () => {
     const host = fixture!.componentInstance;
-    const layer = host.layer.instance;
+    const layer = host.layer().instance;
 
-    expect(layer.getSource()).toBe(host.source.instance);
+    expect(layer.getSource()).toBe(host.source().instance);
 
     fixture!.destroy();
     fixture = undefined;

--- a/projects/ngx-ol/src/lib/sources/imagestatic.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagestatic.component.ts
@@ -1,13 +1,13 @@
 import {
   Component,
   Host,
-  Input,
   forwardRef,
-  Output,
-  EventEmitter,
   OnChanges,
   SimpleChanges,
   OnInit,
+  input,
+  output,
+  signal,
 } from '@angular/core';
 import ImageStatic from 'ol/source/ImageStatic';
 import { Options } from 'ol/source/ImageStatic';
@@ -26,34 +26,36 @@ import { ImageSourceEvent } from 'ol/source/Image';
   ],
 })
 export class SourceImageStaticComponent extends SourceComponent implements OnInit, OnChanges {
-  @Input()
-  projection?: ProjectionLike | string;
-  @Input()
-  imageExtent: Extent;
-  @Input()
-  url: string;
-  @Input()
-  crossOrigin?: null | string;
-  @Input()
-  imageLoadFunction?: LoadFunction;
-  @Input()
-  interpolate?: boolean;
+  projection = input<ProjectionLike | string>();
+  imageExtent = input.required<Extent>();
+  url = input.required<string>();
+  crossOrigin = input<null | string>();
+  imageLoadFunction = input<LoadFunction>();
+  interpolate = input<boolean>();
 
-  @Output()
-  imageLoadStart = new EventEmitter<ImageSourceEvent>();
-  @Output()
-  imageLoadEnd = new EventEmitter<ImageSourceEvent>();
-  @Output()
-  imageLoadError = new EventEmitter<ImageSourceEvent>();
+  imageLoadStart = output<ImageSourceEvent>();
+  imageLoadEnd = output<ImageSourceEvent>();
+  imageLoadError = output<ImageSourceEvent>();
 
   instance: ImageStatic;
 
+  protected readonly _instanceSignal = signal<ImageStatic | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: ImageStatic): ImageStatic {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Host() layer: LayerImageComponent) {
     super(layer);
   }
 
   setLayerSource(): void {
-    this.instance = new ImageStatic(this.createOptions());
+    this.setInstance(new ImageStatic(this.createOptions()));
     this.host.instance.setSource(this.instance);
     this.instance.on('imageloadstart', (event: ImageSourceEvent) =>
       this.imageLoadStart.emit(event),
@@ -77,7 +79,6 @@ export class SourceImageStaticComponent extends SourceComponent implements OnIni
       if (changes.hasOwnProperty(key)) {
         switch (key) {
           case 'url':
-            this.url = changes[key].currentValue;
             this.setLayerSource();
             break;
           default:
@@ -91,13 +92,13 @@ export class SourceImageStaticComponent extends SourceComponent implements OnIni
 
   private createOptions(): Options {
     return {
-      attributions: this.attributions,
-      projection: this.projection,
-      imageExtent: this.imageExtent,
-      url: this.url,
-      crossOrigin: this.crossOrigin,
-      imageLoadFunction: this.imageLoadFunction,
-      interpolate: this.interpolate,
+      attributions: this.attributions(),
+      projection: this.projection(),
+      imageExtent: this.imageExtent(),
+      url: this.url(),
+      crossOrigin: this.crossOrigin(),
+      imageLoadFunction: this.imageLoadFunction(),
+      interpolate: this.interpolate(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/imagestatic.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagestatic.component.ts
@@ -54,7 +54,7 @@ export class SourceImageStaticComponent extends SourceComponent implements OnIni
     super(inject(LayerImageComponent, { host: true }));
   }
 
-  setLayerSource(): void {
+  private replaceInstance(): void {
     this.setInstance(new ImageStatic(this.createOptions()));
     this.host.instance.setSource(this.instance);
     this.instance.on('imageloadstart', (event: ImageSourceEvent) =>
@@ -67,7 +67,7 @@ export class SourceImageStaticComponent extends SourceComponent implements OnIni
   }
 
   ngOnInit() {
-    this.setLayerSource();
+    this.replaceInstance();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -79,7 +79,7 @@ export class SourceImageStaticComponent extends SourceComponent implements OnIni
       if (changes.hasOwnProperty(key)) {
         switch (key) {
           case 'url':
-            this.setLayerSource();
+            this.replaceInstance();
             break;
           default:
             break;

--- a/projects/ngx-ol/src/lib/sources/imagestatic.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagestatic.component.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  Host,
   forwardRef,
   OnChanges,
   SimpleChanges,
@@ -8,6 +7,7 @@ import {
   input,
   output,
   signal,
+  inject,
 } from '@angular/core';
 import ImageStatic from 'ol/source/ImageStatic';
 import { Options } from 'ol/source/ImageStatic';
@@ -50,8 +50,8 @@ export class SourceImageStaticComponent extends SourceComponent implements OnIni
 
     return instance;
   }
-  constructor(@Host() layer: LayerImageComponent) {
-    super(layer);
+  constructor() {
+    super(inject(LayerImageComponent, { host: true }));
   }
 
   setLayerSource(): void {

--- a/projects/ngx-ol/src/lib/sources/imagestatic.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagestatic.component.ts
@@ -26,16 +26,16 @@ import { ImageSourceEvent } from 'ol/source/Image';
   ],
 })
 export class SourceImageStaticComponent extends SourceComponent implements OnInit, OnChanges {
-  projection = input<ProjectionLike | string>();
-  imageExtent = input.required<Extent>();
-  url = input.required<string>();
-  crossOrigin = input<null | string>();
-  imageLoadFunction = input<LoadFunction>();
-  interpolate = input<boolean>();
+  readonly projection = input<ProjectionLike | string>();
+  readonly imageExtent = input.required<Extent>();
+  readonly url = input.required<string>();
+  readonly crossOrigin = input<null | string>();
+  readonly imageLoadFunction = input<LoadFunction>();
+  readonly interpolate = input<boolean>();
 
-  imageLoadStart = output<ImageSourceEvent>();
-  imageLoadEnd = output<ImageSourceEvent>();
-  imageLoadError = output<ImageSourceEvent>();
+  readonly imageLoadStart = output<ImageSourceEvent>();
+  readonly imageLoadEnd = output<ImageSourceEvent>();
+  readonly imageLoadError = output<ImageSourceEvent>();
 
   instance: ImageStatic;
 

--- a/projects/ngx-ol/src/lib/sources/imagestatic.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagestatic.component.ts
@@ -71,7 +71,6 @@ export class SourceImageStaticComponent extends SourceComponent implements OnIni
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    const properties: { [index: string]: any } = {};
     if (!this.instance) {
       return;
     }
@@ -85,10 +84,8 @@ export class SourceImageStaticComponent extends SourceComponent implements OnIni
           default:
             break;
         }
-        properties[key] = changes[key].currentValue;
       }
     }
-    this.instance.setProperties(properties, false);
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/sources/imagestatic.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagestatic.component.ts
@@ -75,6 +75,7 @@ export class SourceImageStaticComponent extends SourceComponent implements OnIni
     if (!this.instance) {
       return;
     }
+    super.ngOnChanges(changes);
     for (const key in changes) {
       if (changes.hasOwnProperty(key)) {
         switch (key) {

--- a/projects/ngx-ol/src/lib/sources/imagetile.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/imagetile.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -22,11 +22,9 @@ class SourceImageTileHostComponent {
   zoom = 2;
   url = 'https://example.com/{z}/{x}/{y}.png';
 
-  @ViewChild(SourceImageTileComponent)
-  source!: SourceImageTileComponent;
+  readonly source = viewChild.required<SourceImageTileComponent>(SourceImageTileComponent);
 
-  @ViewChild(LayerWebGLTileComponent)
-  layer!: LayerWebGLTileComponent;
+  readonly layer = viewChild.required<LayerWebGLTileComponent>(LayerWebGLTileComponent);
 }
 
 describe('SourceImageTileComponent', () => {
@@ -46,8 +44,8 @@ describe('SourceImageTileComponent', () => {
   });
 
   it('binds its image tile source into the WebGL tile layer through Angular inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/sources/imagetile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagetile.component.ts
@@ -1,4 +1,14 @@
-import { Component, forwardRef, Host, Input, OnChanges, OnInit, Optional, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  forwardRef,
+  Host,
+  OnChanges,
+  OnInit,
+  Optional,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import type { ProjectionLike } from 'ol/proj';
 import type { Size } from 'ol/size';
 import ImageTileSource from 'ol/source/ImageTile';
@@ -12,59 +22,58 @@ import { SourceComponent } from './source.component';
 @Component({
   selector: 'aol-source-imagetile',
   template: ` <ng-content></ng-content> `,
-  providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceImageTileComponent) }],
+  providers: [
+    { provide: SourceComponent, useExisting: forwardRef(() => SourceImageTileComponent) },
+  ],
 })
 export class SourceImageTileComponent extends SourceComponent implements OnInit, OnChanges {
-  @Input()
-  url?: UrlLike;
+  url = input<UrlLike>();
 
-  @Input()
-  loader?: Loader;
+  loader = input<Loader>();
 
-  @Input()
-  maxZoom?: number;
+  maxZoom = input<number>();
 
-  @Input()
-  minZoom?: number;
+  minZoom = input<number>();
 
-  @Input()
-  tileSize?: number | Size;
+  tileSize = input<number | Size>();
 
-  @Input()
-  gutter?: number;
+  gutter = input<number>();
 
-  @Input()
-  maxResolution?: number;
+  maxResolution = input<number>();
 
-  @Input()
-  projection?: ProjectionLike;
+  projection = input<ProjectionLike>();
 
-  @Input()
-  tileGrid?: TileGrid;
+  tileGrid = input<TileGrid>();
 
-  @Input()
-  state?: State;
+  state = input<State>();
 
-  @Input()
-  wrapX?: boolean;
+  wrapX = input<boolean>();
 
-  @Input()
-  transition?: number;
+  transition = input<number>();
 
-  @Input()
-  interpolate?: boolean;
+  interpolate = input<boolean>();
 
-  @Input()
-  crossOrigin?: CrossOriginAttribute;
+  crossOrigin = input<CrossOriginAttribute>();
 
   instance: ImageTileSource;
 
+  protected readonly _instanceSignal = signal<ImageTileSource | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: ImageTileSource): ImageTileSource {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Optional() @Host() layer?: LayerWebGLTileComponent) {
     super(layer!);
   }
 
   ngOnInit() {
-    this.instance = new ImageTileSource(this.createOptions());
+    this.setInstance(new ImageTileSource(this.createOptions()));
     this.register(this.instance);
   }
 
@@ -76,22 +85,22 @@ export class SourceImageTileComponent extends SourceComponent implements OnInit,
 
   private createOptions(): Options {
     return {
-      url: this.url,
-      loader: this.loader,
-      attributions: this.attributions,
-      attributionsCollapsible: this.attributionsCollapsible,
-      maxZoom: this.maxZoom,
-      minZoom: this.minZoom,
-      tileSize: this.tileSize,
-      gutter: this.gutter,
-      maxResolution: this.maxResolution,
-      projection: this.projection,
-      tileGrid: this.tileGrid,
-      state: this.state,
-      wrapX: this.wrapX,
-      transition: this.transition,
-      interpolate: this.interpolate,
-      crossOrigin: this.crossOrigin,
+      url: this.url(),
+      loader: this.loader(),
+      attributions: this.attributions(),
+      attributionsCollapsible: this.attributionsCollapsible(),
+      maxZoom: this.maxZoom(),
+      minZoom: this.minZoom(),
+      tileSize: this.tileSize(),
+      gutter: this.gutter(),
+      maxResolution: this.maxResolution(),
+      projection: this.projection(),
+      tileGrid: this.tileGrid(),
+      state: this.state(),
+      wrapX: this.wrapX(),
+      transition: this.transition(),
+      interpolate: this.interpolate(),
+      crossOrigin: this.crossOrigin(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/imagetile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagetile.component.ts
@@ -78,6 +78,7 @@ export class SourceImageTileComponent extends SourceComponent implements OnInit,
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    super.ngOnChanges(changes);
     if (this.instance && changes.url?.currentValue) {
       this.instance.setUrl(changes.url.currentValue);
     }

--- a/projects/ngx-ol/src/lib/sources/imagetile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagetile.component.ts
@@ -26,33 +26,33 @@ import { SourceComponent } from './source.component';
   ],
 })
 export class SourceImageTileComponent extends SourceComponent implements OnInit, OnChanges {
-  url = input<UrlLike>();
+  readonly url = input<UrlLike>();
 
-  loader = input<Loader>();
+  readonly loader = input<Loader>();
 
-  maxZoom = input<number>();
+  readonly maxZoom = input<number>();
 
-  minZoom = input<number>();
+  readonly minZoom = input<number>();
 
-  tileSize = input<number | Size>();
+  readonly tileSize = input<number | Size>();
 
-  gutter = input<number>();
+  readonly gutter = input<number>();
 
-  maxResolution = input<number>();
+  readonly maxResolution = input<number>();
 
-  projection = input<ProjectionLike>();
+  readonly projection = input<ProjectionLike>();
 
-  tileGrid = input<TileGrid>();
+  readonly tileGrid = input<TileGrid>();
 
-  state = input<State>();
+  readonly state = input<State>();
 
-  wrapX = input<boolean>();
+  readonly wrapX = input<boolean>();
 
-  transition = input<number>();
+  readonly transition = input<number>();
 
-  interpolate = input<boolean>();
+  readonly interpolate = input<boolean>();
 
-  crossOrigin = input<CrossOriginAttribute>();
+  readonly crossOrigin = input<CrossOriginAttribute>();
 
   instance: ImageTileSource;
 

--- a/projects/ngx-ol/src/lib/sources/imagetile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagetile.component.ts
@@ -1,13 +1,12 @@
 import {
   Component,
   forwardRef,
-  Host,
   OnChanges,
   OnInit,
-  Optional,
   SimpleChanges,
   input,
   signal,
+  inject,
 } from '@angular/core';
 import type { ProjectionLike } from 'ol/proj';
 import type { Size } from 'ol/size';
@@ -68,8 +67,8 @@ export class SourceImageTileComponent extends SourceComponent implements OnInit,
 
     return instance;
   }
-  constructor(@Optional() @Host() layer?: LayerWebGLTileComponent) {
-    super(layer!);
+  constructor() {
+    super(inject(LayerWebGLTileComponent, { optional: true, host: true })!);
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/sources/imagewms.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/imagewms.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -28,11 +28,9 @@ class SourceImageWMSHostComponent {
   params = signal<Record<string, string>>({ LAYERS: 'basic', TIME: '2026-01-01' });
   loadStarts = 0;
 
-  @ViewChild(SourceImageWMSComponent)
-  source!: SourceImageWMSComponent;
+  readonly source = viewChild.required<SourceImageWMSComponent>(SourceImageWMSComponent);
 
-  @ViewChild(LayerImageComponent)
-  layer!: LayerImageComponent;
+  readonly layer = viewChild.required<LayerImageComponent>(LayerImageComponent);
 }
 
 describe('SourceImageWMSComponent', () => {
@@ -52,44 +50,44 @@ describe('SourceImageWMSComponent', () => {
   });
 
   it('binds WMS image params and emits image load events through Angular bindings', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
-    expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
+    expect(fixture.componentInstance.source().instance.getParams()).toMatchObject({
       LAYERS: 'basic',
       TIME: '2026-01-01',
     });
 
-    fixture.componentInstance.source.instance.dispatchEvent('imageloadstart');
+    fixture.componentInstance.source().instance.dispatchEvent('imageloadstart');
     expect(fixture.componentInstance.loadStarts).toBe(1);
 
     fixture.componentInstance.params.set({ LAYERS: 'updated', TIME: '2026-01-01' });
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
+    expect(fixture.componentInstance.source().instance.getParams()).toMatchObject({
       LAYERS: 'updated',
       TIME: '2026-01-01',
     });
   });
 
   it('replaces the image WMS source and keeps outputs bound when params are removed', () => {
-    const source = fixture.componentInstance.source.instance;
+    const source = fixture.componentInstance.source().instance;
 
     fixture.componentInstance.params.set({ LAYERS: 'updated' });
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.source.instance).not.toBe(source);
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.source().instance).not.toBe(source);
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
-    const params = fixture.componentInstance.source.instance.getParams();
+    const params = fixture.componentInstance.source().instance.getParams();
 
     expect(params).toMatchObject({
       LAYERS: 'updated',
     });
     expect(params['TIME']).toBeUndefined();
 
-    fixture.componentInstance.source.instance.dispatchEvent('imageloadstart');
+    fixture.componentInstance.source().instance.dispatchEvent('imageloadstart');
     expect(fixture.componentInstance.loadStarts).toBe(1);
   });
 });

--- a/projects/ngx-ol/src/lib/sources/imagewms.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/imagewms.component.spec.ts
@@ -25,7 +25,7 @@ class SourceImageWMSHostComponent {
   center = [0, 0];
   zoom = 2;
   url = 'https://example.com/wms';
-  params = signal({ LAYERS: 'basic' });
+  params = signal<Record<string, string>>({ LAYERS: 'basic', TIME: '2026-01-01' });
   loadStarts = 0;
 
   @ViewChild(SourceImageWMSComponent)
@@ -57,16 +57,39 @@ describe('SourceImageWMSComponent', () => {
     );
     expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
       LAYERS: 'basic',
+      TIME: '2026-01-01',
     });
 
     fixture.componentInstance.source.instance.dispatchEvent('imageloadstart');
     expect(fixture.componentInstance.loadStarts).toBe(1);
 
-    fixture.componentInstance.params.set({ LAYERS: 'updated' });
+    fixture.componentInstance.params.set({ LAYERS: 'updated', TIME: '2026-01-01' });
     fixture.detectChanges(false);
 
     expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
       LAYERS: 'updated',
+      TIME: '2026-01-01',
     });
+  });
+
+  it('replaces the image WMS source and keeps outputs bound when params are removed', () => {
+    const source = fixture.componentInstance.source.instance;
+
+    fixture.componentInstance.params.set({ LAYERS: 'updated' });
+    fixture.detectChanges(false);
+
+    expect(fixture.componentInstance.source.instance).not.toBe(source);
+    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
+      fixture.componentInstance.source.instance,
+    );
+    const params = fixture.componentInstance.source.instance.getParams();
+
+    expect(params).toMatchObject({
+      LAYERS: 'updated',
+    });
+    expect(params['TIME']).toBeUndefined();
+
+    fixture.componentInstance.source.instance.dispatchEvent('imageloadstart');
+    expect(fixture.componentInstance.loadStarts).toBe(1);
   });
 });

--- a/projects/ngx-ol/src/lib/sources/imagewms.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagewms.component.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  Host,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -9,6 +8,7 @@ import {
   input,
   output,
   signal,
+  inject,
 } from '@angular/core';
 import ImageWMS from 'ol/source/ImageWMS';
 import { Options } from 'ol/source/ImageWMS';
@@ -60,8 +60,8 @@ export class SourceImageWMSComponent
 
     return instance;
   }
-  constructor(@Host() layer: LayerImageComponent) {
-    super(layer);
+  constructor() {
+    super(inject(LayerImageComponent, { host: true }));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/sources/imagewms.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagewms.component.ts
@@ -69,8 +69,18 @@ export class SourceImageWMSComponent extends SourceComponent implements OnChange
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    super.ngOnChanges(changes);
     if (this.instance && changes.hasOwnProperty('params')) {
       this.instance.updateParams(this.params());
+    }
+    if (this.instance && changes.imageLoadFunction?.currentValue) {
+      this.instance.setImageLoadFunction(changes.imageLoadFunction.currentValue);
+    }
+    if (this.instance && changes.url) {
+      this.instance.setUrl(changes.url.currentValue);
+    }
+    if (this.instance && changes.resolutions) {
+      this.instance.setResolutions(changes.resolutions.currentValue);
     }
   }
 

--- a/projects/ngx-ol/src/lib/sources/imagewms.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagewms.component.ts
@@ -26,7 +26,10 @@ import { unByKey } from 'ol/Observable';
   template: ` <ng-content></ng-content> `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceImageWMSComponent) }],
 })
-export class SourceImageWMSComponent extends SourceComponent implements OnChanges, OnDestroy, OnInit {
+export class SourceImageWMSComponent
+  extends SourceComponent
+  implements OnChanges, OnDestroy, OnInit
+{
   crossOrigin = input<null | string>();
   hidpi = input<boolean>();
   serverType = input<ServerType>();

--- a/projects/ngx-ol/src/lib/sources/imagewms.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagewms.component.ts
@@ -65,7 +65,7 @@ export class SourceImageWMSComponent
   }
 
   ngOnInit() {
-    this.setLayerSource();
+    this.replaceInstance();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -75,7 +75,7 @@ export class SourceImageWMSComponent
     }
 
     if (this.hasRemovedParamKeys(changes)) {
-      this.setLayerSource();
+      this.replaceInstance();
       return;
     }
 
@@ -114,7 +114,7 @@ export class SourceImageWMSComponent
     };
   }
 
-  private setLayerSource(): void {
+  private replaceInstance(): void {
     this.unbindInstanceEvents();
     this.setInstance(new ImageWMS(this.createOptions()));
     this.host.instance.setSource(this.instance);

--- a/projects/ngx-ol/src/lib/sources/imagewms.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagewms.component.ts
@@ -30,20 +30,20 @@ export class SourceImageWMSComponent
   extends SourceComponent
   implements OnChanges, OnDestroy, OnInit
 {
-  crossOrigin = input<null | string>();
-  hidpi = input<boolean>();
-  serverType = input<ServerType>();
-  imageLoadFunction = input<LoadFunction>();
-  interpolate = input<boolean>();
-  params = input<{ [key: string]: any }>();
-  projection = input<ProjectionLike | string>();
-  ratio = input<number>();
-  resolutions = input<Array<number>>();
-  url = input<string>();
+  readonly crossOrigin = input<null | string>();
+  readonly hidpi = input<boolean>();
+  readonly serverType = input<ServerType>();
+  readonly imageLoadFunction = input<LoadFunction>();
+  readonly interpolate = input<boolean>();
+  readonly params = input<{ [key: string]: any }>();
+  readonly projection = input<ProjectionLike | string>();
+  readonly ratio = input<number>();
+  readonly resolutions = input<Array<number>>();
+  readonly url = input<string>();
 
-  imageLoadStart = output<ImageSourceEvent>();
-  imageLoadEnd = output<ImageSourceEvent>();
-  imageLoadError = output<ImageSourceEvent>();
+  readonly imageLoadStart = output<ImageSourceEvent>();
+  readonly imageLoadEnd = output<ImageSourceEvent>();
+  readonly imageLoadError = output<ImageSourceEvent>();
 
   instance: ImageWMS;
 

--- a/projects/ngx-ol/src/lib/sources/imagewms.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagewms.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   Host,
   OnChanges,
+  OnDestroy,
   OnInit,
   forwardRef,
   SimpleChanges,
@@ -17,13 +18,15 @@ import { ProjectionLike } from 'ol/proj';
 import { LoadFunction } from 'ol/Image';
 import { ImageSourceEvent } from 'ol/source/Image';
 import { ServerType } from 'ol/source/wms';
+import type { EventsKey } from 'ol/events';
+import { unByKey } from 'ol/Observable';
 
 @Component({
   selector: 'aol-source-imagewms',
   template: ` <ng-content></ng-content> `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceImageWMSComponent) }],
 })
-export class SourceImageWMSComponent extends SourceComponent implements OnChanges, OnInit {
+export class SourceImageWMSComponent extends SourceComponent implements OnChanges, OnDestroy, OnInit {
   crossOrigin = input<null | string>();
   hidpi = input<boolean>();
   serverType = input<ServerType>();
@@ -45,6 +48,8 @@ export class SourceImageWMSComponent extends SourceComponent implements OnChange
 
   readonly instanceSignal = this._instanceSignal.asReadonly();
 
+  private eventKeys: EventsKey[] = [];
+
   protected setInstance(instance: ImageWMS): ImageWMS {
     this.instance = instance;
 
@@ -57,21 +62,22 @@ export class SourceImageWMSComponent extends SourceComponent implements OnChange
   }
 
   ngOnInit() {
-    this.setInstance(new ImageWMS(this.createOptions()));
-    this.host.instance.setSource(this.instance);
-    this.instance.on('imageloadstart', (event: ImageSourceEvent) =>
-      this.imageLoadStart.emit(event),
-    );
-    this.instance.on('imageloadend', (event: ImageSourceEvent) => this.imageLoadEnd.emit(event));
-    this.instance.on('imageloaderror', (event: ImageSourceEvent) =>
-      this.imageLoadError.emit(event),
-    );
+    this.setLayerSource();
   }
 
   ngOnChanges(changes: SimpleChanges) {
     super.ngOnChanges(changes);
+    if (!this.instance) {
+      return;
+    }
+
+    if (this.hasRemovedParamKeys(changes)) {
+      this.setLayerSource();
+      return;
+    }
+
     if (this.instance && changes.hasOwnProperty('params')) {
-      this.instance.updateParams(this.params());
+      this.instance.updateParams(this.params() ?? {});
     }
     if (this.instance && changes.imageLoadFunction?.currentValue) {
       this.instance.setImageLoadFunction(changes.imageLoadFunction.currentValue);
@@ -82,6 +88,11 @@ export class SourceImageWMSComponent extends SourceComponent implements OnChange
     if (this.instance && changes.resolutions) {
       this.instance.setResolutions(changes.resolutions.currentValue);
     }
+  }
+
+  ngOnDestroy() {
+    this.unbindInstanceEvents();
+    super.ngOnDestroy();
   }
 
   private createOptions(): Options {
@@ -98,5 +109,46 @@ export class SourceImageWMSComponent extends SourceComponent implements OnChange
       resolutions: this.resolutions(),
       url: this.url(),
     };
+  }
+
+  private setLayerSource(): void {
+    this.unbindInstanceEvents();
+    this.setInstance(new ImageWMS(this.createOptions()));
+    this.host.instance.setSource(this.instance);
+    this.bindInstanceEvents();
+  }
+
+  private bindInstanceEvents(): void {
+    this.eventKeys = [
+      this.instance.on('imageloadstart', (event: ImageSourceEvent) =>
+        this.imageLoadStart.emit(event),
+      ),
+      this.instance.on('imageloadend', (event: ImageSourceEvent) => this.imageLoadEnd.emit(event)),
+      this.instance.on('imageloaderror', (event: ImageSourceEvent) =>
+        this.imageLoadError.emit(event),
+      ),
+    ];
+  }
+
+  private unbindInstanceEvents(): void {
+    if (!this.eventKeys.length) {
+      return;
+    }
+
+    unByKey(this.eventKeys);
+    this.eventKeys = [];
+  }
+
+  private hasRemovedParamKeys(changes: SimpleChanges): boolean {
+    if (!changes.params || changes.params.firstChange) {
+      return false;
+    }
+
+    const previousParams = changes.params.previousValue ?? {};
+    const nextParams = changes.params.currentValue ?? {};
+
+    return Object.keys(previousParams).some(
+      (key) => !Object.prototype.hasOwnProperty.call(nextParams, key),
+    );
   }
 }

--- a/projects/ngx-ol/src/lib/sources/imagewms.component.ts
+++ b/projects/ngx-ol/src/lib/sources/imagewms.component.ts
@@ -1,13 +1,13 @@
 import {
   Component,
   Host,
-  Input,
   OnChanges,
   OnInit,
   forwardRef,
   SimpleChanges,
-  Output,
-  EventEmitter,
+  input,
+  output,
+  signal,
 } from '@angular/core';
 import ImageWMS from 'ol/source/ImageWMS';
 import { Options } from 'ol/source/ImageWMS';
@@ -24,42 +24,40 @@ import { ServerType } from 'ol/source/wms';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceImageWMSComponent) }],
 })
 export class SourceImageWMSComponent extends SourceComponent implements OnChanges, OnInit {
-  @Input()
-  crossOrigin?: null | string;
-  @Input()
-  hidpi?: boolean;
-  @Input()
-  serverType?: ServerType;
-  @Input()
-  imageLoadFunction?: LoadFunction;
-  @Input()
-  interpolate?: boolean;
-  @Input()
-  params?: { [key: string]: any };
-  @Input()
-  projection?: ProjectionLike | string;
-  @Input()
-  ratio?: number;
-  @Input()
-  resolutions?: Array<number>;
-  @Input()
-  url?: string;
+  crossOrigin = input<null | string>();
+  hidpi = input<boolean>();
+  serverType = input<ServerType>();
+  imageLoadFunction = input<LoadFunction>();
+  interpolate = input<boolean>();
+  params = input<{ [key: string]: any }>();
+  projection = input<ProjectionLike | string>();
+  ratio = input<number>();
+  resolutions = input<Array<number>>();
+  url = input<string>();
 
-  @Output()
-  imageLoadStart = new EventEmitter<ImageSourceEvent>();
-  @Output()
-  imageLoadEnd = new EventEmitter<ImageSourceEvent>();
-  @Output()
-  imageLoadError = new EventEmitter<ImageSourceEvent>();
+  imageLoadStart = output<ImageSourceEvent>();
+  imageLoadEnd = output<ImageSourceEvent>();
+  imageLoadError = output<ImageSourceEvent>();
 
   instance: ImageWMS;
 
+  protected readonly _instanceSignal = signal<ImageWMS | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: ImageWMS): ImageWMS {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Host() layer: LayerImageComponent) {
     super(layer);
   }
 
   ngOnInit() {
-    this.instance = new ImageWMS(this.createOptions());
+    this.setInstance(new ImageWMS(this.createOptions()));
     this.host.instance.setSource(this.instance);
     this.instance.on('imageloadstart', (event: ImageSourceEvent) =>
       this.imageLoadStart.emit(event),
@@ -72,23 +70,23 @@ export class SourceImageWMSComponent extends SourceComponent implements OnChange
 
   ngOnChanges(changes: SimpleChanges) {
     if (this.instance && changes.hasOwnProperty('params')) {
-      this.instance.updateParams(this.params);
+      this.instance.updateParams(this.params());
     }
   }
 
   private createOptions(): Options {
     return {
-      attributions: this.attributions,
-      crossOrigin: this.crossOrigin,
-      hidpi: this.hidpi,
-      serverType: this.serverType,
-      imageLoadFunction: this.imageLoadFunction,
-      interpolate: this.interpolate,
-      params: this.params,
-      projection: this.projection,
-      ratio: this.ratio,
-      resolutions: this.resolutions,
-      url: this.url,
+      attributions: this.attributions(),
+      crossOrigin: this.crossOrigin(),
+      hidpi: this.hidpi(),
+      serverType: this.serverType(),
+      imageLoadFunction: this.imageLoadFunction(),
+      interpolate: this.interpolate(),
+      params: this.params(),
+      projection: this.projection(),
+      ratio: this.ratio(),
+      resolutions: this.resolutions(),
+      url: this.url(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/ogcmaptile.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/ogcmaptile.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -22,11 +22,9 @@ class SourceOgcMapTileHostComponent {
   zoom = 2;
   url = 'https://example.com/ogc-map-tiles.json';
 
-  @ViewChild(SourceOGCMapTileComponent)
-  source!: SourceOGCMapTileComponent;
+  readonly source = viewChild.required<SourceOGCMapTileComponent>(SourceOGCMapTileComponent);
 
-  @ViewChild(LayerTileComponent)
-  layer!: LayerTileComponent;
+  readonly layer = viewChild.required<LayerTileComponent>(LayerTileComponent);
 }
 
 describe('SourceOGCMapTileComponent', () => {
@@ -46,8 +44,8 @@ describe('SourceOGCMapTileComponent', () => {
   });
 
   it('binds an OGC map tile source into the tile layer through template inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/sources/ogcmaptile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/ogcmaptile.component.ts
@@ -14,18 +14,18 @@ import { LayerTileComponent } from '../layers/layertile.component';
   ],
 })
 export class SourceOGCMapTileComponent extends SourceComponent implements AfterContentInit {
-  url = input.required<string>();
-  context = input<any>();
-  mediaType = input<string>();
-  projection = input<ProjectionLike>();
-  cacheSize = input<number>();
-  crossOrigin = input<null | string>();
-  interpolate = input<boolean>();
-  reprojectionErrorThreshold = input<number>();
-  tileLoadFunction = input<LoadFunction>();
-  wrapX = input<boolean>();
-  transition = input<number>();
-  collections = input<string[]>();
+  readonly url = input.required<string>();
+  readonly context = input<any>();
+  readonly mediaType = input<string>();
+  readonly projection = input<ProjectionLike>();
+  readonly cacheSize = input<number>();
+  readonly crossOrigin = input<null | string>();
+  readonly interpolate = input<boolean>();
+  readonly reprojectionErrorThreshold = input<number>();
+  readonly tileLoadFunction = input<LoadFunction>();
+  readonly wrapX = input<boolean>();
+  readonly transition = input<number>();
+  readonly collections = input<string[]>();
 
   public instance: OGCMapTile;
 

--- a/projects/ngx-ol/src/lib/sources/ogcmaptile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/ogcmaptile.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, Component, Host, Input, forwardRef } from '@angular/core';
+import { AfterContentInit, Component, Host, forwardRef, input, signal } from '@angular/core';
 import { ProjectionLike } from 'ol/proj';
 import OGCMapTile from 'ol/source/OGCMapTile';
 import { Options } from 'ol/source/OGCMapTile';
@@ -14,45 +14,56 @@ import { LayerTileComponent } from '../layers/layertile.component';
   ],
 })
 export class SourceOGCMapTileComponent extends SourceComponent implements AfterContentInit {
-  @Input() url: string;
-  @Input() context?: any;
-  @Input() mediaType?: string;
-  @Input() projection?: ProjectionLike;
-  @Input() cacheSize?: number;
-  @Input() crossOrigin?: null | string;
-  @Input() interpolate?: boolean;
-  @Input() reprojectionErrorThreshold?: number;
-  @Input() tileLoadFunction?: LoadFunction;
-  @Input() wrapX?: boolean;
-  @Input() transition?: number;
-  @Input() collections?: string[];
+  url = input.required<string>();
+  context = input<any>();
+  mediaType = input<string>();
+  projection = input<ProjectionLike>();
+  cacheSize = input<number>();
+  crossOrigin = input<null | string>();
+  interpolate = input<boolean>();
+  reprojectionErrorThreshold = input<number>();
+  tileLoadFunction = input<LoadFunction>();
+  wrapX = input<boolean>();
+  transition = input<number>();
+  collections = input<string[]>();
 
   public instance: OGCMapTile;
 
+  protected readonly _instanceSignal = signal<OGCMapTile | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: OGCMapTile): OGCMapTile {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Host() layer: LayerTileComponent) {
     super(layer);
   }
 
   ngAfterContentInit() {
-    this.instance = new OGCMapTile(this.createOptions());
+    this.setInstance(new OGCMapTile(this.createOptions()));
     this.host.instance.setSource(this.instance);
   }
 
   private createOptions(): Options {
     return {
-      url: this.url,
-      context: this.context,
-      mediaType: this.mediaType,
-      projection: this.projection,
-      attributions: this.attributions,
-      cacheSize: this.cacheSize,
-      crossOrigin: this.crossOrigin,
-      interpolate: this.interpolate,
-      reprojectionErrorThreshold: this.reprojectionErrorThreshold,
-      tileLoadFunction: this.tileLoadFunction,
-      wrapX: this.wrapX,
-      transition: this.transition,
-      collections: this.collections,
+      url: this.url(),
+      context: this.context(),
+      mediaType: this.mediaType(),
+      projection: this.projection(),
+      attributions: this.attributions(),
+      cacheSize: this.cacheSize(),
+      crossOrigin: this.crossOrigin(),
+      interpolate: this.interpolate(),
+      reprojectionErrorThreshold: this.reprojectionErrorThreshold(),
+      tileLoadFunction: this.tileLoadFunction(),
+      wrapX: this.wrapX(),
+      transition: this.transition(),
+      collections: this.collections(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/ogcmaptile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/ogcmaptile.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, Component, Host, forwardRef, input, signal } from '@angular/core';
+import { AfterContentInit, Component, forwardRef, input, signal, inject } from '@angular/core';
 import { ProjectionLike } from 'ol/proj';
 import OGCMapTile from 'ol/source/OGCMapTile';
 import { Options } from 'ol/source/OGCMapTile';
@@ -40,8 +40,8 @@ export class SourceOGCMapTileComponent extends SourceComponent implements AfterC
 
     return instance;
   }
-  constructor(@Host() layer: LayerTileComponent) {
-    super(layer);
+  constructor() {
+    super(inject(LayerTileComponent, { host: true }));
   }
 
   ngAfterContentInit() {

--- a/projects/ngx-ol/src/lib/sources/ogcvectortile.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/ogcvectortile.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -24,11 +24,9 @@ class SourceOgcVectorTileHostComponent {
   zoom = 2;
   url = 'https://example.com/ogc-vectortiles.json';
 
-  @ViewChild(SourceOGCVectorTileComponent)
-  source!: SourceOGCVectorTileComponent;
+  readonly source = viewChild.required<SourceOGCVectorTileComponent>(SourceOGCVectorTileComponent);
 
-  @ViewChild(LayerVectorTileComponent)
-  layer!: LayerVectorTileComponent;
+  readonly layer = viewChild.required<LayerVectorTileComponent>(LayerVectorTileComponent);
 }
 
 describe('SourceOGCVectorTileComponent', () => {
@@ -48,8 +46,8 @@ describe('SourceOGCVectorTileComponent', () => {
   });
 
   it('binds an OGC vector tile source into the vector tile layer and prefers child helpers', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/sources/ogcvectortile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/ogcvectortile.component.ts
@@ -1,4 +1,12 @@
-import { Component, Host, Input, forwardRef, ContentChild, AfterContentInit } from '@angular/core';
+import {
+  Component,
+  Host,
+  forwardRef,
+  ContentChild,
+  AfterContentInit,
+  input,
+  signal,
+} from '@angular/core';
 import OGCVectorTile from 'ol/source/OGCVectorTile';
 import { Options } from 'ol/source/OGCVectorTile';
 import TileGrid from 'ol/tilegrid/TileGrid';
@@ -19,18 +27,18 @@ import FeatureFormat from 'ol/format/Feature';
   ],
 })
 export class SourceOGCVectorTileComponent extends SourceComponent implements AfterContentInit {
-  @Input() url: string;
-  @Input() context?: any;
-  @Input() mediaType?: string;
-  @Input() cacheSize?: number;
-  @Input() overlaps?: boolean;
-  @Input() projection?: ProjectionLike;
-  @Input() tileClass?: typeof VectorTile;
-  @Input() transition?: number;
-  @Input() wrapX?: boolean;
-  @Input() zDirection?: number | NearestDirectionFunction;
-  @Input() collections?: string[];
-  @Input() format?: FeatureFormat<any>;
+  url = input.required<string>();
+  context = input<any>();
+  mediaType = input<string>();
+  cacheSize = input<number>();
+  overlaps = input<boolean>();
+  projection = input<ProjectionLike>();
+  tileClass = input<typeof VectorTile>();
+  transition = input<number>();
+  wrapX = input<boolean>();
+  zDirection = input<number | NearestDirectionFunction>();
+  collections = input<string[]>();
+  format = input<FeatureFormat<any>>();
 
   @ContentChild(FormatMVTComponent, { static: false })
   formatMVTComponent: FormatMVTComponent | FormatGeoJSONComponent;
@@ -38,6 +46,18 @@ export class SourceOGCVectorTileComponent extends SourceComponent implements Aft
   formatGeoJSONComponent: FormatGeoJSONComponent;
 
   public instance: OGCVectorTile;
+
+  protected readonly _instanceSignal = signal<OGCVectorTile | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: OGCVectorTile): OGCVectorTile {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   tileGrid: TileGrid;
 
   constructor(@Host() layer: LayerVectorTileComponent) {
@@ -45,7 +65,7 @@ export class SourceOGCVectorTileComponent extends SourceComponent implements Aft
   }
 
   ngAfterContentInit() {
-    let format: FeatureFormat<any> | undefined = this.format;
+    let format: FeatureFormat<any> | undefined = this.format();
     if (this.formatMVTComponent) {
       format = this.formatMVTComponent.instance;
     }
@@ -53,26 +73,26 @@ export class SourceOGCVectorTileComponent extends SourceComponent implements Aft
       format = this.formatGeoJSONComponent.instance;
     }
 
-    this.instance = new OGCVectorTile(this.createOptions(format));
+    this.setInstance(new OGCVectorTile(this.createOptions(format)));
     this.host.instance.setSource(this.instance);
   }
 
   private createOptions(format: FeatureFormat<any> | undefined): Options<any> {
     return {
-      url: this.url,
-      context: this.context,
+      url: this.url(),
+      context: this.context(),
       format,
-      mediaType: this.mediaType,
-      attributions: this.attributions,
-      attributionsCollapsible: this.attributionsCollapsible,
-      cacheSize: this.cacheSize,
-      overlaps: this.overlaps,
-      projection: this.projection,
-      tileClass: this.tileClass,
-      transition: this.transition,
-      wrapX: this.wrapX,
-      zDirection: this.zDirection,
-      collections: this.collections,
+      mediaType: this.mediaType(),
+      attributions: this.attributions(),
+      attributionsCollapsible: this.attributionsCollapsible(),
+      cacheSize: this.cacheSize(),
+      overlaps: this.overlaps(),
+      projection: this.projection(),
+      tileClass: this.tileClass(),
+      transition: this.transition(),
+      wrapX: this.wrapX(),
+      zDirection: this.zDirection(),
+      collections: this.collections(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/ogcvectortile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/ogcvectortile.component.ts
@@ -2,8 +2,8 @@ import {
   Component,
   Host,
   forwardRef,
-  ContentChild,
   AfterContentInit,
+  contentChild,
   input,
   signal,
 } from '@angular/core';
@@ -40,10 +40,8 @@ export class SourceOGCVectorTileComponent extends SourceComponent implements Aft
   collections = input<string[]>();
   format = input<FeatureFormat<any>>();
 
-  @ContentChild(FormatMVTComponent, { static: false })
-  formatMVTComponent: FormatMVTComponent | FormatGeoJSONComponent;
-  @ContentChild(FormatGeoJSONComponent, { static: false })
-  formatGeoJSONComponent: FormatGeoJSONComponent;
+  protected readonly formatMVTComponent = contentChild(FormatMVTComponent);
+  protected readonly formatGeoJSONComponent = contentChild(FormatGeoJSONComponent);
 
   public instance: OGCVectorTile;
 
@@ -66,11 +64,14 @@ export class SourceOGCVectorTileComponent extends SourceComponent implements Aft
 
   ngAfterContentInit() {
     let format: FeatureFormat<any> | undefined = this.format();
-    if (this.formatMVTComponent) {
-      format = this.formatMVTComponent.instance;
+    const formatMVTComponent = this.formatMVTComponent();
+    const formatGeoJSONComponent = this.formatGeoJSONComponent();
+
+    if (formatMVTComponent) {
+      format = formatMVTComponent.instance;
     }
-    if (this.formatGeoJSONComponent) {
-      format = this.formatGeoJSONComponent.instance;
+    if (formatGeoJSONComponent) {
+      format = formatGeoJSONComponent.instance;
     }
 
     this.setInstance(new OGCVectorTile(this.createOptions(format)));

--- a/projects/ngx-ol/src/lib/sources/ogcvectortile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/ogcvectortile.component.ts
@@ -27,18 +27,18 @@ import FeatureFormat from 'ol/format/Feature';
   ],
 })
 export class SourceOGCVectorTileComponent extends SourceComponent implements AfterContentInit {
-  url = input.required<string>();
-  context = input<any>();
-  mediaType = input<string>();
-  cacheSize = input<number>();
-  overlaps = input<boolean>();
-  projection = input<ProjectionLike>();
-  tileClass = input<typeof VectorTile>();
-  transition = input<number>();
-  wrapX = input<boolean>();
-  zDirection = input<number | NearestDirectionFunction>();
-  collections = input<string[]>();
-  format = input<FeatureFormat<any>>();
+  readonly url = input.required<string>();
+  readonly context = input<any>();
+  readonly mediaType = input<string>();
+  readonly cacheSize = input<number>();
+  readonly overlaps = input<boolean>();
+  readonly projection = input<ProjectionLike>();
+  readonly tileClass = input<typeof VectorTile>();
+  readonly transition = input<number>();
+  readonly wrapX = input<boolean>();
+  readonly zDirection = input<number | NearestDirectionFunction>();
+  readonly collections = input<string[]>();
+  readonly format = input<FeatureFormat<any>>();
 
   protected readonly formatMVTComponent = contentChild(FormatMVTComponent);
   protected readonly formatGeoJSONComponent = contentChild(FormatGeoJSONComponent);

--- a/projects/ngx-ol/src/lib/sources/ogcvectortile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/ogcvectortile.component.ts
@@ -1,11 +1,11 @@
 import {
   Component,
-  Host,
   forwardRef,
   AfterContentInit,
   contentChild,
   input,
   signal,
+  inject,
 } from '@angular/core';
 import OGCVectorTile from 'ol/source/OGCVectorTile';
 import { Options } from 'ol/source/OGCVectorTile';
@@ -58,8 +58,8 @@ export class SourceOGCVectorTileComponent extends SourceComponent implements Aft
   }
   tileGrid: TileGrid;
 
-  constructor(@Host() layer: LayerVectorTileComponent) {
-    super(layer);
+  constructor() {
+    super(inject(LayerVectorTileComponent, { host: true }));
   }
 
   ngAfterContentInit() {

--- a/projects/ngx-ol/src/lib/sources/osm.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/osm.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -22,11 +22,9 @@ class SourceOsmHostComponent {
   zoom = 2;
   url = 'https://example.com/{z}/{x}/{y}.png';
 
-  @ViewChild(SourceOsmComponent)
-  source!: SourceOsmComponent;
+  readonly source = viewChild.required<SourceOsmComponent>(SourceOsmComponent);
 
-  @ViewChild(LayerTileComponent)
-  layer!: LayerTileComponent;
+  readonly layer = viewChild.required<LayerTileComponent>(LayerTileComponent);
 }
 
 describe('SourceOsmComponent', () => {
@@ -46,8 +44,8 @@ describe('SourceOsmComponent', () => {
   });
 
   it('binds an OSM source into the tile layer through template inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/sources/osm.component.ts
+++ b/projects/ngx-ol/src/lib/sources/osm.component.ts
@@ -77,8 +77,6 @@ export class SourceOsmComponent extends SourceXYZComponent implements AfterConte
       return;
     }
 
-    const properties: { [index: string]: any } = {};
-
     for (const key in changes) {
       switch (key) {
         case 'attributions':
@@ -93,11 +91,7 @@ export class SourceOsmComponent extends SourceXYZComponent implements AfterConte
         default:
           break;
       }
-
-      properties[key] = changes[key].currentValue;
     }
-
-    this.instance.setProperties(properties, false);
   }
 
   protected override createOptions(): Options {

--- a/projects/ngx-ol/src/lib/sources/osm.component.ts
+++ b/projects/ngx-ol/src/lib/sources/osm.component.ts
@@ -62,8 +62,10 @@ export class SourceOsmComponent extends SourceXYZComponent implements AfterConte
   }
 
   ngAfterContentInit() {
-    if (this.tileGridXYZ) {
-      this.contentTileGrid = this.tileGridXYZ.instance;
+    const tileGridXYZ = this.tileGridXYZ();
+
+    if (tileGridXYZ) {
+      this.contentTileGrid = tileGridXYZ.instance;
     }
     this.setInstance(new OSM(this.createOptions()));
     this.instance.on('tileloadstart', (event: TileSourceEvent) => this.tileLoadStart.emit(event));

--- a/projects/ngx-ol/src/lib/sources/osm.component.ts
+++ b/projects/ngx-ol/src/lib/sources/osm.component.ts
@@ -3,7 +3,9 @@ import {
   Component,
   forwardRef,
   Host,
+  OnChanges,
   Optional,
+  SimpleChanges,
   input,
   output,
   signal,
@@ -22,7 +24,7 @@ import { SourceXYZComponent } from './xyz.component';
   template: ` <div class="aol-source-osm"></div> `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceOsmComponent) }],
 })
-export class SourceOsmComponent extends SourceXYZComponent implements AfterContentInit {
+export class SourceOsmComponent extends SourceXYZComponent implements AfterContentInit, OnChanges {
   cacheSize = input<number>();
   crossOrigin = input<null | string>();
   interpolate = input<boolean>();
@@ -68,6 +70,34 @@ export class SourceOsmComponent extends SourceXYZComponent implements AfterConte
     this.instance.on('tileloadend', (event: TileSourceEvent) => this.tileLoadEnd.emit(event));
     this.instance.on('tileloaderror', (event: TileSourceEvent) => this.tileLoadError.emit(event));
     this.register(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (!this.instance) {
+      return;
+    }
+
+    const properties: { [index: string]: any } = {};
+
+    for (const key in changes) {
+      switch (key) {
+        case 'attributions':
+          this.instance.setAttributions(changes[key].currentValue);
+          continue;
+        case 'tileLoadFunction':
+          this.instance.setTileLoadFunction(changes[key].currentValue);
+          continue;
+        case 'url':
+          this.instance.setUrl(changes[key].currentValue);
+          continue;
+        default:
+          break;
+      }
+
+      properties[key] = changes[key].currentValue;
+    }
+
+    this.instance.setProperties(properties, false);
   }
 
   protected override createOptions(): Options {

--- a/projects/ngx-ol/src/lib/sources/osm.component.ts
+++ b/projects/ngx-ol/src/lib/sources/osm.component.ts
@@ -1,12 +1,12 @@
 import {
   AfterContentInit,
   Component,
-  EventEmitter,
   forwardRef,
   Host,
-  Input,
   Optional,
-  Output,
+  input,
+  output,
+  signal,
 } from '@angular/core';
 import OSM from 'ol/source/OSM';
 import { Options } from 'ol/source/OSM';
@@ -23,36 +23,34 @@ import { SourceXYZComponent } from './xyz.component';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceOsmComponent) }],
 })
 export class SourceOsmComponent extends SourceXYZComponent implements AfterContentInit {
-  @Input()
-  cacheSize?: number;
-  @Input()
-  crossOrigin?: string;
-  @Input()
-  interpolate?: boolean;
-  @Input()
-  maxZoom?: number;
-  @Input()
-  reprojectionErrorThreshold?: number;
-  @Input()
-  tileLoadFunction?: LoadFunction;
-  @Input()
-  transition?: number;
-  @Input()
-  url?: string;
-  @Input()
-  wrapX?: boolean;
-  @Input()
-  zDirection?: number | NearestDirectionFunction;
+  cacheSize = input<number>();
+  crossOrigin = input<null | string>();
+  interpolate = input<boolean>();
+  maxZoom = input<number>();
+  reprojectionErrorThreshold = input<number>();
+  tileLoadFunction = input<LoadFunction>();
+  transition = input<number>();
+  url = input<string>();
+  wrapX = input<boolean>();
+  zDirection = input<number | NearestDirectionFunction>();
 
-  @Output()
-  tileLoadStart = new EventEmitter<TileSourceEvent>();
-  @Output()
-  tileLoadEnd = new EventEmitter<TileSourceEvent>();
-  @Output()
-  tileLoadError = new EventEmitter<TileSourceEvent>();
+  tileLoadStart = output<TileSourceEvent>();
+  tileLoadEnd = output<TileSourceEvent>();
+  tileLoadError = output<TileSourceEvent>();
 
   instance: OSM;
 
+  protected readonly _instanceSignal = signal<OSM | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: OSM): OSM {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(
     @Optional()
     @Host()
@@ -63,9 +61,9 @@ export class SourceOsmComponent extends SourceXYZComponent implements AfterConte
 
   ngAfterContentInit() {
     if (this.tileGridXYZ) {
-      this.tileGrid = this.tileGridXYZ.instance;
+      this.contentTileGrid = this.tileGridXYZ.instance;
     }
-    this.instance = new OSM(this.createOptions());
+    this.setInstance(new OSM(this.createOptions()));
     this.instance.on('tileloadstart', (event: TileSourceEvent) => this.tileLoadStart.emit(event));
     this.instance.on('tileloadend', (event: TileSourceEvent) => this.tileLoadEnd.emit(event));
     this.instance.on('tileloaderror', (event: TileSourceEvent) => this.tileLoadError.emit(event));
@@ -74,17 +72,17 @@ export class SourceOsmComponent extends SourceXYZComponent implements AfterConte
 
   protected override createOptions(): Options {
     return {
-      attributions: this.attributions,
-      cacheSize: this.cacheSize,
-      crossOrigin: this.crossOrigin,
-      interpolate: this.interpolate,
-      maxZoom: this.maxZoom,
-      reprojectionErrorThreshold: this.reprojectionErrorThreshold,
-      tileLoadFunction: this.tileLoadFunction,
-      transition: this.transition,
-      url: this.url,
-      wrapX: this.wrapX,
-      zDirection: this.zDirection,
+      attributions: this.attributions(),
+      cacheSize: this.cacheSize(),
+      crossOrigin: this.crossOrigin(),
+      interpolate: this.interpolate(),
+      maxZoom: this.maxZoom(),
+      reprojectionErrorThreshold: this.reprojectionErrorThreshold(),
+      tileLoadFunction: this.tileLoadFunction(),
+      transition: this.transition(),
+      url: this.url(),
+      wrapX: this.wrapX(),
+      zDirection: this.zDirection(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/osm.component.ts
+++ b/projects/ngx-ol/src/lib/sources/osm.component.ts
@@ -2,13 +2,12 @@ import {
   AfterContentInit,
   Component,
   forwardRef,
-  Host,
   OnChanges,
-  Optional,
   SimpleChanges,
   input,
   output,
   signal,
+  inject,
 } from '@angular/core';
 import OSM from 'ol/source/OSM';
 import { Options } from 'ol/source/OSM';
@@ -53,12 +52,8 @@ export class SourceOsmComponent extends SourceXYZComponent implements AfterConte
 
     return instance;
   }
-  constructor(
-    @Optional()
-    @Host()
-    protected layer?: LayerTileComponent,
-  ) {
-    super(layer);
+  constructor() {
+    super();
   }
 
   ngAfterContentInit() {

--- a/projects/ngx-ol/src/lib/sources/osm.component.ts
+++ b/projects/ngx-ol/src/lib/sources/osm.component.ts
@@ -7,14 +7,12 @@ import {
   input,
   output,
   signal,
-  inject,
 } from '@angular/core';
 import OSM from 'ol/source/OSM';
 import { Options } from 'ol/source/OSM';
 import { TileSourceEvent } from 'ol/source/Tile';
 import { LoadFunction } from 'ol/Tile';
 import { NearestDirectionFunction } from 'ol/array';
-import { LayerTileComponent } from '../layers/layertile.component';
 import { SourceComponent } from './source.component';
 import { SourceXYZComponent } from './xyz.component';
 
@@ -24,20 +22,20 @@ import { SourceXYZComponent } from './xyz.component';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceOsmComponent) }],
 })
 export class SourceOsmComponent extends SourceXYZComponent implements AfterContentInit, OnChanges {
-  cacheSize = input<number>();
-  crossOrigin = input<null | string>();
-  interpolate = input<boolean>();
-  maxZoom = input<number>();
-  reprojectionErrorThreshold = input<number>();
-  tileLoadFunction = input<LoadFunction>();
-  transition = input<number>();
-  url = input<string>();
-  wrapX = input<boolean>();
-  zDirection = input<number | NearestDirectionFunction>();
+  readonly cacheSize = input<number>();
+  readonly crossOrigin = input<null | string>();
+  readonly interpolate = input<boolean>();
+  readonly maxZoom = input<number>();
+  readonly reprojectionErrorThreshold = input<number>();
+  readonly tileLoadFunction = input<LoadFunction>();
+  readonly transition = input<number>();
+  readonly url = input<string>();
+  readonly wrapX = input<boolean>();
+  readonly zDirection = input<number | NearestDirectionFunction>();
 
-  tileLoadStart = output<TileSourceEvent>();
-  tileLoadEnd = output<TileSourceEvent>();
-  tileLoadError = output<TileSourceEvent>();
+  readonly tileLoadStart = output<TileSourceEvent>();
+  readonly tileLoadEnd = output<TileSourceEvent>();
+  readonly tileLoadError = output<TileSourceEvent>();
 
   instance: OSM;
 

--- a/projects/ngx-ol/src/lib/sources/raster.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/raster.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -12,10 +12,7 @@ import { SourceImageStaticComponent } from './imagestatic.component';
       <aol-view [center]="center" [zoom]="zoom"></aol-view>
       <aol-layer-image>
         <aol-source-raster>
-          <aol-source-imagestatic
-            [url]="url"
-            [imageExtent]="imageExtent"
-          ></aol-source-imagestatic>
+          <aol-source-imagestatic [url]="url" [imageExtent]="imageExtent"></aol-source-imagestatic>
         </aol-source-raster>
       </aol-layer-image>
     </aol-map>
@@ -29,14 +26,13 @@ class SourceRasterHostComponent {
   url = 'https://example.com/image.png';
   imageExtent: [number, number, number, number] = [0, 0, 10, 10];
 
-  @ViewChild(SourceRasterComponent)
-  source!: SourceRasterComponent;
+  readonly source = viewChild.required<SourceRasterComponent>(SourceRasterComponent);
 
-  @ViewChild(SourceImageStaticComponent)
-  nestedSource!: SourceImageStaticComponent;
+  readonly nestedSource = viewChild.required<SourceImageStaticComponent>(
+    SourceImageStaticComponent,
+  );
 
-  @ViewChild(LayerImageComponent)
-  layer!: LayerImageComponent;
+  readonly layer = viewChild.required<LayerImageComponent>(LayerImageComponent);
 }
 
 describe('SourceRasterComponent', () => {
@@ -56,11 +52,11 @@ describe('SourceRasterComponent', () => {
   });
 
   it('binds a raster source into the image layer and uses its nested source helper', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
-    expect(fixture.componentInstance.source.sources).toEqual([
-      fixture.componentInstance.nestedSource.instance,
+    expect(fixture.componentInstance.source().sources).toEqual([
+      fixture.componentInstance.nestedSource().instance,
     ]);
   });
 });

--- a/projects/ngx-ol/src/lib/sources/raster.component.ts
+++ b/projects/ngx-ol/src/lib/sources/raster.component.ts
@@ -1,9 +1,9 @@
 import {
   AfterContentInit,
   Component,
-  ContentChild,
   OnChanges,
   SimpleChanges,
+  contentChild,
   forwardRef,
   Host,
   input,
@@ -52,20 +52,19 @@ export class SourceRasterComponent extends SourceComponent implements AfterConte
   }
   sources: Source[] = [];
 
-  @ContentChild(SourceComponent, { static: false })
-  set source(sourceComponent: SourceComponent) {
-    this.sources = [sourceComponent.instance];
-    if (this.instance) {
-      // Openlayer doesn't handle sources update. Just recreate Raster instance.
-      this.init();
-    }
-  }
+  protected readonly sourceComponent = contentChild(SourceComponent);
 
   constructor(@Host() layer: LayerImageComponent) {
     super(layer);
   }
 
   ngAfterContentInit() {
+    const sourceComponent = this.sourceComponent();
+
+    if (sourceComponent) {
+      this.sources = [sourceComponent.instance];
+    }
+
     this.init();
   }
 

--- a/projects/ngx-ol/src/lib/sources/raster.component.ts
+++ b/projects/ngx-ol/src/lib/sources/raster.component.ts
@@ -2,11 +2,11 @@ import {
   AfterContentInit,
   Component,
   ContentChild,
-  EventEmitter,
   forwardRef,
   Host,
-  Input,
-  Output,
+  input,
+  output,
+  signal,
 } from '@angular/core';
 import Raster from 'ol/source/Raster';
 import Source from 'ol/source/Source';
@@ -26,23 +26,28 @@ import { SourceComponent } from './source.component';
   ],
 })
 export class SourceRasterComponent extends SourceComponent implements AfterContentInit {
-  @Input()
-  operation?: Operation;
-  @Input()
-  threads?: number;
-  @Input()
-  lib?: any;
-  @Input()
-  operationType?: 'pixel' | 'image';
-  @Input()
-  resolutions?: number[] | null;
+  operation = input<Operation>();
+  threads = input<number>();
+  lib = input<any>();
+  operationType = input<'pixel' | 'image'>();
+  resolutions = input<number[] | null>();
 
-  @Output()
-  beforeOperations = new EventEmitter<RasterSourceEvent>();
-  @Output()
-  afterOperations = new EventEmitter<RasterSourceEvent>();
+  beforeOperations = output<RasterSourceEvent>();
+  afterOperations = output<RasterSourceEvent>();
 
   instance: Raster;
+
+  protected readonly _instanceSignal = signal<Raster | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Raster): Raster {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   sources: Source[] = [];
 
   @ContentChild(SourceComponent, { static: false })
@@ -63,7 +68,7 @@ export class SourceRasterComponent extends SourceComponent implements AfterConte
   }
 
   init() {
-    this.instance = new Raster(this.createOptions());
+    this.setInstance(new Raster(this.createOptions()));
     this.instance.on('beforeoperations', (event: RasterSourceEvent) =>
       this.beforeOperations.emit(event),
     );
@@ -76,11 +81,11 @@ export class SourceRasterComponent extends SourceComponent implements AfterConte
   private createOptions(): Options {
     return {
       sources: this.sources,
-      operation: this.operation,
-      threads: this.threads,
-      lib: this.lib,
-      operationType: this.operationType,
-      resolutions: this.resolutions,
+      operation: this.operation(),
+      threads: this.threads(),
+      lib: this.lib(),
+      operationType: this.operationType(),
+      resolutions: this.resolutions(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/raster.component.ts
+++ b/projects/ngx-ol/src/lib/sources/raster.component.ts
@@ -2,6 +2,8 @@ import {
   AfterContentInit,
   Component,
   ContentChild,
+  OnChanges,
+  SimpleChanges,
   forwardRef,
   Host,
   input,
@@ -25,7 +27,7 @@ import { SourceComponent } from './source.component';
     },
   ],
 })
-export class SourceRasterComponent extends SourceComponent implements AfterContentInit {
+export class SourceRasterComponent extends SourceComponent implements AfterContentInit, OnChanges {
   operation = input<Operation>();
   threads = input<number>();
   lib = input<any>();
@@ -65,6 +67,13 @@ export class SourceRasterComponent extends SourceComponent implements AfterConte
 
   ngAfterContentInit() {
     this.init();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    super.ngOnChanges(changes);
+    if (this.instance && changes.operation?.currentValue) {
+      this.instance.setOperation(changes.operation.currentValue, this.lib());
+    }
   }
 
   init() {

--- a/projects/ngx-ol/src/lib/sources/raster.component.ts
+++ b/projects/ngx-ol/src/lib/sources/raster.component.ts
@@ -5,10 +5,10 @@ import {
   SimpleChanges,
   contentChild,
   forwardRef,
-  Host,
   input,
   output,
   signal,
+  inject,
 } from '@angular/core';
 import Raster from 'ol/source/Raster';
 import Source from 'ol/source/Source';
@@ -54,8 +54,8 @@ export class SourceRasterComponent extends SourceComponent implements AfterConte
 
   protected readonly sourceComponent = contentChild(SourceComponent);
 
-  constructor(@Host() layer: LayerImageComponent) {
-    super(layer);
+  constructor() {
+    super(inject(LayerImageComponent, { host: true }));
   }
 
   ngAfterContentInit() {

--- a/projects/ngx-ol/src/lib/sources/raster.component.ts
+++ b/projects/ngx-ol/src/lib/sources/raster.component.ts
@@ -28,14 +28,14 @@ import { SourceComponent } from './source.component';
   ],
 })
 export class SourceRasterComponent extends SourceComponent implements AfterContentInit, OnChanges {
-  operation = input<Operation>();
-  threads = input<number>();
-  lib = input<any>();
-  operationType = input<'pixel' | 'image'>();
-  resolutions = input<number[] | null>();
+  readonly operation = input<Operation>();
+  readonly threads = input<number>();
+  readonly lib = input<any>();
+  readonly operationType = input<'pixel' | 'image'>();
+  readonly resolutions = input<number[] | null>();
 
-  beforeOperations = output<RasterSourceEvent>();
-  afterOperations = output<RasterSourceEvent>();
+  readonly beforeOperations = output<RasterSourceEvent>();
+  readonly afterOperations = output<RasterSourceEvent>();
 
   instance: Raster;
 

--- a/projects/ngx-ol/src/lib/sources/raster.component.ts
+++ b/projects/ngx-ol/src/lib/sources/raster.component.ts
@@ -65,7 +65,7 @@ export class SourceRasterComponent extends SourceComponent implements AfterConte
       this.sources = [sourceComponent.instance];
     }
 
-    this.init();
+    this.initializeInstance();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -75,7 +75,7 @@ export class SourceRasterComponent extends SourceComponent implements AfterConte
     }
   }
 
-  init() {
+  initializeInstance() {
     this.setInstance(new Raster(this.createOptions()));
     this.instance.on('beforeoperations', (event: RasterSourceEvent) =>
       this.beforeOperations.emit(event),

--- a/projects/ngx-ol/src/lib/sources/source.component.ts
+++ b/projects/ngx-ol/src/lib/sources/source.component.ts
@@ -6,9 +6,9 @@ import { LayerComponent } from '../layers/layer.component';
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export abstract class SourceComponent implements OnChanges, OnDestroy {
-  attributions = input<AttributionLike>();
+  readonly attributions = input<AttributionLike>();
 
-  attributionsCollapsible = input<boolean>();
+  readonly attributionsCollapsible = input<boolean>();
 
   public instance: Source;
 
@@ -23,9 +23,9 @@ export abstract class SourceComponent implements OnChanges, OnDestroy {
 
     return instance;
   }
-  public componentType = 'source';
+  readonly componentType: string = 'source';
 
-  protected constructor(protected host: LayerComponent) {}
+  protected constructor(protected readonly host: LayerComponent) {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (!this.instance) {

--- a/projects/ngx-ol/src/lib/sources/source.component.ts
+++ b/projects/ngx-ol/src/lib/sources/source.component.ts
@@ -1,11 +1,11 @@
-import { OnDestroy, Directive, input, signal } from '@angular/core';
+import { OnChanges, OnDestroy, Directive, SimpleChanges, input, signal } from '@angular/core';
 import Source, { AttributionLike } from 'ol/source/Source';
 
 import { LayerComponent } from '../layers/layer.component';
 
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
-export abstract class SourceComponent implements OnDestroy {
+export abstract class SourceComponent implements OnChanges, OnDestroy {
   attributions = input<AttributionLike>();
 
   attributionsCollapsible = input<boolean>();
@@ -26,6 +26,16 @@ export abstract class SourceComponent implements OnDestroy {
   public componentType = 'source';
 
   protected constructor(protected host: LayerComponent) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (!this.instance) {
+      return;
+    }
+
+    if (changes.attributions) {
+      this.instance.setAttributions(changes.attributions.currentValue);
+    }
+  }
 
   ngOnDestroy() {
     if (this.host && this.host.instance) {

--- a/projects/ngx-ol/src/lib/sources/source.component.ts
+++ b/projects/ngx-ol/src/lib/sources/source.component.ts
@@ -1,4 +1,4 @@
-import { Input, OnDestroy, Directive } from '@angular/core';
+import { OnDestroy, Directive, input, signal } from '@angular/core';
 import Source, { AttributionLike } from 'ol/source/Source';
 
 import { LayerComponent } from '../layers/layer.component';
@@ -6,13 +6,23 @@ import { LayerComponent } from '../layers/layer.component';
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export abstract class SourceComponent implements OnDestroy {
-  @Input()
-  attributions?: AttributionLike;
+  attributions = input<AttributionLike>();
 
-  @Input()
-  attributionsCollapsible?: boolean;
+  attributionsCollapsible = input<boolean>();
 
   public instance: Source;
+
+  protected readonly _instanceSignal = signal<Source | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Source): Source {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   public componentType = 'source';
 
   protected constructor(protected host: LayerComponent) {}

--- a/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, signal, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -10,7 +10,7 @@ import { SourceTileArcGISRestComponent } from './tilearcgisrest.component';
     <aol-map width="320px" height="240px">
       <aol-view [center]="center" [zoom]="zoom"></aol-view>
       <aol-layer-tile>
-        <aol-source-tilearcgisrest [url]="url" [params]="params"></aol-source-tilearcgisrest>
+        <aol-source-tilearcgisrest [url]="url" [params]="params()"></aol-source-tilearcgisrest>
       </aol-layer-tile>
     </aol-map>
   `,
@@ -21,7 +21,7 @@ class SourceTileArcGISRestHostComponent {
   center = [0, 0];
   zoom = 2;
   url = 'https://example.com/arcgis/rest/services/demo/MapServer';
-  params = { LAYERS: 'show:1' };
+  params = signal<Record<string, string>>({ LAYERS: 'show:1', TIME: '2026-01-01' });
 
   @ViewChild(SourceTileArcGISRestComponent)
   source!: SourceTileArcGISRestComponent;
@@ -52,6 +52,38 @@ describe('SourceTileArcGISRestComponent', () => {
     );
     expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
       LAYERS: 'show:1',
+      TIME: '2026-01-01',
     });
+  });
+
+  it('updates retained ArcGIS REST params without replacing the source', () => {
+    const source = fixture.componentInstance.source.instance;
+
+    fixture.componentInstance.params.set({ LAYERS: 'show:2', TIME: '2026-01-01' });
+    fixture.detectChanges(false);
+
+    expect(fixture.componentInstance.source.instance).toBe(source);
+    expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
+      LAYERS: 'show:2',
+      TIME: '2026-01-01',
+    });
+  });
+
+  it('replaces the source when removed ArcGIS REST params would otherwise stay merged', () => {
+    const source = fixture.componentInstance.source.instance;
+
+    fixture.componentInstance.params.set({ LAYERS: 'show:2' });
+    fixture.detectChanges(false);
+
+    expect(fixture.componentInstance.source.instance).not.toBe(source);
+    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
+      fixture.componentInstance.source.instance,
+    );
+    const params = fixture.componentInstance.source.instance.getParams();
+
+    expect(params).toMatchObject({
+      LAYERS: 'show:2',
+    });
+    expect(params['TIME']).toBeUndefined();
   });
 });

--- a/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -23,11 +23,11 @@ class SourceTileArcGISRestHostComponent {
   url = 'https://example.com/arcgis/rest/services/demo/MapServer';
   params = signal<Record<string, string>>({ LAYERS: 'show:1', TIME: '2026-01-01' });
 
-  @ViewChild(SourceTileArcGISRestComponent)
-  source!: SourceTileArcGISRestComponent;
+  readonly source = viewChild.required<SourceTileArcGISRestComponent>(
+    SourceTileArcGISRestComponent,
+  );
 
-  @ViewChild(LayerTileComponent)
-  layer!: LayerTileComponent;
+  readonly layer = viewChild.required<LayerTileComponent>(LayerTileComponent);
 }
 
 describe('SourceTileArcGISRestComponent', () => {
@@ -47,39 +47,39 @@ describe('SourceTileArcGISRestComponent', () => {
   });
 
   it('binds ArcGIS REST params into the layer source through Angular inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
-    expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
+    expect(fixture.componentInstance.source().instance.getParams()).toMatchObject({
       LAYERS: 'show:1',
       TIME: '2026-01-01',
     });
   });
 
   it('updates retained ArcGIS REST params without replacing the source', () => {
-    const source = fixture.componentInstance.source.instance;
+    const source = fixture.componentInstance.source().instance;
 
     fixture.componentInstance.params.set({ LAYERS: 'show:2', TIME: '2026-01-01' });
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.source.instance).toBe(source);
-    expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
+    expect(fixture.componentInstance.source().instance).toBe(source);
+    expect(fixture.componentInstance.source().instance.getParams()).toMatchObject({
       LAYERS: 'show:2',
       TIME: '2026-01-01',
     });
   });
 
   it('replaces the source when removed ArcGIS REST params would otherwise stay merged', () => {
-    const source = fixture.componentInstance.source.instance;
+    const source = fixture.componentInstance.source().instance;
 
     fixture.componentInstance.params.set({ LAYERS: 'show:2' });
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.source.instance).not.toBe(source);
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.source().instance).not.toBe(source);
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
-    const params = fixture.componentInstance.source.instance.getParams();
+    const params = fixture.componentInstance.source().instance.getParams();
 
     expect(params).toMatchObject({
       LAYERS: 'show:2',

--- a/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.ts
@@ -1,12 +1,12 @@
 import {
   Component,
   forwardRef,
-  Host,
   OnChanges,
   OnInit,
   SimpleChanges,
   input,
   signal,
+  inject,
 } from '@angular/core';
 import type { NearestDirectionFunction } from 'ol/array';
 import type { ProjectionLike } from 'ol/proj';
@@ -66,8 +66,8 @@ export class SourceTileArcGISRestComponent extends SourceComponent implements On
 
     return instance;
   }
-  constructor(@Host() layer: LayerTileComponent) {
-    super(layer);
+  constructor() {
+    super(inject(LayerTileComponent, { host: true }));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.ts
@@ -25,33 +25,33 @@ import { SourceComponent } from './source.component';
   ],
 })
 export class SourceTileArcGISRestComponent extends SourceComponent implements OnInit, OnChanges {
-  cacheSize = input<number>();
+  readonly cacheSize = input<number>();
 
-  crossOrigin = input<string | null>();
+  readonly crossOrigin = input<string | null>();
 
-  interpolate = input<boolean>();
+  readonly interpolate = input<boolean>();
 
-  params = input<{ [key: string]: any }>();
+  readonly params = input<{ [key: string]: any }>();
 
-  hidpi = input<boolean>();
+  readonly hidpi = input<boolean>();
 
-  tileGrid = input<TileGrid>();
+  readonly tileGrid = input<TileGrid>();
 
-  projection = input<ProjectionLike>();
+  readonly projection = input<ProjectionLike>();
 
-  reprojectionErrorThreshold = input<number>();
+  readonly reprojectionErrorThreshold = input<number>();
 
-  tileLoadFunction = input<LoadFunction>();
+  readonly tileLoadFunction = input<LoadFunction>();
 
-  url = input<string>();
+  readonly url = input<string>();
 
-  wrapX = input<boolean>();
+  readonly wrapX = input<boolean>();
 
-  transition = input<number>();
+  readonly transition = input<number>();
 
-  urls = input<string[]>();
+  readonly urls = input<string[]>();
 
-  zDirection = input<number | NearestDirectionFunction>();
+  readonly zDirection = input<number | NearestDirectionFunction>();
 
   instance: TileArcGISRest;
 

--- a/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.ts
@@ -71,14 +71,22 @@ export class SourceTileArcGISRestComponent extends SourceComponent implements On
   }
 
   ngOnInit() {
-    this.setInstance(new TileArcGISRest(this.createOptions()));
-    this.host.instance.setSource(this.instance);
+    this.setLayerSource();
   }
 
   ngOnChanges(changes: SimpleChanges) {
     super.ngOnChanges(changes);
-    if (this.instance && changes.hasOwnProperty('params') && this.params()) {
-      this.instance.updateParams(this.params());
+    if (!this.instance) {
+      return;
+    }
+
+    if (this.hasRemovedParamKeys(changes)) {
+      this.setLayerSource();
+      return;
+    }
+
+    if (this.instance && changes.hasOwnProperty('params')) {
+      this.instance.updateParams(this.params() ?? {});
     }
     if (this.instance && changes.tileLoadFunction?.currentValue) {
       this.instance.setTileLoadFunction(changes.tileLoadFunction.currentValue);
@@ -109,5 +117,23 @@ export class SourceTileArcGISRestComponent extends SourceComponent implements On
       urls: this.urls(),
       zDirection: this.zDirection(),
     };
+  }
+
+  private setLayerSource(): void {
+    this.setInstance(new TileArcGISRest(this.createOptions()));
+    this.host.instance.setSource(this.instance);
+  }
+
+  private hasRemovedParamKeys(changes: SimpleChanges): boolean {
+    if (!changes.params || changes.params.firstChange) {
+      return false;
+    }
+
+    const previousParams = changes.params.previousValue ?? {};
+    const nextParams = changes.params.currentValue ?? {};
+
+    return Object.keys(previousParams).some(
+      (key) => !Object.prototype.hasOwnProperty.call(nextParams, key),
+    );
   }
 }

--- a/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.ts
@@ -2,10 +2,11 @@ import {
   Component,
   forwardRef,
   Host,
-  Input,
   OnChanges,
   OnInit,
   SimpleChanges,
+  input,
+  signal,
 } from '@angular/core';
 import type { NearestDirectionFunction } from 'ol/array';
 import type { ProjectionLike } from 'ol/proj';
@@ -19,85 +20,84 @@ import { SourceComponent } from './source.component';
 @Component({
   selector: 'aol-source-tilearcgisrest',
   template: ` <ng-content></ng-content> `,
-  providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceTileArcGISRestComponent) }],
+  providers: [
+    { provide: SourceComponent, useExisting: forwardRef(() => SourceTileArcGISRestComponent) },
+  ],
 })
 export class SourceTileArcGISRestComponent extends SourceComponent implements OnInit, OnChanges {
-  @Input()
-  cacheSize?: number;
+  cacheSize = input<number>();
 
-  @Input()
-  crossOrigin?: string | null;
+  crossOrigin = input<string | null>();
 
-  @Input()
-  interpolate?: boolean;
+  interpolate = input<boolean>();
 
-  @Input()
-  params?: { [key: string]: any };
+  params = input<{ [key: string]: any }>();
 
-  @Input()
-  hidpi?: boolean;
+  hidpi = input<boolean>();
 
-  @Input()
-  tileGrid?: TileGrid;
+  tileGrid = input<TileGrid>();
 
-  @Input()
-  projection?: ProjectionLike;
+  projection = input<ProjectionLike>();
 
-  @Input()
-  reprojectionErrorThreshold?: number;
+  reprojectionErrorThreshold = input<number>();
 
-  @Input()
-  tileLoadFunction?: LoadFunction;
+  tileLoadFunction = input<LoadFunction>();
 
-  @Input()
-  url?: string;
+  url = input<string>();
 
-  @Input()
-  wrapX?: boolean;
+  wrapX = input<boolean>();
 
-  @Input()
-  transition?: number;
+  transition = input<number>();
 
-  @Input()
-  urls?: string[];
+  urls = input<string[]>();
 
-  @Input()
-  zDirection?: number | NearestDirectionFunction;
+  zDirection = input<number | NearestDirectionFunction>();
 
   instance: TileArcGISRest;
 
+  protected readonly _instanceSignal = signal<TileArcGISRest | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: TileArcGISRest): TileArcGISRest {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Host() layer: LayerTileComponent) {
     super(layer);
   }
 
   ngOnInit() {
-    this.instance = new TileArcGISRest(this.createOptions());
+    this.setInstance(new TileArcGISRest(this.createOptions()));
     this.host.instance.setSource(this.instance);
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.instance && changes.hasOwnProperty('params') && this.params) {
-      this.instance.updateParams(this.params);
+    if (this.instance && changes.hasOwnProperty('params') && this.params()) {
+      this.instance.updateParams(this.params());
     }
   }
 
   private createOptions(): Options {
     return {
-      attributions: this.attributions,
-      cacheSize: this.cacheSize,
-      crossOrigin: this.crossOrigin,
-      interpolate: this.interpolate,
-      params: this.params,
-      hidpi: this.hidpi,
-      tileGrid: this.tileGrid,
-      projection: this.projection,
-      reprojectionErrorThreshold: this.reprojectionErrorThreshold,
-      tileLoadFunction: this.tileLoadFunction,
-      url: this.url,
-      wrapX: this.wrapX,
-      transition: this.transition,
-      urls: this.urls,
-      zDirection: this.zDirection,
+      attributions: this.attributions(),
+      cacheSize: this.cacheSize(),
+      crossOrigin: this.crossOrigin(),
+      interpolate: this.interpolate(),
+      params: this.params(),
+      hidpi: this.hidpi(),
+      tileGrid: this.tileGrid(),
+      projection: this.projection(),
+      reprojectionErrorThreshold: this.reprojectionErrorThreshold(),
+      tileLoadFunction: this.tileLoadFunction(),
+      url: this.url(),
+      wrapX: this.wrapX(),
+      transition: this.transition(),
+      urls: this.urls(),
+      zDirection: this.zDirection(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.ts
@@ -71,7 +71,7 @@ export class SourceTileArcGISRestComponent extends SourceComponent implements On
   }
 
   ngOnInit() {
-    this.setLayerSource();
+    this.replaceInstance();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -81,7 +81,7 @@ export class SourceTileArcGISRestComponent extends SourceComponent implements On
     }
 
     if (this.hasRemovedParamKeys(changes)) {
-      this.setLayerSource();
+      this.replaceInstance();
       return;
     }
 
@@ -119,7 +119,7 @@ export class SourceTileArcGISRestComponent extends SourceComponent implements On
     };
   }
 
-  private setLayerSource(): void {
+  private replaceInstance(): void {
     this.setInstance(new TileArcGISRest(this.createOptions()));
     this.host.instance.setSource(this.instance);
   }

--- a/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilearcgisrest.component.ts
@@ -76,8 +76,18 @@ export class SourceTileArcGISRestComponent extends SourceComponent implements On
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    super.ngOnChanges(changes);
     if (this.instance && changes.hasOwnProperty('params') && this.params()) {
       this.instance.updateParams(this.params());
+    }
+    if (this.instance && changes.tileLoadFunction?.currentValue) {
+      this.instance.setTileLoadFunction(changes.tileLoadFunction.currentValue);
+    }
+    if (this.instance && changes.url?.currentValue) {
+      this.instance.setUrl(changes.url.currentValue);
+    }
+    if (this.instance && changes.urls?.currentValue) {
+      this.instance.setUrls(changes.urls.currentValue);
     }
   }
 

--- a/projects/ngx-ol/src/lib/sources/tilejson.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/tilejson.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { Config } from 'ol/source/TileJSON';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -27,11 +27,9 @@ class SourceTileJSONHostComponent {
     maxzoom: 3,
   };
 
-  @ViewChild(SourceTileJSONComponent)
-  source!: SourceTileJSONComponent;
+  readonly source = viewChild.required<SourceTileJSONComponent>(SourceTileJSONComponent);
 
-  @ViewChild(LayerTileComponent)
-  layer!: LayerTileComponent;
+  readonly layer = viewChild.required<LayerTileComponent>(LayerTileComponent);
 }
 
 describe('SourceTileJSONComponent', () => {
@@ -51,10 +49,10 @@ describe('SourceTileJSONComponent', () => {
   });
 
   it('binds TileJSON configuration into the tile layer through Angular inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
-    expect(fixture.componentInstance.source.instance.getTileJSON()).toEqual(
+    expect(fixture.componentInstance.source().instance.getTileJSON()).toEqual(
       fixture.componentInstance.tileJSON,
     );
   });

--- a/projects/ngx-ol/src/lib/sources/tilejson.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilejson.component.ts
@@ -1,4 +1,4 @@
-import { Component, Host, Input, OnInit, forwardRef } from '@angular/core';
+import { Component, Host, OnInit, forwardRef, input, signal } from '@angular/core';
 import TileJSON from 'ol/source/TileJSON';
 import { Config, Options } from 'ol/source/TileJSON';
 import { LoadFunction } from 'ol/Tile';
@@ -13,57 +13,56 @@ import { SourceComponent } from './source.component';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceTileJSONComponent) }],
 })
 export class SourceTileJSONComponent extends SourceComponent implements OnInit {
-  @Input()
-  cacheSize?: number;
-  @Input()
-  crossOrigin?: string | null;
-  @Input()
-  interpolate?: boolean;
-  @Input()
-  jsonp?: boolean;
-  @Input()
-  reprojectionErrorThreshold?: number;
-  @Input()
-  tileJSON?: Config;
-  @Input()
-  tileLoadFunction?: LoadFunction;
-  @Input()
-  tileSize?: number | Size;
-  @Input()
-  url?: string;
-  @Input()
-  wrapX?: boolean;
-  @Input()
-  transition?: number;
-  @Input()
-  zDirection?: number | NearestDirectionFunction;
+  cacheSize = input<number>();
+  crossOrigin = input<string | null>();
+  interpolate = input<boolean>();
+  jsonp = input<boolean>();
+  reprojectionErrorThreshold = input<number>();
+  tileJSON = input<Config>();
+  tileLoadFunction = input<LoadFunction>();
+  tileSize = input<number | Size>();
+  url = input<string>();
+  wrapX = input<boolean>();
+  transition = input<number>();
+  zDirection = input<number | NearestDirectionFunction>();
 
   instance: TileJSON;
 
+  protected readonly _instanceSignal = signal<TileJSON | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: TileJSON): TileJSON {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Host() layer: LayerTileComponent) {
     super(layer);
   }
 
   ngOnInit() {
-    this.instance = new TileJSON(this.createOptions());
+    this.setInstance(new TileJSON(this.createOptions()));
     this.host.instance.setSource(this.instance);
   }
 
   private createOptions(): Options {
     return {
-      attributions: this.attributions,
-      cacheSize: this.cacheSize,
-      crossOrigin: this.crossOrigin,
-      interpolate: this.interpolate,
-      jsonp: this.jsonp,
-      reprojectionErrorThreshold: this.reprojectionErrorThreshold,
-      tileJSON: this.tileJSON,
-      tileLoadFunction: this.tileLoadFunction,
-      tileSize: this.tileSize,
-      url: this.url,
-      wrapX: this.wrapX,
-      transition: this.transition,
-      zDirection: this.zDirection,
+      attributions: this.attributions(),
+      cacheSize: this.cacheSize(),
+      crossOrigin: this.crossOrigin(),
+      interpolate: this.interpolate(),
+      jsonp: this.jsonp(),
+      reprojectionErrorThreshold: this.reprojectionErrorThreshold(),
+      tileJSON: this.tileJSON(),
+      tileLoadFunction: this.tileLoadFunction(),
+      tileSize: this.tileSize(),
+      url: this.url(),
+      wrapX: this.wrapX(),
+      transition: this.transition(),
+      zDirection: this.zDirection(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/tilejson.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilejson.component.ts
@@ -13,18 +13,18 @@ import { SourceComponent } from './source.component';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceTileJSONComponent) }],
 })
 export class SourceTileJSONComponent extends SourceComponent implements OnInit {
-  cacheSize = input<number>();
-  crossOrigin = input<string | null>();
-  interpolate = input<boolean>();
-  jsonp = input<boolean>();
-  reprojectionErrorThreshold = input<number>();
-  tileJSON = input<Config>();
-  tileLoadFunction = input<LoadFunction>();
-  tileSize = input<number | Size>();
-  url = input<string>();
-  wrapX = input<boolean>();
-  transition = input<number>();
-  zDirection = input<number | NearestDirectionFunction>();
+  readonly cacheSize = input<number>();
+  readonly crossOrigin = input<string | null>();
+  readonly interpolate = input<boolean>();
+  readonly jsonp = input<boolean>();
+  readonly reprojectionErrorThreshold = input<number>();
+  readonly tileJSON = input<Config>();
+  readonly tileLoadFunction = input<LoadFunction>();
+  readonly tileSize = input<number | Size>();
+  readonly url = input<string>();
+  readonly wrapX = input<boolean>();
+  readonly transition = input<number>();
+  readonly zDirection = input<number | NearestDirectionFunction>();
 
   instance: TileJSON;
 

--- a/projects/ngx-ol/src/lib/sources/tilejson.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilejson.component.ts
@@ -1,4 +1,4 @@
-import { Component, Host, OnInit, forwardRef, input, signal } from '@angular/core';
+import { Component, OnInit, forwardRef, input, signal, inject } from '@angular/core';
 import TileJSON from 'ol/source/TileJSON';
 import { Config, Options } from 'ol/source/TileJSON';
 import { LoadFunction } from 'ol/Tile';
@@ -39,8 +39,8 @@ export class SourceTileJSONComponent extends SourceComponent implements OnInit {
 
     return instance;
   }
-  constructor(@Host() layer: LayerTileComponent) {
-    super(layer);
+  constructor() {
+    super(inject(LayerTileComponent, { host: true }));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/sources/tilewms.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewms.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -23,11 +23,9 @@ class SourceTileWMSHostComponent {
   url = 'https://example.com/wms';
   params = signal<Record<string, string>>({ LAYERS: 'basic', TIME: '2026-01-01' });
 
-  @ViewChild(SourceTileWMSComponent)
-  source!: SourceTileWMSComponent;
+  readonly source = viewChild.required<SourceTileWMSComponent>(SourceTileWMSComponent);
 
-  @ViewChild(LayerTileComponent)
-  layer!: LayerTileComponent;
+  readonly layer = viewChild.required<LayerTileComponent>(LayerTileComponent);
 }
 
 describe('SourceTileWMSComponent', () => {
@@ -47,39 +45,39 @@ describe('SourceTileWMSComponent', () => {
   });
 
   it('binds WMS params into the layer source through Angular inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
-    expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
+    expect(fixture.componentInstance.source().instance.getParams()).toMatchObject({
       LAYERS: 'basic',
       TIME: '2026-01-01',
     });
   });
 
   it('updates retained WMS params without replacing the source', () => {
-    const source = fixture.componentInstance.source.instance;
+    const source = fixture.componentInstance.source().instance;
 
     fixture.componentInstance.params.set({ LAYERS: 'updated', TIME: '2026-01-01' });
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.source.instance).toBe(source);
-    expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
+    expect(fixture.componentInstance.source().instance).toBe(source);
+    expect(fixture.componentInstance.source().instance.getParams()).toMatchObject({
       LAYERS: 'updated',
       TIME: '2026-01-01',
     });
   });
 
   it('replaces the source when removed WMS params would otherwise stay merged', () => {
-    const source = fixture.componentInstance.source.instance;
+    const source = fixture.componentInstance.source().instance;
 
     fixture.componentInstance.params.set({ LAYERS: 'updated' });
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.source.instance).not.toBe(source);
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.source().instance).not.toBe(source);
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
-    const params = fixture.componentInstance.source.instance.getParams();
+    const params = fixture.componentInstance.source().instance.getParams();
 
     expect(params).toMatchObject({
       LAYERS: 'updated',

--- a/projects/ngx-ol/src/lib/sources/tilewms.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewms.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, signal, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -10,7 +10,7 @@ import { SourceTileWMSComponent } from './tilewms.component';
     <aol-map width="320px" height="240px">
       <aol-view [center]="center" [zoom]="zoom"></aol-view>
       <aol-layer-tile>
-        <aol-source-tilewms [url]="url" [params]="params"></aol-source-tilewms>
+        <aol-source-tilewms [url]="url" [params]="params()"></aol-source-tilewms>
       </aol-layer-tile>
     </aol-map>
   `,
@@ -21,7 +21,7 @@ class SourceTileWMSHostComponent {
   center = [0, 0];
   zoom = 2;
   url = 'https://example.com/wms';
-  params = { LAYERS: 'basic' };
+  params = signal<Record<string, string>>({ LAYERS: 'basic', TIME: '2026-01-01' });
 
   @ViewChild(SourceTileWMSComponent)
   source!: SourceTileWMSComponent;
@@ -52,6 +52,38 @@ describe('SourceTileWMSComponent', () => {
     );
     expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
       LAYERS: 'basic',
+      TIME: '2026-01-01',
     });
+  });
+
+  it('updates retained WMS params without replacing the source', () => {
+    const source = fixture.componentInstance.source.instance;
+
+    fixture.componentInstance.params.set({ LAYERS: 'updated', TIME: '2026-01-01' });
+    fixture.detectChanges(false);
+
+    expect(fixture.componentInstance.source.instance).toBe(source);
+    expect(fixture.componentInstance.source.instance.getParams()).toMatchObject({
+      LAYERS: 'updated',
+      TIME: '2026-01-01',
+    });
+  });
+
+  it('replaces the source when removed WMS params would otherwise stay merged', () => {
+    const source = fixture.componentInstance.source.instance;
+
+    fixture.componentInstance.params.set({ LAYERS: 'updated' });
+    fixture.detectChanges(false);
+
+    expect(fixture.componentInstance.source.instance).not.toBe(source);
+    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
+      fixture.componentInstance.source.instance,
+    );
+    const params = fixture.componentInstance.source.instance.getParams();
+
+    expect(params).toMatchObject({
+      LAYERS: 'updated',
+    });
+    expect(params['TIME']).toBeUndefined();
   });
 });

--- a/projects/ngx-ol/src/lib/sources/tilewms.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewms.component.ts
@@ -66,8 +66,18 @@ export class SourceTileWMSComponent extends SourceComponent implements OnChanges
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    super.ngOnChanges(changes);
     if (this.instance && changes.hasOwnProperty('params')) {
       this.instance.updateParams(this.params());
+    }
+    if (this.instance && changes.tileLoadFunction?.currentValue) {
+      this.instance.setTileLoadFunction(changes.tileLoadFunction.currentValue);
+    }
+    if (this.instance && changes.url?.currentValue) {
+      this.instance.setUrl(changes.url.currentValue);
+    }
+    if (this.instance && changes.urls?.currentValue) {
+      this.instance.setUrls(changes.urls.currentValue);
     }
   }
 

--- a/projects/ngx-ol/src/lib/sources/tilewms.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewms.component.ts
@@ -61,7 +61,7 @@ export class SourceTileWMSComponent extends SourceComponent implements OnChanges
   }
 
   ngOnInit() {
-    this.setLayerSource();
+    this.replaceInstance();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -71,7 +71,7 @@ export class SourceTileWMSComponent extends SourceComponent implements OnChanges
     }
 
     if (this.hasRemovedParamKeys(changes)) {
-      this.setLayerSource();
+      this.replaceInstance();
       return;
     }
 
@@ -113,7 +113,7 @@ export class SourceTileWMSComponent extends SourceComponent implements OnChanges
     };
   }
 
-  private setLayerSource(): void {
+  private replaceInstance(): void {
     this.setInstance(new TileWMS(this.createOptions()));
     this.host.instance.setSource(this.instance);
   }

--- a/projects/ngx-ol/src/lib/sources/tilewms.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewms.component.ts
@@ -61,12 +61,20 @@ export class SourceTileWMSComponent extends SourceComponent implements OnChanges
   }
 
   ngOnInit() {
-    this.setInstance(new TileWMS(this.createOptions()));
-    this.host.instance.setSource(this.instance);
+    this.setLayerSource();
   }
 
   ngOnChanges(changes: SimpleChanges) {
     super.ngOnChanges(changes);
+    if (!this.instance) {
+      return;
+    }
+
+    if (this.hasRemovedParamKeys(changes)) {
+      this.setLayerSource();
+      return;
+    }
+
     if (this.instance && changes.hasOwnProperty('params')) {
       this.instance.updateParams(this.params());
     }
@@ -103,5 +111,23 @@ export class SourceTileWMSComponent extends SourceComponent implements OnChanges
       transition: this.transition(),
       zDirection: this.zDirection(),
     };
+  }
+
+  private setLayerSource(): void {
+    this.setInstance(new TileWMS(this.createOptions()));
+    this.host.instance.setSource(this.instance);
+  }
+
+  private hasRemovedParamKeys(changes: SimpleChanges): boolean {
+    if (!changes.params || changes.params.firstChange) {
+      return false;
+    }
+
+    const previousParams = changes.params.previousValue ?? {};
+    const nextParams = changes.params.currentValue ?? {};
+
+    return Object.keys(previousParams).some(
+      (key) => !Object.prototype.hasOwnProperty.call(nextParams, key),
+    );
   }
 }

--- a/projects/ngx-ol/src/lib/sources/tilewms.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewms.component.ts
@@ -25,23 +25,23 @@ import { ServerType } from 'ol/source/wms';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceTileWMSComponent) }],
 })
 export class SourceTileWMSComponent extends SourceComponent implements OnChanges, OnInit {
-  cacheSize = input<number>();
-  crossOrigin = input<null | string>();
-  gutter = input<number>();
-  hidpi = input<boolean>();
-  interpolate = input<boolean>();
-  params = input.required<{ [key: string]: any }>();
-  projection = input<ProjectionLike>();
-  reprojectionErrorThreshold = input<number>();
-  serverType = input<ServerType>();
-  tileClass = input<typeof ImageTile>();
-  tileGrid = input<TileGrid>();
-  tileLoadFunction = input<LoadFunction>();
-  url = input<string>();
-  urls = input<string[]>();
-  wrapX = input<boolean>();
-  transition = input<number>();
-  zDirection = input<number | NearestDirectionFunction>();
+  readonly cacheSize = input<number>();
+  readonly crossOrigin = input<null | string>();
+  readonly gutter = input<number>();
+  readonly hidpi = input<boolean>();
+  readonly interpolate = input<boolean>();
+  readonly params = input.required<{ [key: string]: any }>();
+  readonly projection = input<ProjectionLike>();
+  readonly reprojectionErrorThreshold = input<number>();
+  readonly serverType = input<ServerType>();
+  readonly tileClass = input<typeof ImageTile>();
+  readonly tileGrid = input<TileGrid>();
+  readonly tileLoadFunction = input<LoadFunction>();
+  readonly url = input<string>();
+  readonly urls = input<string[]>();
+  readonly wrapX = input<boolean>();
+  readonly transition = input<number>();
+  readonly zDirection = input<number | NearestDirectionFunction>();
 
   instance: TileWMS;
 

--- a/projects/ngx-ol/src/lib/sources/tilewms.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewms.component.ts
@@ -1,11 +1,12 @@
 import {
   Component,
   Host,
-  Input,
   OnChanges,
   OnInit,
   forwardRef,
   SimpleChanges,
+  input,
+  signal,
 } from '@angular/core';
 import { LayerTileComponent } from '../layers/layertile.component';
 import { SourceComponent } from './source.component';
@@ -24,79 +25,73 @@ import { ServerType } from 'ol/source/wms';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceTileWMSComponent) }],
 })
 export class SourceTileWMSComponent extends SourceComponent implements OnChanges, OnInit {
-  @Input()
-  cacheSize?: number;
-  @Input()
-  crossOrigin?: null | string;
-  @Input()
-  gutter?: number;
-  @Input()
-  hidpi?: boolean;
-  @Input()
-  interpolate?: boolean;
-  @Input()
-  params: { [key: string]: any };
-  @Input()
-  projection?: ProjectionLike;
-  @Input()
-  reprojectionErrorThreshold?: number;
-  @Input()
-  serverType?: ServerType;
-  @Input()
-  tileClass?: typeof ImageTile;
-  @Input()
-  tileGrid?: TileGrid;
-  @Input()
-  tileLoadFunction?: LoadFunction;
-  @Input()
-  url?: string;
-  @Input()
-  urls?: string[];
-  @Input()
-  wrapX?: boolean;
-  @Input()
-  transition?: number;
-  @Input()
-  zDirection?: number | NearestDirectionFunction;
+  cacheSize = input<number>();
+  crossOrigin = input<null | string>();
+  gutter = input<number>();
+  hidpi = input<boolean>();
+  interpolate = input<boolean>();
+  params = input.required<{ [key: string]: any }>();
+  projection = input<ProjectionLike>();
+  reprojectionErrorThreshold = input<number>();
+  serverType = input<ServerType>();
+  tileClass = input<typeof ImageTile>();
+  tileGrid = input<TileGrid>();
+  tileLoadFunction = input<LoadFunction>();
+  url = input<string>();
+  urls = input<string[]>();
+  wrapX = input<boolean>();
+  transition = input<number>();
+  zDirection = input<number | NearestDirectionFunction>();
 
   instance: TileWMS;
 
+  protected readonly _instanceSignal = signal<TileWMS | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: TileWMS): TileWMS {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Host() layer: LayerTileComponent) {
     super(layer);
   }
 
   ngOnInit() {
-    this.instance = new TileWMS(this.createOptions());
+    this.setInstance(new TileWMS(this.createOptions()));
     this.host.instance.setSource(this.instance);
   }
 
   ngOnChanges(changes: SimpleChanges) {
     if (this.instance && changes.hasOwnProperty('params')) {
-      this.instance.updateParams(this.params);
+      this.instance.updateParams(this.params());
     }
   }
 
   private createOptions(): Options {
     return {
-      attributions: this.attributions,
-      attributionsCollapsible: this.attributionsCollapsible,
-      cacheSize: this.cacheSize,
-      crossOrigin: this.crossOrigin,
-      gutter: this.gutter,
-      hidpi: this.hidpi,
-      interpolate: this.interpolate,
-      params: this.params,
-      projection: this.projection,
-      reprojectionErrorThreshold: this.reprojectionErrorThreshold,
-      serverType: this.serverType,
-      tileClass: this.tileClass,
-      tileGrid: this.tileGrid,
-      tileLoadFunction: this.tileLoadFunction,
-      url: this.url,
-      urls: this.urls,
-      wrapX: this.wrapX,
-      transition: this.transition,
-      zDirection: this.zDirection,
+      attributions: this.attributions(),
+      attributionsCollapsible: this.attributionsCollapsible(),
+      cacheSize: this.cacheSize(),
+      crossOrigin: this.crossOrigin(),
+      gutter: this.gutter(),
+      hidpi: this.hidpi(),
+      interpolate: this.interpolate(),
+      params: this.params(),
+      projection: this.projection(),
+      reprojectionErrorThreshold: this.reprojectionErrorThreshold(),
+      serverType: this.serverType(),
+      tileClass: this.tileClass(),
+      tileGrid: this.tileGrid(),
+      tileLoadFunction: this.tileLoadFunction(),
+      url: this.url(),
+      urls: this.urls(),
+      wrapX: this.wrapX(),
+      transition: this.transition(),
+      zDirection: this.zDirection(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/tilewms.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewms.component.ts
@@ -1,12 +1,12 @@
 import {
   Component,
-  Host,
   OnChanges,
   OnInit,
   forwardRef,
   SimpleChanges,
   input,
   signal,
+  inject,
 } from '@angular/core';
 import { LayerTileComponent } from '../layers/layertile.component';
 import { SourceComponent } from './source.component';
@@ -56,8 +56,8 @@ export class SourceTileWMSComponent extends SourceComponent implements OnChanges
 
     return instance;
   }
-  constructor(@Host() layer: LayerTileComponent) {
-    super(layer);
+  constructor() {
+    super(inject(LayerTileComponent, { host: true }));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/sources/tilewmts.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewmts.component.spec.ts
@@ -15,6 +15,7 @@ import { SourceTileWMTSComponent } from './tilewmts.component';
           [layer]="layerName"
           [style]="styleName"
           [matrixSet]="matrixSet"
+          [dimensions]="dimensions()"
           [url]="url()"
           (tileLoadStart)="tileLoadStart($event)"
           (tileLoadEnd)="tileLoadEnd($event)"
@@ -38,6 +39,7 @@ class SourceTileWmtsHostComponent {
   layerName = 'demo';
   styleName = 'default';
   matrixSet = 'webmercator';
+  dimensions = signal<Record<string, string>>({ TIME: '2026-01-01', ELEVATION: '0' });
   url = signal('https://example.com/wmts');
   origin: [number, number] = [0, 0];
   resolutions = [2, 1];
@@ -101,6 +103,34 @@ describe('SourceTileWMTSComponent', () => {
 
     expect(host.source.instance).not.toBe(previousSource);
     expect(host.layer.instance.getSource()).toBe(host.source.instance);
+  });
+
+  it('updates WMTS dimensions without recreating the source when keys are retained', () => {
+    const host = fixture!.componentInstance;
+    const previousSource = host.source.instance;
+
+    host.dimensions.set({ TIME: '2026-01-02', ELEVATION: '0' });
+
+    fixture!.detectChanges();
+
+    expect(host.source.instance).toBe(previousSource);
+    expect(host.source.instance.getDimensions()).toEqual({
+      TIME: '2026-01-02',
+      ELEVATION: '0',
+    });
+  });
+
+  it('recreates the WMTS source when dimension keys are removed', () => {
+    const host = fixture!.componentInstance;
+    const previousSource = host.source.instance;
+
+    host.dimensions.set({ TIME: '2026-01-03' });
+
+    fixture!.detectChanges();
+
+    expect(host.source.instance).not.toBe(previousSource);
+    expect(host.layer.instance.getSource()).toBe(host.source.instance);
+    expect(host.source.instance.getDimensions()).toEqual({ TIME: '2026-01-03' });
   });
 
   it('clears the tile layer source when the source component is destroyed', () => {

--- a/projects/ngx-ol/src/lib/sources/tilewmts.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewmts.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -48,14 +48,11 @@ class SourceTileWmtsHostComponent {
   tileLoadEnd = vi.fn();
   tileLoadError = vi.fn();
 
-  @ViewChild(SourceTileWMTSComponent)
-  source!: SourceTileWMTSComponent;
+  readonly source = viewChild.required<SourceTileWMTSComponent>(SourceTileWMTSComponent);
 
-  @ViewChild(LayerTileComponent)
-  layer!: LayerTileComponent;
+  readonly layer = viewChild.required<LayerTileComponent>(LayerTileComponent);
 
-  @ViewChild(TileGridWMTSComponent)
-  tileGrid!: TileGridWMTSComponent;
+  readonly tileGrid = viewChild.required<TileGridWMTSComponent>(TileGridWMTSComponent);
 }
 
 describe('SourceTileWMTSComponent', () => {
@@ -77,16 +74,16 @@ describe('SourceTileWMTSComponent', () => {
   it('binds a WMTS source into the tile layer and prefers the child tile grid helper', () => {
     const host = fixture!.componentInstance;
 
-    expect(host.layer.instance.getSource()).toBe(host.source.instance);
-    expect(host.source.instance.getTileGrid()).toBe(host.tileGrid.instance);
+    expect(host.layer().instance.getSource()).toBe(host.source().instance);
+    expect(host.source().instance.getTileGrid()).toBe(host.tileGrid().instance);
   });
 
   it('forwards tile load events through template outputs', () => {
     const host = fixture!.componentInstance;
 
-    host.source.instance.dispatchEvent('tileloadstart');
-    host.source.instance.dispatchEvent('tileloadend');
-    host.source.instance.dispatchEvent('tileloaderror');
+    host.source().instance.dispatchEvent('tileloadstart');
+    host.source().instance.dispatchEvent('tileloadend');
+    host.source().instance.dispatchEvent('tileloaderror');
 
     expect(host.tileLoadStart).toHaveBeenCalledOnce();
     expect(host.tileLoadEnd).toHaveBeenCalledOnce();
@@ -95,26 +92,26 @@ describe('SourceTileWMTSComponent', () => {
 
   it('recreates and re-registers the source when the URL binding changes', () => {
     const host = fixture!.componentInstance;
-    const previousSource = host.source.instance;
+    const previousSource = host.source().instance;
 
     host.url.set('https://example.com/updated-wmts');
 
     fixture!.detectChanges();
 
-    expect(host.source.instance).not.toBe(previousSource);
-    expect(host.layer.instance.getSource()).toBe(host.source.instance);
+    expect(host.source().instance).not.toBe(previousSource);
+    expect(host.layer().instance.getSource()).toBe(host.source().instance);
   });
 
   it('updates WMTS dimensions without recreating the source when keys are retained', () => {
     const host = fixture!.componentInstance;
-    const previousSource = host.source.instance;
+    const previousSource = host.source().instance;
 
     host.dimensions.set({ TIME: '2026-01-02', ELEVATION: '0' });
 
     fixture!.detectChanges();
 
-    expect(host.source.instance).toBe(previousSource);
-    expect(host.source.instance.getDimensions()).toEqual({
+    expect(host.source().instance).toBe(previousSource);
+    expect(host.source().instance.getDimensions()).toEqual({
       TIME: '2026-01-02',
       ELEVATION: '0',
     });
@@ -122,22 +119,22 @@ describe('SourceTileWMTSComponent', () => {
 
   it('recreates the WMTS source when dimension keys are removed', () => {
     const host = fixture!.componentInstance;
-    const previousSource = host.source.instance;
+    const previousSource = host.source().instance;
 
     host.dimensions.set({ TIME: '2026-01-03' });
 
     fixture!.detectChanges();
 
-    expect(host.source.instance).not.toBe(previousSource);
-    expect(host.layer.instance.getSource()).toBe(host.source.instance);
-    expect(host.source.instance.getDimensions()).toEqual({ TIME: '2026-01-03' });
+    expect(host.source().instance).not.toBe(previousSource);
+    expect(host.layer().instance.getSource()).toBe(host.source().instance);
+    expect(host.source().instance.getDimensions()).toEqual({ TIME: '2026-01-03' });
   });
 
   it('clears the tile layer source when the source component is destroyed', () => {
     const host = fixture!.componentInstance;
-    const layer = host.layer.instance;
+    const layer = host.layer().instance;
 
-    expect(layer.getSource()).toBe(host.source.instance);
+    expect(layer.getSource()).toBe(host.source().instance);
 
     fixture!.destroy();
     fixture = undefined;

--- a/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  Host,
   forwardRef,
   AfterContentInit,
   SimpleChanges,
@@ -9,6 +8,7 @@ import {
   input,
   output,
   signal,
+  inject,
 } from '@angular/core';
 import { LayerTileComponent } from '../layers/layertile.component';
 import { SourceComponent } from './source.component';
@@ -72,8 +72,8 @@ export class SourceTileWMTSComponent
 
     return instance;
   }
-  constructor(@Host() layer: LayerTileComponent) {
-    super(layer);
+  constructor() {
+    super(inject(LayerTileComponent, { host: true }));
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
@@ -30,31 +30,31 @@ export class SourceTileWMTSComponent
   extends SourceComponent
   implements AfterContentInit, OnChanges
 {
-  cacheSize = input<number>();
-  crossOrigin = input<null | string>();
-  interpolate = input<boolean>();
-  tileGrid = input<WMTS>();
-  projection = input<ProjectionLike>();
-  reprojectionErrorThreshold = input<number>();
-  requestEncoding = input<RequestEncoding | undefined>();
-  layer = input.required<string>();
-  style = input.required<string>();
-  tileClass = input<any>();
-  tilePixelRatio = input<number>();
-  version = input<string>();
-  format = input<string>();
-  matrixSet = input.required<string>();
-  dimensions = input<any>();
-  url = input<string>();
-  tileLoadFunction = input<LoadFunction>();
-  urls = input<string[]>();
-  wrapX = input<boolean>();
-  transition = input<number>();
-  zDirection = input<number | NearestDirectionFunction>();
+  readonly cacheSize = input<number>();
+  readonly crossOrigin = input<null | string>();
+  readonly interpolate = input<boolean>();
+  readonly tileGrid = input<WMTS>();
+  readonly projection = input<ProjectionLike>();
+  readonly reprojectionErrorThreshold = input<number>();
+  readonly requestEncoding = input<RequestEncoding | undefined>();
+  readonly layer = input.required<string>();
+  readonly style = input.required<string>();
+  readonly tileClass = input<any>();
+  readonly tilePixelRatio = input<number>();
+  readonly version = input<string>();
+  readonly format = input<string>();
+  readonly matrixSet = input.required<string>();
+  readonly dimensions = input<any>();
+  readonly url = input<string>();
+  readonly tileLoadFunction = input<LoadFunction>();
+  readonly urls = input<string[]>();
+  readonly wrapX = input<boolean>();
+  readonly transition = input<number>();
+  readonly zDirection = input<number | NearestDirectionFunction>();
 
-  tileLoadStart = output<TileSourceEvent>();
-  tileLoadEnd = output<TileSourceEvent>();
-  tileLoadError = output<TileSourceEvent>();
+  readonly tileLoadStart = output<TileSourceEvent>();
+  readonly tileLoadEnd = output<TileSourceEvent>();
+  readonly tileLoadError = output<TileSourceEvent>();
 
   protected readonly tileGridWMTS = contentChild(TileGridWMTSComponent);
 

--- a/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
@@ -3,9 +3,9 @@ import {
   Host,
   forwardRef,
   AfterContentInit,
-  ContentChild,
   SimpleChanges,
   OnChanges,
+  contentChild,
   input,
   output,
   signal,
@@ -56,8 +56,7 @@ export class SourceTileWMTSComponent
   tileLoadEnd = output<TileSourceEvent>();
   tileLoadError = output<TileSourceEvent>();
 
-  @ContentChild(TileGridWMTSComponent, { static: false })
-  tileGridWMTS: TileGridWMTSComponent;
+  protected readonly tileGridWMTS = contentChild(TileGridWMTSComponent);
 
   instance: SourceWMTS;
   private contentTileGrid?: WMTS;
@@ -113,8 +112,10 @@ export class SourceTileWMTSComponent
   }
 
   ngAfterContentInit(): void {
-    if (this.tileGridWMTS) {
-      this.contentTileGrid = this.tileGridWMTS.instance;
+    const tileGridWMTS = this.tileGridWMTS();
+
+    if (tileGridWMTS) {
+      this.contentTileGrid = tileGridWMTS.instance;
     }
     if (this.contentTileGrid ?? this.tileGrid()) {
       this.setLayerSource();

--- a/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
@@ -1,14 +1,14 @@
 import {
   Component,
   Host,
-  Input,
   forwardRef,
   AfterContentInit,
   ContentChild,
   SimpleChanges,
   OnChanges,
-  Output,
-  EventEmitter,
+  input,
+  output,
+  signal,
 } from '@angular/core';
 import { LayerTileComponent } from '../layers/layertile.component';
 import { SourceComponent } from './source.component';
@@ -30,61 +30,49 @@ export class SourceTileWMTSComponent
   extends SourceComponent
   implements AfterContentInit, OnChanges
 {
-  @Input()
-  cacheSize?: number;
-  @Input()
-  crossOrigin?: null | string;
-  @Input()
-  interpolate?: boolean;
-  @Input()
-  tileGrid: WMTS;
-  @Input()
-  projection?: ProjectionLike;
-  @Input()
-  reprojectionErrorThreshold?: number;
-  @Input()
-  requestEncoding?: RequestEncoding | undefined;
-  @Input()
-  layer: string;
-  @Input()
-  style: string;
-  @Input()
-  tileClass?: any;
-  @Input()
-  tilePixelRatio?: number;
-  @Input()
-  version?: string;
-  @Input()
-  format?: string;
-  @Input()
-  matrixSet: string;
-  @Input()
-  dimensions?: any;
-  @Input()
-  url?: string;
-  @Input()
-  tileLoadFunction?: LoadFunction;
-  @Input()
-  urls?: string[];
-  @Input()
-  wrapX?: boolean;
-  @Input()
-  transition?: number;
-  @Input()
-  zDirection?: number | NearestDirectionFunction;
+  cacheSize = input<number>();
+  crossOrigin = input<null | string>();
+  interpolate = input<boolean>();
+  tileGrid = input<WMTS>();
+  projection = input<ProjectionLike>();
+  reprojectionErrorThreshold = input<number>();
+  requestEncoding = input<RequestEncoding | undefined>();
+  layer = input.required<string>();
+  style = input.required<string>();
+  tileClass = input<any>();
+  tilePixelRatio = input<number>();
+  version = input<string>();
+  format = input<string>();
+  matrixSet = input.required<string>();
+  dimensions = input<any>();
+  url = input<string>();
+  tileLoadFunction = input<LoadFunction>();
+  urls = input<string[]>();
+  wrapX = input<boolean>();
+  transition = input<number>();
+  zDirection = input<number | NearestDirectionFunction>();
 
-  @Output()
-  tileLoadStart = new EventEmitter<TileSourceEvent>();
-  @Output()
-  tileLoadEnd = new EventEmitter<TileSourceEvent>();
-  @Output()
-  tileLoadError = new EventEmitter<TileSourceEvent>();
+  tileLoadStart = output<TileSourceEvent>();
+  tileLoadEnd = output<TileSourceEvent>();
+  tileLoadError = output<TileSourceEvent>();
 
   @ContentChild(TileGridWMTSComponent, { static: false })
   tileGridWMTS: TileGridWMTSComponent;
 
   instance: SourceWMTS;
+  private contentTileGrid?: WMTS;
 
+  protected readonly _instanceSignal = signal<SourceWMTS | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: SourceWMTS): SourceWMTS {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Host() layer: LayerTileComponent) {
     super(layer);
   }
@@ -98,7 +86,6 @@ export class SourceTileWMTSComponent
       if (changes.hasOwnProperty(key)) {
         switch (key) {
           case 'url':
-            this.url = changes[key].currentValue;
             this.setLayerSource();
             break;
           default:
@@ -111,7 +98,7 @@ export class SourceTileWMTSComponent
   }
 
   setLayerSource(): void {
-    this.instance = new SourceWMTS(this.createOptions());
+    this.setInstance(new SourceWMTS(this.createOptions()));
     this.instance.on('tileloadstart', (event: TileSourceEvent) => this.tileLoadStart.emit(event));
     this.instance.on('tileloadend', (event: TileSourceEvent) => this.tileLoadEnd.emit(event));
     this.instance.on('tileloaderror', (event: TileSourceEvent) => this.tileLoadError.emit(event));
@@ -120,38 +107,38 @@ export class SourceTileWMTSComponent
 
   ngAfterContentInit(): void {
     if (this.tileGridWMTS) {
-      this.tileGrid = this.tileGridWMTS.instance;
+      this.contentTileGrid = this.tileGridWMTS.instance;
     }
-    if (this.tileGrid) {
+    if (this.contentTileGrid ?? this.tileGrid()) {
       this.setLayerSource();
     }
   }
 
   private createOptions(): Options {
     return {
-      attributions: this.attributions,
-      attributionsCollapsible: this.attributionsCollapsible,
-      cacheSize: this.cacheSize,
-      crossOrigin: this.crossOrigin,
-      interpolate: this.interpolate,
-      tileGrid: this.tileGrid,
-      projection: this.projection,
-      reprojectionErrorThreshold: this.reprojectionErrorThreshold,
-      requestEncoding: this.requestEncoding,
-      layer: this.layer,
-      style: this.style,
-      tileClass: this.tileClass,
-      tilePixelRatio: this.tilePixelRatio,
-      format: this.format,
-      version: this.version,
-      matrixSet: this.matrixSet,
-      dimensions: this.dimensions,
-      url: this.url,
-      tileLoadFunction: this.tileLoadFunction,
-      urls: this.urls,
-      wrapX: this.wrapX,
-      transition: this.transition,
-      zDirection: this.zDirection,
+      attributions: this.attributions(),
+      attributionsCollapsible: this.attributionsCollapsible(),
+      cacheSize: this.cacheSize(),
+      crossOrigin: this.crossOrigin(),
+      interpolate: this.interpolate(),
+      tileGrid: (this.contentTileGrid ?? this.tileGrid())!,
+      projection: this.projection(),
+      reprojectionErrorThreshold: this.reprojectionErrorThreshold(),
+      requestEncoding: this.requestEncoding(),
+      layer: this.layer(),
+      style: this.style(),
+      tileClass: this.tileClass(),
+      tilePixelRatio: this.tilePixelRatio(),
+      format: this.format(),
+      version: this.version(),
+      matrixSet: this.matrixSet(),
+      dimensions: this.dimensions(),
+      url: this.url(),
+      tileLoadFunction: this.tileLoadFunction(),
+      urls: this.urls(),
+      wrapX: this.wrapX(),
+      transition: this.transition(),
+      zDirection: this.zDirection(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
@@ -82,6 +82,7 @@ export class SourceTileWMTSComponent
     if (!this.instance) {
       return;
     }
+    super.ngOnChanges(changes);
     for (const key in changes) {
       if (changes.hasOwnProperty(key)) {
         switch (key) {

--- a/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
@@ -82,7 +82,7 @@ export class SourceTileWMTSComponent
     }
     super.ngOnChanges(changes);
     if (changes.hasOwnProperty('url') || this.hasRemovedDimensionKeys(changes)) {
-      this.setLayerSource();
+      this.replaceInstance();
       return;
     }
     if (changes.hasOwnProperty('dimensions')) {
@@ -103,7 +103,7 @@ export class SourceTileWMTSComponent
     );
   }
 
-  setLayerSource(): void {
+  private replaceInstance(): void {
     this.setInstance(new SourceWMTS(this.createOptions()));
     this.instance.on('tileloadstart', (event: TileSourceEvent) => this.tileLoadStart.emit(event));
     this.instance.on('tileloadend', (event: TileSourceEvent) => this.tileLoadEnd.emit(event));
@@ -118,7 +118,7 @@ export class SourceTileWMTSComponent
       this.contentTileGrid = tileGridWMTS.instance;
     }
     if (this.contentTileGrid ?? this.tileGrid()) {
-      this.setLayerSource();
+      this.replaceInstance();
     }
   }
 

--- a/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
+++ b/projects/ngx-ol/src/lib/sources/tilewmts.component.ts
@@ -78,24 +78,30 @@ export class SourceTileWMTSComponent
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    const properties: { [index: string]: any } = {};
     if (!this.instance) {
       return;
     }
     super.ngOnChanges(changes);
-    for (const key in changes) {
-      if (changes.hasOwnProperty(key)) {
-        switch (key) {
-          case 'url':
-            this.setLayerSource();
-            break;
-          default:
-            break;
-        }
-        properties[key] = changes[key].currentValue;
-      }
+    if (changes.hasOwnProperty('url') || this.hasRemovedDimensionKeys(changes)) {
+      this.setLayerSource();
+      return;
     }
-    this.instance.setProperties(properties, false);
+    if (changes.hasOwnProperty('dimensions')) {
+      this.instance.updateDimensions(changes.dimensions.currentValue ?? {});
+    }
+  }
+
+  private hasRemovedDimensionKeys(changes: SimpleChanges): boolean {
+    if (!changes.dimensions || changes.dimensions.firstChange) {
+      return false;
+    }
+
+    const previousDimensions = changes.dimensions.previousValue ?? {};
+    const nextDimensions = changes.dimensions.currentValue ?? {};
+
+    return Object.keys(previousDimensions).some(
+      (key) => !Object.prototype.hasOwnProperty.call(nextDimensions, key),
+    );
   }
 
   setLayerSource(): void {
@@ -130,8 +136,8 @@ export class SourceTileWMTSComponent
       style: this.style(),
       tileClass: this.tileClass(),
       tilePixelRatio: this.tilePixelRatio(),
-      format: this.format(),
       version: this.version(),
+      format: this.format(),
       matrixSet: this.matrixSet(),
       dimensions: this.dimensions(),
       url: this.url(),

--- a/projects/ngx-ol/src/lib/sources/utfgrid.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/utfgrid.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -22,11 +22,9 @@ class SourceUtfGridHostComponent {
   zoom = 2;
   url = 'https://example.com/utfgrid.json';
 
-  @ViewChild(SourceUTFGridComponent)
-  source!: SourceUTFGridComponent;
+  readonly source = viewChild.required<SourceUTFGridComponent>(SourceUTFGridComponent);
 
-  @ViewChild(LayerTileComponent)
-  layer!: LayerTileComponent;
+  readonly layer = viewChild.required<LayerTileComponent>(LayerTileComponent);
 }
 
 describe('SourceUTFGridComponent', () => {
@@ -46,8 +44,8 @@ describe('SourceUTFGridComponent', () => {
   });
 
   it('binds a UTFGrid source into the tile layer through template inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/sources/utfgrid.component.ts
+++ b/projects/ngx-ol/src/lib/sources/utfgrid.component.ts
@@ -1,4 +1,4 @@
-import { Component, Host, OnInit, forwardRef, input, signal } from '@angular/core';
+import { Component, OnInit, forwardRef, input, signal, inject } from '@angular/core';
 import { SourceComponent } from './source.component';
 import { LayerTileComponent } from '../layers/layertile.component';
 import UTFGrid from 'ol/source/UTFGrid';
@@ -32,8 +32,8 @@ export class SourceUTFGridComponent extends SourceComponent implements OnInit {
 
     return instance;
   }
-  constructor(@Host() layer: LayerTileComponent) {
-    super(layer);
+  constructor() {
+    super(inject(LayerTileComponent, { host: true }));
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/sources/utfgrid.component.ts
+++ b/projects/ngx-ol/src/lib/sources/utfgrid.component.ts
@@ -12,12 +12,12 @@ import { NearestDirectionFunction } from 'ol/array';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceUTFGridComponent) }],
 })
 export class SourceUTFGridComponent extends SourceComponent implements OnInit {
-  preemptive = input<boolean>();
-  jsonp = input<boolean>();
-  tileJSON = input<Config>();
-  url = input<string>();
-  wrapX = input<boolean>();
-  zDirection = input<number | NearestDirectionFunction>();
+  readonly preemptive = input<boolean>();
+  readonly jsonp = input<boolean>();
+  readonly tileJSON = input<Config>();
+  readonly url = input<string>();
+  readonly wrapX = input<boolean>();
+  readonly zDirection = input<number | NearestDirectionFunction>();
 
   instance: UTFGrid;
 

--- a/projects/ngx-ol/src/lib/sources/utfgrid.component.ts
+++ b/projects/ngx-ol/src/lib/sources/utfgrid.component.ts
@@ -1,4 +1,4 @@
-import { Component, Host, Input, OnInit, forwardRef } from '@angular/core';
+import { Component, Host, OnInit, forwardRef, input, signal } from '@angular/core';
 import { SourceComponent } from './source.component';
 import { LayerTileComponent } from '../layers/layertile.component';
 import UTFGrid from 'ol/source/UTFGrid';
@@ -12,38 +12,43 @@ import { NearestDirectionFunction } from 'ol/array';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceUTFGridComponent) }],
 })
 export class SourceUTFGridComponent extends SourceComponent implements OnInit {
-  @Input()
-  preemptive?: boolean;
-  @Input()
-  jsonp?: boolean;
-  @Input()
-  tileJSON?: Config;
-  @Input()
-  url?: string;
-  @Input()
-  wrapX?: boolean;
-  @Input()
-  zDirection?: number | NearestDirectionFunction;
+  preemptive = input<boolean>();
+  jsonp = input<boolean>();
+  tileJSON = input<Config>();
+  url = input<string>();
+  wrapX = input<boolean>();
+  zDirection = input<number | NearestDirectionFunction>();
 
   instance: UTFGrid;
 
+  protected readonly _instanceSignal = signal<UTFGrid | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: UTFGrid): UTFGrid {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Host() layer: LayerTileComponent) {
     super(layer);
   }
 
   ngOnInit() {
-    this.instance = new UTFGrid(this.createOptions());
+    this.setInstance(new UTFGrid(this.createOptions()));
     this.host.instance.setSource(this.instance);
   }
 
   private createOptions(): Options {
     return {
-      preemptive: this.preemptive,
-      jsonp: this.jsonp,
-      tileJSON: this.tileJSON,
-      url: this.url,
-      wrapX: this.wrapX,
-      zDirection: this.zDirection,
+      preemptive: this.preemptive(),
+      jsonp: this.jsonp(),
+      tileJSON: this.tileJSON(),
+      url: this.url(),
+      wrapX: this.wrapX(),
+      zDirection: this.zDirection(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/vector.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/vector.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
@@ -24,11 +24,9 @@ class SourceVectorHostComponent {
   zoom = 2;
   features = signal<Feature[] | undefined>([new Feature(new Point([1, 2]))]);
 
-  @ViewChild(SourceVectorComponent)
-  source!: SourceVectorComponent;
+  readonly source = viewChild.required<SourceVectorComponent>(SourceVectorComponent);
 
-  @ViewChild(LayerVectorComponent)
-  layer!: LayerVectorComponent;
+  readonly layer = viewChild.required<LayerVectorComponent>(LayerVectorComponent);
 }
 
 describe('SourceVectorComponent', () => {
@@ -48,10 +46,10 @@ describe('SourceVectorComponent', () => {
   });
 
   it('binds a vector source into the vector layer through template inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
-    expect(fixture.componentInstance.source.instance.getFeatures()).toHaveLength(1);
+    expect(fixture.componentInstance.source().instance.getFeatures()).toHaveLength(1);
   });
 
   it('clears existing features when the features binding is cleared', () => {
@@ -59,6 +57,6 @@ describe('SourceVectorComponent', () => {
 
     fixture.detectChanges();
 
-    expect(fixture.componentInstance.source.instance.getFeatures()).toHaveLength(0);
+    expect(fixture.componentInstance.source().instance.getFeatures()).toHaveLength(0);
   });
 });

--- a/projects/ngx-ol/src/lib/sources/vector.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/vector.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, signal, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
@@ -12,7 +12,7 @@ import { SourceVectorComponent } from './vector.component';
     <aol-map width="320px" height="240px">
       <aol-view [center]="center" [zoom]="zoom"></aol-view>
       <aol-layer-vector>
-        <aol-source-vector [features]="features"></aol-source-vector>
+        <aol-source-vector [features]="features()"></aol-source-vector>
       </aol-layer-vector>
     </aol-map>
   `,
@@ -22,7 +22,7 @@ import { SourceVectorComponent } from './vector.component';
 class SourceVectorHostComponent {
   center = [0, 0];
   zoom = 2;
-  features = [new Feature(new Point([1, 2]))];
+  features = signal<Feature[] | undefined>([new Feature(new Point([1, 2]))]);
 
   @ViewChild(SourceVectorComponent)
   source!: SourceVectorComponent;
@@ -52,5 +52,13 @@ describe('SourceVectorComponent', () => {
       fixture.componentInstance.source.instance,
     );
     expect(fixture.componentInstance.source.instance.getFeatures()).toHaveLength(1);
+  });
+
+  it('clears existing features when the features binding is cleared', () => {
+    fixture.componentInstance.features.set(undefined);
+
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.source.instance.getFeatures()).toHaveLength(0);
   });
 });

--- a/projects/ngx-ol/src/lib/sources/vector.component.ts
+++ b/projects/ngx-ol/src/lib/sources/vector.component.ts
@@ -1,11 +1,10 @@
 import {
   Component,
-  Host,
   OnChanges,
   OnInit,
-  Optional,
   SimpleChanges,
   forwardRef,
+  inject,
   input,
   signal,
 } from '@angular/core';
@@ -48,12 +47,12 @@ export class SourceVectorComponent extends SourceComponent implements OnInit, On
 
     return instance;
   }
-  constructor(
-    @Optional() @Host() vectorLayer: LayerVectorComponent,
-    @Optional() @Host() vectorImageLayer: LayerVectorImageComponent,
-    @Optional() @Host() heatmapLayer: LayerHeatmapComponent,
-  ) {
-    super(vectorLayer || vectorImageLayer || heatmapLayer);
+  constructor() {
+    super(
+      inject(LayerVectorComponent, { optional: true, host: true }) ||
+        inject(LayerVectorImageComponent, { optional: true, host: true }) ||
+        inject(LayerHeatmapComponent, { optional: true, host: true })!,
+    );
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/sources/vector.component.ts
+++ b/projects/ngx-ol/src/lib/sources/vector.component.ts
@@ -71,9 +71,11 @@ export class SourceVectorComponent extends SourceComponent implements OnInit, On
     if (this.instance && changes.url?.currentValue) {
       this.instance.setUrl(changes.url.currentValue);
     }
-    if (features?.currentValue && this.instance) {
+    if (features && this.instance) {
       this.instance.clear();
-      this.instance.addFeatures(features.currentValue);
+      if (features.currentValue) {
+        this.instance.addFeatures(features.currentValue);
+      }
     }
   }
 

--- a/projects/ngx-ol/src/lib/sources/vector.component.ts
+++ b/projects/ngx-ol/src/lib/sources/vector.component.ts
@@ -25,14 +25,14 @@ import { LayerHeatmapComponent } from '../layers/layerheatmap.component';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceVectorComponent) }],
 })
 export class SourceVectorComponent extends SourceComponent implements OnInit, OnChanges {
-  overlaps = input<boolean>();
-  features = input<FeatureLike[] | Collection<FeatureLike> | undefined>();
-  useSpatialIndex = input<boolean>();
-  wrapX = input<boolean>();
-  loader = input<FeatureLoader<FeatureLike>>();
-  url = input<string | FeatureUrlFunction>();
-  format = input<FeatureFormat<any>>();
-  strategy = input<LoadingStrategy>();
+  readonly overlaps = input<boolean>();
+  readonly features = input<FeatureLike[] | Collection<FeatureLike> | undefined>();
+  readonly useSpatialIndex = input<boolean>();
+  readonly wrapX = input<boolean>();
+  readonly loader = input<FeatureLoader<FeatureLike>>();
+  readonly url = input<string | FeatureUrlFunction>();
+  readonly format = input<FeatureFormat<any>>();
+  readonly strategy = input<LoadingStrategy>();
 
   instance: Vector;
 

--- a/projects/ngx-ol/src/lib/sources/vector.component.ts
+++ b/projects/ngx-ol/src/lib/sources/vector.component.ts
@@ -1,4 +1,14 @@
-import { Component, Host, Input, OnChanges, OnInit, Optional, SimpleChanges, forwardRef } from '@angular/core';
+import {
+  Component,
+  Host,
+  OnChanges,
+  OnInit,
+  Optional,
+  SimpleChanges,
+  forwardRef,
+  input,
+  signal,
+} from '@angular/core';
 import Collection from 'ol/Collection.js';
 import type { FeatureLike } from 'ol/Feature.js';
 import type FeatureFormat from 'ol/format/Feature.js';
@@ -16,25 +26,28 @@ import { LayerHeatmapComponent } from '../layers/layerheatmap.component';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceVectorComponent) }],
 })
 export class SourceVectorComponent extends SourceComponent implements OnInit, OnChanges {
-  @Input()
-  overlaps: boolean;
-  @Input()
-  features: FeatureLike[] | Collection<FeatureLike> | undefined;
-  @Input()
-  useSpatialIndex: boolean;
-  @Input()
-  wrapX: boolean;
-  @Input()
-  loader?: FeatureLoader<FeatureLike>;
-  @Input()
-  url?: string | FeatureUrlFunction;
-  @Input()
-  format?: FeatureFormat<any>;
-  @Input()
-  strategy?: LoadingStrategy;
+  overlaps = input<boolean>();
+  features = input<FeatureLike[] | Collection<FeatureLike> | undefined>();
+  useSpatialIndex = input<boolean>();
+  wrapX = input<boolean>();
+  loader = input<FeatureLoader<FeatureLike>>();
+  url = input<string | FeatureUrlFunction>();
+  format = input<FeatureFormat<any>>();
+  strategy = input<LoadingStrategy>();
 
   instance: Vector;
 
+  protected readonly _instanceSignal = signal<Vector | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Vector): Vector {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(
     @Optional() @Host() vectorLayer: LayerVectorComponent,
     @Optional() @Host() vectorImageLayer: LayerVectorImageComponent,
@@ -59,15 +72,15 @@ export class SourceVectorComponent extends SourceComponent implements OnInit, On
 
   private createOptions(): Options<FeatureLike> {
     return {
-      attributions: this.attributions,
-      overlaps: this.overlaps,
-      features: this.features,
-      useSpatialIndex: this.useSpatialIndex,
-      wrapX: this.wrapX,
-      loader: this.loader,
-      url: this.url,
-      format: this.format,
-      strategy: this.strategy,
+      attributions: this.attributions(),
+      overlaps: this.overlaps(),
+      features: this.features(),
+      useSpatialIndex: this.useSpatialIndex(),
+      wrapX: this.wrapX(),
+      loader: this.loader(),
+      url: this.url(),
+      format: this.format(),
+      strategy: this.strategy(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/vector.component.ts
+++ b/projects/ngx-ol/src/lib/sources/vector.component.ts
@@ -62,8 +62,15 @@ export class SourceVectorComponent extends SourceComponent implements OnInit, On
   }
 
   ngOnChanges(changes: SimpleChanges): void {
+    super.ngOnChanges(changes);
     const { features } = changes;
 
+    if (this.instance && changes.loader?.currentValue) {
+      this.instance.setLoader(changes.loader.currentValue);
+    }
+    if (this.instance && changes.url?.currentValue) {
+      this.instance.setUrl(changes.url.currentValue);
+    }
     if (features?.currentValue && this.instance) {
       this.instance.clear();
       this.instance.addFeatures(features.currentValue);

--- a/projects/ngx-ol/src/lib/sources/vectortile.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/vectortile.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -28,14 +28,11 @@ class SourceVectorTileHostComponent {
   origin: [number, number] = [0, 0];
   resolutions = [2, 1];
 
-  @ViewChild(SourceVectorTileComponent)
-  source!: SourceVectorTileComponent;
+  readonly source = viewChild.required<SourceVectorTileComponent>(SourceVectorTileComponent);
 
-  @ViewChild(LayerVectorTileComponent)
-  layer!: LayerVectorTileComponent;
+  readonly layer = viewChild.required<LayerVectorTileComponent>(LayerVectorTileComponent);
 
-  @ViewChild(TileGridComponent)
-  tileGrid!: TileGridComponent;
+  readonly tileGrid = viewChild.required<TileGridComponent>(TileGridComponent);
 }
 
 describe('SourceVectorTileComponent', () => {
@@ -55,11 +52,11 @@ describe('SourceVectorTileComponent', () => {
   });
 
   it('binds a vector tile source into the vector tile layer and prefers child helpers', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
-    expect(fixture.componentInstance.source.instance.getTileGrid()).toBe(
-      fixture.componentInstance.tileGrid.instance,
+    expect(fixture.componentInstance.source().instance.getTileGrid()).toBe(
+      fixture.componentInstance.tileGrid().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/sources/vectortile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/vectortile.component.ts
@@ -1,11 +1,11 @@
 import {
   Component,
-  Host,
   forwardRef,
   AfterContentInit,
   contentChild,
   input,
   signal,
+  inject,
 } from '@angular/core';
 import VectorTile from 'ol/source/VectorTile';
 import { Options } from 'ol/source/VectorTile';
@@ -70,8 +70,8 @@ export class SourceVectorTileComponent extends SourceComponent implements AfterC
   }
   tileGrid: TileGrid;
 
-  constructor(@Host() layer: LayerVectorTileComponent) {
-    super(layer);
+  constructor() {
+    super(inject(LayerVectorTileComponent, { host: true }));
   }
 
   ngAfterContentInit() {

--- a/projects/ngx-ol/src/lib/sources/vectortile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/vectortile.component.ts
@@ -2,8 +2,8 @@ import {
   Component,
   Host,
   forwardRef,
-  ContentChild,
   AfterContentInit,
+  contentChild,
   input,
   signal,
 } from '@angular/core';
@@ -51,12 +51,9 @@ export class SourceVectorTileComponent extends SourceComponent implements AfterC
   zDirection = input<number | NearestDirectionFunction>();
   format = input<FeatureFormat<any>>();
 
-  @ContentChild(FormatMVTComponent, { static: false })
-  formatMVTComponent: FormatMVTComponent;
-  @ContentChild(FormatGeoJSONComponent, { static: false })
-  formatGeoJSONComponent: FormatGeoJSONComponent;
-  @ContentChild(TileGridComponent, { static: false })
-  tileGridComponent: TileGridComponent;
+  protected readonly formatMVTComponent = contentChild(FormatMVTComponent);
+  protected readonly formatGeoJSONComponent = contentChild(FormatGeoJSONComponent);
+  protected readonly tileGridComponent = contentChild(TileGridComponent);
 
   public instance: VectorTile;
 
@@ -79,13 +76,19 @@ export class SourceVectorTileComponent extends SourceComponent implements AfterC
 
   ngAfterContentInit() {
     let format: FeatureFormat<any> | undefined = this.format();
-    if (this.formatMVTComponent) {
-      format = this.formatMVTComponent.instance;
+    const formatMVTComponent = this.formatMVTComponent();
+    const formatGeoJSONComponent = this.formatGeoJSONComponent();
+    const tileGridComponent = this.tileGridComponent();
+
+    if (formatMVTComponent) {
+      format = formatMVTComponent.instance;
     }
-    if (this.formatGeoJSONComponent) {
-      format = this.formatGeoJSONComponent.instance;
+    if (formatGeoJSONComponent) {
+      format = formatGeoJSONComponent.instance;
     }
-    this.tileGrid = this.tileGridComponent.instance;
+    if (tileGridComponent) {
+      this.tileGrid = tileGridComponent.instance;
+    }
 
     this.setInstance(new VectorTile(this.createOptions(format)));
     this.host.instance.setSource(this.instance);

--- a/projects/ngx-ol/src/lib/sources/vectortile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/vectortile.component.ts
@@ -1,4 +1,12 @@
-import { Component, Host, Input, forwardRef, ContentChild, AfterContentInit } from '@angular/core';
+import {
+  Component,
+  Host,
+  forwardRef,
+  ContentChild,
+  AfterContentInit,
+  input,
+  signal,
+} from '@angular/core';
 import VectorTile from 'ol/source/VectorTile';
 import { Options } from 'ol/source/VectorTile';
 import TileGrid from 'ol/tilegrid/TileGrid';
@@ -24,42 +32,24 @@ import FeatureFormat from 'ol/format/Feature';
   ],
 })
 export class SourceVectorTileComponent extends SourceComponent implements AfterContentInit {
-  @Input()
-  cacheSize?: number;
-  @Input()
-  extent?: Extent;
-  @Input()
-  overlaps?: boolean;
-  @Input()
-  projection?: ProjectionLike;
-  @Input()
-  state?: State;
-  @Input()
-  tileClass?: typeof OlVectorTile;
-  @Input()
-  maxZoom?: number;
-  @Input()
-  minZoom?: number;
-  @Input()
-  tileSize?: number | Size;
-  @Input()
-  maxResolution?: number;
-  @Input()
-  tileUrlFunction?: UrlFunction;
-  @Input()
-  tileLoadFunction?: LoadFunction;
-  @Input()
-  url?: string;
-  @Input()
-  urls?: string[];
-  @Input()
-  transition?: number;
-  @Input()
-  wrapX?: boolean;
-  @Input()
-  zDirection?: number | NearestDirectionFunction;
-  @Input()
-  format?: FeatureFormat<any>;
+  cacheSize = input<number>();
+  extent = input<Extent>();
+  overlaps = input<boolean>();
+  projection = input<ProjectionLike>();
+  state = input<State>();
+  tileClass = input<typeof OlVectorTile>();
+  maxZoom = input<number>();
+  minZoom = input<number>();
+  tileSize = input<number | Size>();
+  maxResolution = input<number>();
+  tileUrlFunction = input<UrlFunction>();
+  tileLoadFunction = input<LoadFunction>();
+  url = input<string>();
+  urls = input<string[]>();
+  transition = input<number>();
+  wrapX = input<boolean>();
+  zDirection = input<number | NearestDirectionFunction>();
+  format = input<FeatureFormat<any>>();
 
   @ContentChild(FormatMVTComponent, { static: false })
   formatMVTComponent: FormatMVTComponent;
@@ -69,6 +59,18 @@ export class SourceVectorTileComponent extends SourceComponent implements AfterC
   tileGridComponent: TileGridComponent;
 
   public instance: VectorTile;
+
+  protected readonly _instanceSignal = signal<VectorTile | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: VectorTile): VectorTile {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   tileGrid: TileGrid;
 
   constructor(@Host() layer: LayerVectorTileComponent) {
@@ -76,7 +78,7 @@ export class SourceVectorTileComponent extends SourceComponent implements AfterC
   }
 
   ngAfterContentInit() {
-    let format: FeatureFormat<any> | undefined = this.format;
+    let format: FeatureFormat<any> | undefined = this.format();
     if (this.formatMVTComponent) {
       format = this.formatMVTComponent.instance;
     }
@@ -85,32 +87,32 @@ export class SourceVectorTileComponent extends SourceComponent implements AfterC
     }
     this.tileGrid = this.tileGridComponent.instance;
 
-    this.instance = new VectorTile(this.createOptions(format));
+    this.setInstance(new VectorTile(this.createOptions(format)));
     this.host.instance.setSource(this.instance);
   }
 
   private createOptions(format: FeatureFormat<any> | undefined): Options<any> {
     return {
-      attributions: this.attributions,
-      cacheSize: this.cacheSize,
-      extent: this.extent,
+      attributions: this.attributions(),
+      cacheSize: this.cacheSize(),
+      extent: this.extent(),
       format,
-      overlaps: this.overlaps,
-      projection: this.projection,
-      state: this.state,
-      tileClass: this.tileClass,
-      maxZoom: this.maxZoom,
-      minZoom: this.minZoom,
-      tileSize: this.tileSize,
-      maxResolution: this.maxResolution,
+      overlaps: this.overlaps(),
+      projection: this.projection(),
+      state: this.state(),
+      tileClass: this.tileClass(),
+      maxZoom: this.maxZoom(),
+      minZoom: this.minZoom(),
+      tileSize: this.tileSize(),
+      maxResolution: this.maxResolution(),
       tileGrid: this.tileGrid,
-      tileUrlFunction: this.tileUrlFunction,
-      tileLoadFunction: this.tileLoadFunction,
-      url: this.url,
-      urls: this.urls,
-      transition: this.transition,
-      wrapX: this.wrapX,
-      zDirection: this.zDirection,
+      tileUrlFunction: this.tileUrlFunction(),
+      tileLoadFunction: this.tileLoadFunction(),
+      url: this.url(),
+      urls: this.urls(),
+      transition: this.transition(),
+      wrapX: this.wrapX(),
+      zDirection: this.zDirection(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/vectortile.component.ts
+++ b/projects/ngx-ol/src/lib/sources/vectortile.component.ts
@@ -32,24 +32,24 @@ import FeatureFormat from 'ol/format/Feature';
   ],
 })
 export class SourceVectorTileComponent extends SourceComponent implements AfterContentInit {
-  cacheSize = input<number>();
-  extent = input<Extent>();
-  overlaps = input<boolean>();
-  projection = input<ProjectionLike>();
-  state = input<State>();
-  tileClass = input<typeof OlVectorTile>();
-  maxZoom = input<number>();
-  minZoom = input<number>();
-  tileSize = input<number | Size>();
-  maxResolution = input<number>();
-  tileUrlFunction = input<UrlFunction>();
-  tileLoadFunction = input<LoadFunction>();
-  url = input<string>();
-  urls = input<string[]>();
-  transition = input<number>();
-  wrapX = input<boolean>();
-  zDirection = input<number | NearestDirectionFunction>();
-  format = input<FeatureFormat<any>>();
+  readonly cacheSize = input<number>();
+  readonly extent = input<Extent>();
+  readonly overlaps = input<boolean>();
+  readonly projection = input<ProjectionLike>();
+  readonly state = input<State>();
+  readonly tileClass = input<typeof OlVectorTile>();
+  readonly maxZoom = input<number>();
+  readonly minZoom = input<number>();
+  readonly tileSize = input<number | Size>();
+  readonly maxResolution = input<number>();
+  readonly tileUrlFunction = input<UrlFunction>();
+  readonly tileLoadFunction = input<LoadFunction>();
+  readonly url = input<string>();
+  readonly urls = input<string[]>();
+  readonly transition = input<number>();
+  readonly wrapX = input<boolean>();
+  readonly zDirection = input<number | NearestDirectionFunction>();
+  readonly format = input<FeatureFormat<any>>();
 
   protected readonly formatMVTComponent = contentChild(FormatMVTComponent);
   protected readonly formatGeoJSONComponent = contentChild(FormatGeoJSONComponent);

--- a/projects/ngx-ol/src/lib/sources/xyz.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/xyz.component.spec.ts
@@ -74,14 +74,14 @@ describe('SourceXYZComponent', () => {
     expect(host.tileLoadError).toHaveBeenCalledOnce();
   });
 
-  it('recreates and re-registers the source when the URL binding changes', () => {
+  it('updates the existing source URL when the URL binding changes', () => {
     const host = fixture!.componentInstance;
     const previousSource = host.source.instance;
 
     host.url.set('https://tiles.example.com/{z}/{x}/{y}.png');
     fixture!.detectChanges();
 
-    expect(host.source.instance).not.toBe(previousSource);
+    expect(host.source.instance).toBe(previousSource);
     expect(host.layer.instance.getSource()).toBe(host.source.instance);
     expect(host.source.instance.getUrls()).toEqual([
       'https://tiles.example.com/{z}/{x}/{y}.png',

--- a/projects/ngx-ol/src/lib/sources/xyz.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/xyz.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -30,11 +30,9 @@ class SourceXYZHostComponent {
   tileLoadEnd = vi.fn();
   tileLoadError = vi.fn();
 
-  @ViewChild(SourceXYZComponent)
-  source!: SourceXYZComponent;
+  readonly source = viewChild.required<SourceXYZComponent>(SourceXYZComponent);
 
-  @ViewChild(LayerTileComponent)
-  layer!: LayerTileComponent;
+  readonly layer = viewChild.required<LayerTileComponent>(LayerTileComponent);
 }
 
 describe('SourceXYZComponent', () => {
@@ -56,18 +54,16 @@ describe('SourceXYZComponent', () => {
   it('binds an XYZ source into the tile layer through template inputs', () => {
     const host = fixture!.componentInstance;
 
-    expect(host.layer.instance.getSource()).toBe(host.source.instance);
-    expect(host.source.instance.getUrls()).toEqual([
-      'https://example.com/{z}/{x}/{y}.png',
-    ]);
+    expect(host.layer().instance.getSource()).toBe(host.source().instance);
+    expect(host.source().instance.getUrls()).toEqual(['https://example.com/{z}/{x}/{y}.png']);
   });
 
   it('forwards tile load events through template outputs', () => {
     const host = fixture!.componentInstance;
 
-    host.source.instance.dispatchEvent('tileloadstart');
-    host.source.instance.dispatchEvent('tileloadend');
-    host.source.instance.dispatchEvent('tileloaderror');
+    host.source().instance.dispatchEvent('tileloadstart');
+    host.source().instance.dispatchEvent('tileloadend');
+    host.source().instance.dispatchEvent('tileloaderror');
 
     expect(host.tileLoadStart).toHaveBeenCalledOnce();
     expect(host.tileLoadEnd).toHaveBeenCalledOnce();
@@ -76,23 +72,21 @@ describe('SourceXYZComponent', () => {
 
   it('updates the existing source URL when the URL binding changes', () => {
     const host = fixture!.componentInstance;
-    const previousSource = host.source.instance;
+    const previousSource = host.source().instance;
 
     host.url.set('https://tiles.example.com/{z}/{x}/{y}.png');
     fixture!.detectChanges();
 
-    expect(host.source.instance).toBe(previousSource);
-    expect(host.layer.instance.getSource()).toBe(host.source.instance);
-    expect(host.source.instance.getUrls()).toEqual([
-      'https://tiles.example.com/{z}/{x}/{y}.png',
-    ]);
+    expect(host.source().instance).toBe(previousSource);
+    expect(host.layer().instance.getSource()).toBe(host.source().instance);
+    expect(host.source().instance.getUrls()).toEqual(['https://tiles.example.com/{z}/{x}/{y}.png']);
   });
 
   it('clears the layer source when the source component is destroyed', () => {
     const host = fixture!.componentInstance;
-    const layer = host.layer.instance;
+    const layer = host.layer().instance;
 
-    expect(layer.getSource()).toBe(host.source.instance);
+    expect(layer.getSource()).toBe(host.source().instance);
 
     fixture!.destroy();
     fixture = undefined;

--- a/projects/ngx-ol/src/lib/sources/xyz.component.ts
+++ b/projects/ngx-ol/src/lib/sources/xyz.component.ts
@@ -92,8 +92,28 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
     if (!this.instance) {
       return;
     }
+    super.ngOnChanges(changes);
     for (const key in changes) {
       if (changes.hasOwnProperty(key)) {
+        switch (key) {
+          case 'tileLoadFunction':
+            if (changes[key].currentValue) {
+              this.instance.setTileLoadFunction(changes[key].currentValue);
+            }
+            continue;
+          case 'tileUrlFunction':
+            if (changes[key].currentValue) {
+              this.instance.setTileUrlFunction(changes[key].currentValue);
+            }
+            continue;
+          case 'urls':
+            if (changes[key].currentValue) {
+              this.instance.setUrls(changes[key].currentValue);
+            }
+            continue;
+          default:
+            break;
+        }
         properties[key] = changes[key].currentValue;
       }
     }

--- a/projects/ngx-ol/src/lib/sources/xyz.component.ts
+++ b/projects/ngx-ol/src/lib/sources/xyz.component.ts
@@ -2,14 +2,14 @@ import {
   AfterContentInit,
   Component,
   ContentChild,
-  EventEmitter,
   forwardRef,
   Host,
-  Input,
   OnChanges,
   Optional,
-  Output,
   SimpleChanges,
+  input,
+  output,
+  signal,
 } from '@angular/core';
 import { Size } from 'ol/size';
 import XYZ from 'ol/source/XYZ';
@@ -30,57 +30,47 @@ import { SourceComponent } from './source.component';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceXYZComponent) }],
 })
 export class SourceXYZComponent extends SourceComponent implements AfterContentInit, OnChanges {
-  @Input()
-  cacheSize?: number;
-  @Input()
-  crossOrigin?: null | string;
-  @Input()
-  gutter?: number;
-  @Input()
-  interpolate?: boolean;
-  @Input()
-  projection?: ProjectionLike;
-  @Input()
-  reprojectionErrorThreshold?: number;
-  @Input()
-  maxResolution?: number;
-  @Input()
-  minZoom?: number;
-  @Input()
-  maxZoom?: number;
-  @Input()
-  tileGrid?: TileGrid;
-  @Input()
-  tileLoadFunction?: LoadFunction;
-  @Input()
-  tilePixelRatio?: number;
-  @Input()
-  tileSize?: number | Size;
-  @Input()
-  tileUrlFunction?: UrlFunction;
-  @Input()
-  transition?: number;
-  @Input()
-  url?: string;
-  @Input()
-  urls?: string[];
-  @Input()
-  wrapX?: boolean;
-  @Input()
-  zDirection?: number | NearestDirectionFunction;
+  cacheSize = input<number>();
+  crossOrigin = input<null | string>();
+  gutter = input<number>();
+  interpolate = input<boolean>();
+  projection = input<ProjectionLike>();
+  reprojectionErrorThreshold = input<number>();
+  maxResolution = input<number>();
+  minZoom = input<number>();
+  maxZoom = input<number>();
+  tileGrid = input<TileGrid>();
+  tileLoadFunction = input<LoadFunction>();
+  tilePixelRatio = input<number>();
+  tileSize = input<number | Size>();
+  tileUrlFunction = input<UrlFunction>();
+  transition = input<number>();
+  url = input<string>();
+  urls = input<string[]>();
+  wrapX = input<boolean>();
+  zDirection = input<number | NearestDirectionFunction>();
 
   @ContentChild(TileGridComponent, { static: false })
   tileGridXYZ: TileGridComponent;
 
-  @Output()
-  tileLoadStart = new EventEmitter<TileSourceEvent>();
-  @Output()
-  tileLoadEnd = new EventEmitter<TileSourceEvent>();
-  @Output()
-  tileLoadError = new EventEmitter<TileSourceEvent>();
+  tileLoadStart = output<TileSourceEvent>();
+  tileLoadEnd = output<TileSourceEvent>();
+  tileLoadError = output<TileSourceEvent>();
 
   instance: XYZ;
+  protected contentTileGrid?: TileGrid;
 
+  protected readonly _instanceSignal = signal<XYZ | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: XYZ): XYZ {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(
     @Optional()
     @Host()
@@ -91,7 +81,7 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
 
   ngAfterContentInit() {
     if (this.tileGridXYZ) {
-      this.tileGrid = this.tileGridXYZ.instance;
+      this.contentTileGrid = this.tileGridXYZ.instance;
     }
     this.init();
   }
@@ -115,7 +105,7 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
   }
 
   init() {
-    this.instance = new XYZ(this.createOptions());
+    this.setInstance(new XYZ(this.createOptions()));
 
     this.instance.on('tileloadstart', (event: TileSourceEvent) => this.tileLoadStart.emit(event));
     this.instance.on('tileloadend', (event: TileSourceEvent) => this.tileLoadEnd.emit(event));
@@ -126,27 +116,27 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
 
   protected createOptions(): Options {
     return {
-      attributions: this.attributions,
-      attributionsCollapsible: this.attributionsCollapsible,
-      cacheSize: this.cacheSize,
-      crossOrigin: this.crossOrigin,
-      gutter: this.gutter,
-      interpolate: this.interpolate,
-      projection: this.projection,
-      reprojectionErrorThreshold: this.reprojectionErrorThreshold,
-      maxResolution: this.maxResolution,
-      minZoom: this.minZoom,
-      maxZoom: this.maxZoom,
-      tileGrid: this.tileGrid,
-      tileLoadFunction: this.tileLoadFunction,
-      tilePixelRatio: this.tilePixelRatio,
-      tileSize: this.tileSize,
-      tileUrlFunction: this.tileUrlFunction,
-      transition: this.transition,
-      url: this.url,
-      urls: this.urls,
-      wrapX: this.wrapX,
-      zDirection: this.zDirection,
+      attributions: this.attributions(),
+      attributionsCollapsible: this.attributionsCollapsible(),
+      cacheSize: this.cacheSize(),
+      crossOrigin: this.crossOrigin(),
+      gutter: this.gutter(),
+      interpolate: this.interpolate(),
+      projection: this.projection(),
+      reprojectionErrorThreshold: this.reprojectionErrorThreshold(),
+      maxResolution: this.maxResolution(),
+      minZoom: this.minZoom(),
+      maxZoom: this.maxZoom(),
+      tileGrid: this.contentTileGrid ?? this.tileGrid(),
+      tileLoadFunction: this.tileLoadFunction(),
+      tilePixelRatio: this.tilePixelRatio(),
+      tileSize: this.tileSize(),
+      tileUrlFunction: this.tileUrlFunction(),
+      transition: this.transition(),
+      url: this.url(),
+      urls: this.urls(),
+      wrapX: this.wrapX(),
+      zDirection: this.zDirection(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/xyz.component.ts
+++ b/projects/ngx-ol/src/lib/sources/xyz.component.ts
@@ -87,8 +87,6 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    const properties: { [index: string]: any } = {};
-
     if (!this.instance) {
       return;
     }
@@ -111,16 +109,16 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
               this.instance.setUrls(changes[key].currentValue);
             }
             continue;
+          case 'url':
+            if (changes[key].currentValue !== undefined) {
+              this.instance.setUrl(changes[key].currentValue);
+              continue;
+            }
+            break;
           default:
             break;
         }
-        properties[key] = changes[key].currentValue;
       }
-    }
-
-    this.instance.setProperties(properties, false);
-    if (changes.hasOwnProperty('url')) {
-      this.init();
     }
   }
 

--- a/projects/ngx-ol/src/lib/sources/xyz.component.ts
+++ b/projects/ngx-ol/src/lib/sources/xyz.component.ts
@@ -29,31 +29,31 @@ import { SourceComponent } from './source.component';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceXYZComponent) }],
 })
 export class SourceXYZComponent extends SourceComponent implements AfterContentInit, OnChanges {
-  cacheSize = input<number>();
-  crossOrigin = input<null | string>();
-  gutter = input<number>();
-  interpolate = input<boolean>();
-  projection = input<ProjectionLike>();
-  reprojectionErrorThreshold = input<number>();
-  maxResolution = input<number>();
-  minZoom = input<number>();
-  maxZoom = input<number>();
-  tileGrid = input<TileGrid>();
-  tileLoadFunction = input<LoadFunction>();
-  tilePixelRatio = input<number>();
-  tileSize = input<number | Size>();
-  tileUrlFunction = input<UrlFunction>();
-  transition = input<number>();
-  url = input<string>();
-  urls = input<string[]>();
-  wrapX = input<boolean>();
-  zDirection = input<number | NearestDirectionFunction>();
+  readonly cacheSize = input<number>();
+  readonly crossOrigin = input<null | string>();
+  readonly gutter = input<number>();
+  readonly interpolate = input<boolean>();
+  readonly projection = input<ProjectionLike>();
+  readonly reprojectionErrorThreshold = input<number>();
+  readonly maxResolution = input<number>();
+  readonly minZoom = input<number>();
+  readonly maxZoom = input<number>();
+  readonly tileGrid = input<TileGrid>();
+  readonly tileLoadFunction = input<LoadFunction>();
+  readonly tilePixelRatio = input<number>();
+  readonly tileSize = input<number | Size>();
+  readonly tileUrlFunction = input<UrlFunction>();
+  readonly transition = input<number>();
+  readonly url = input<string>();
+  readonly urls = input<string[]>();
+  readonly wrapX = input<boolean>();
+  readonly zDirection = input<number | NearestDirectionFunction>();
 
   protected readonly tileGridXYZ = contentChild(TileGridComponent);
 
-  tileLoadStart = output<TileSourceEvent>();
-  tileLoadEnd = output<TileSourceEvent>();
-  tileLoadError = output<TileSourceEvent>();
+  readonly tileLoadStart = output<TileSourceEvent>();
+  readonly tileLoadEnd = output<TileSourceEvent>();
+  readonly tileLoadError = output<TileSourceEvent>();
 
   instance: XYZ;
   protected contentTileGrid?: TileGrid;

--- a/projects/ngx-ol/src/lib/sources/xyz.component.ts
+++ b/projects/ngx-ol/src/lib/sources/xyz.component.ts
@@ -1,12 +1,12 @@
 import {
   AfterContentInit,
   Component,
-  ContentChild,
   forwardRef,
   Host,
   OnChanges,
   Optional,
   SimpleChanges,
+  contentChild,
   input,
   output,
   signal,
@@ -50,8 +50,7 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
   wrapX = input<boolean>();
   zDirection = input<number | NearestDirectionFunction>();
 
-  @ContentChild(TileGridComponent, { static: false })
-  tileGridXYZ: TileGridComponent;
+  protected readonly tileGridXYZ = contentChild(TileGridComponent);
 
   tileLoadStart = output<TileSourceEvent>();
   tileLoadEnd = output<TileSourceEvent>();
@@ -80,8 +79,10 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
   }
 
   ngAfterContentInit() {
-    if (this.tileGridXYZ) {
-      this.contentTileGrid = this.tileGridXYZ.instance;
+    const tileGridXYZ = this.tileGridXYZ();
+
+    if (tileGridXYZ) {
+      this.contentTileGrid = tileGridXYZ.instance;
     }
     this.init();
   }

--- a/projects/ngx-ol/src/lib/sources/xyz.component.ts
+++ b/projects/ngx-ol/src/lib/sources/xyz.component.ts
@@ -2,14 +2,13 @@ import {
   AfterContentInit,
   Component,
   forwardRef,
-  Host,
   OnChanges,
-  Optional,
   SimpleChanges,
   contentChild,
   input,
   output,
   signal,
+  inject,
 } from '@angular/core';
 import { Size } from 'ol/size';
 import XYZ from 'ol/source/XYZ';
@@ -70,12 +69,8 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
 
     return instance;
   }
-  constructor(
-    @Optional()
-    @Host()
-    protected layer?: LayerTileComponent,
-  ) {
-    super(layer!);
+  constructor() {
+    super(inject(LayerTileComponent, { optional: true, host: true })!);
   }
 
   ngAfterContentInit() {

--- a/projects/ngx-ol/src/lib/sources/xyz.component.ts
+++ b/projects/ngx-ol/src/lib/sources/xyz.component.ts
@@ -79,7 +79,7 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
     if (tileGridXYZ) {
       this.contentTileGrid = tileGridXYZ.instance;
     }
-    this.init();
+    this.initializeInstance();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -118,7 +118,7 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
     }
   }
 
-  init() {
+  initializeInstance() {
     this.setInstance(new XYZ(this.createOptions()));
 
     this.instance.on('tileloadstart', (event: TileSourceEvent) => this.tileLoadStart.emit(event));

--- a/projects/ngx-ol/src/lib/sources/zoomify.component.spec.ts
+++ b/projects/ngx-ol/src/lib/sources/zoomify.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -23,11 +23,9 @@ class SourceZoomifyHostComponent {
   url = 'https://example.com/zoomify/';
   size: [number, number] = [1024, 1024];
 
-  @ViewChild(SourceZoomifyComponent)
-  source!: SourceZoomifyComponent;
+  readonly source = viewChild.required<SourceZoomifyComponent>(SourceZoomifyComponent);
 
-  @ViewChild(LayerTileComponent)
-  layer!: LayerTileComponent;
+  readonly layer = viewChild.required<LayerTileComponent>(LayerTileComponent);
 }
 
 describe('SourceZoomifyComponent', () => {
@@ -47,8 +45,8 @@ describe('SourceZoomifyComponent', () => {
   });
 
   it('binds a Zoomify source into the tile layer through template inputs', () => {
-    expect(fixture.componentInstance.layer.instance.getSource()).toBe(
-      fixture.componentInstance.source.instance,
+    expect(fixture.componentInstance.layer().instance.getSource()).toBe(
+      fixture.componentInstance.source().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/sources/zoomify.component.ts
+++ b/projects/ngx-ol/src/lib/sources/zoomify.component.ts
@@ -14,31 +14,31 @@ import { SourceComponent } from './source.component';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceZoomifyComponent) }],
 })
 export class SourceZoomifyComponent extends SourceComponent implements OnInit {
-  cacheSize = input<number>();
+  readonly cacheSize = input<number>();
 
-  crossOrigin = input<string | null>();
+  readonly crossOrigin = input<string | null>();
 
-  interpolate = input<boolean>();
+  readonly interpolate = input<boolean>();
 
-  projection = input<ProjectionLike>();
+  readonly projection = input<ProjectionLike>();
 
-  tilePixelRatio = input<number>();
+  readonly tilePixelRatio = input<number>();
 
-  reprojectionErrorThreshold = input<number>();
+  readonly reprojectionErrorThreshold = input<number>();
 
-  url = input.required<string>();
+  readonly url = input.required<string>();
 
-  tierSizeCalculation = input<TierSizeCalculation>();
+  readonly tierSizeCalculation = input<TierSizeCalculation>();
 
-  size = input.required<Size>();
+  readonly size = input.required<Size>();
 
-  extent = input<Extent>();
+  readonly extent = input<Extent>();
 
-  transition = input<number>();
+  readonly transition = input<number>();
 
-  tileSize = input<number>();
+  readonly tileSize = input<number>();
 
-  zDirection = input<number | NearestDirectionFunction>();
+  readonly zDirection = input<number | NearestDirectionFunction>();
 
   instance: Zoomify;
 

--- a/projects/ngx-ol/src/lib/sources/zoomify.component.ts
+++ b/projects/ngx-ol/src/lib/sources/zoomify.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, Host, Input, OnInit, Optional } from '@angular/core';
+import { Component, forwardRef, Host, OnInit, Optional, input, signal } from '@angular/core';
 import type { NearestDirectionFunction } from 'ol/array';
 import type { Extent } from 'ol/extent';
 import type { ProjectionLike } from 'ol/proj';
@@ -14,72 +14,70 @@ import { SourceComponent } from './source.component';
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceZoomifyComponent) }],
 })
 export class SourceZoomifyComponent extends SourceComponent implements OnInit {
-  @Input()
-  cacheSize?: number;
+  cacheSize = input<number>();
 
-  @Input()
-  crossOrigin?: string | null;
+  crossOrigin = input<string | null>();
 
-  @Input()
-  interpolate?: boolean;
+  interpolate = input<boolean>();
 
-  @Input()
-  projection?: ProjectionLike;
+  projection = input<ProjectionLike>();
 
-  @Input()
-  tilePixelRatio?: number;
+  tilePixelRatio = input<number>();
 
-  @Input()
-  reprojectionErrorThreshold?: number;
+  reprojectionErrorThreshold = input<number>();
 
-  @Input()
-  url!: string;
+  url = input.required<string>();
 
-  @Input()
-  tierSizeCalculation?: TierSizeCalculation;
+  tierSizeCalculation = input<TierSizeCalculation>();
 
-  @Input()
-  size!: Size;
+  size = input.required<Size>();
 
-  @Input()
-  extent?: Extent;
+  extent = input<Extent>();
 
-  @Input()
-  transition?: number;
+  transition = input<number>();
 
-  @Input()
-  tileSize?: number;
+  tileSize = input<number>();
 
-  @Input()
-  zDirection?: number | NearestDirectionFunction;
+  zDirection = input<number | NearestDirectionFunction>();
 
   instance: Zoomify;
 
+  protected readonly _instanceSignal = signal<Zoomify | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Zoomify): Zoomify {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Optional() @Host() layer?: LayerTileComponent) {
     super(layer!);
   }
 
   ngOnInit() {
-    this.instance = new Zoomify(this.createOptions());
+    this.setInstance(new Zoomify(this.createOptions()));
     this.register(this.instance);
   }
 
   private createOptions(): Options {
     return {
-      attributions: this.attributions,
-      cacheSize: this.cacheSize,
-      crossOrigin: this.crossOrigin,
-      interpolate: this.interpolate,
-      projection: this.projection,
-      tilePixelRatio: this.tilePixelRatio,
-      reprojectionErrorThreshold: this.reprojectionErrorThreshold,
-      url: this.url,
-      tierSizeCalculation: this.tierSizeCalculation,
-      size: this.size,
-      extent: this.extent,
-      transition: this.transition,
-      tileSize: this.tileSize,
-      zDirection: this.zDirection,
+      attributions: this.attributions(),
+      cacheSize: this.cacheSize(),
+      crossOrigin: this.crossOrigin(),
+      interpolate: this.interpolate(),
+      projection: this.projection(),
+      tilePixelRatio: this.tilePixelRatio(),
+      reprojectionErrorThreshold: this.reprojectionErrorThreshold(),
+      url: this.url(),
+      tierSizeCalculation: this.tierSizeCalculation(),
+      size: this.size(),
+      extent: this.extent(),
+      transition: this.transition(),
+      tileSize: this.tileSize(),
+      zDirection: this.zDirection(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/sources/zoomify.component.ts
+++ b/projects/ngx-ol/src/lib/sources/zoomify.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, Host, OnInit, Optional, input, signal } from '@angular/core';
+import { Component, forwardRef, OnInit, input, signal, inject } from '@angular/core';
 import type { NearestDirectionFunction } from 'ol/array';
 import type { Extent } from 'ol/extent';
 import type { ProjectionLike } from 'ol/proj';
@@ -53,8 +53,8 @@ export class SourceZoomifyComponent extends SourceComponent implements OnInit {
 
     return instance;
   }
-  constructor(@Optional() @Host() layer?: LayerTileComponent) {
-    super(layer!);
+  constructor() {
+    super(inject(LayerTileComponent, { optional: true, host: true })!);
   }
 
   ngOnInit() {

--- a/projects/ngx-ol/src/lib/styles/circle.component.spec.ts
+++ b/projects/ngx-ol/src/lib/styles/circle.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -28,11 +28,9 @@ class StyleCircleHostComponent {
   zoom = 2;
   radius = signal(8);
 
-  @ViewChild(StyleCircleComponent)
-  circle!: StyleCircleComponent;
+  readonly circle = viewChild.required<StyleCircleComponent>(StyleCircleComponent);
 
-  @ViewChild(StyleComponent)
-  style!: StyleComponent;
+  readonly style = viewChild.required<StyleComponent>(StyleComponent);
 }
 
 describe('StyleCircleComponent', () => {
@@ -52,9 +50,9 @@ describe('StyleCircleComponent', () => {
   });
 
   it('creates a circle image style and applies it to the style host', () => {
-    expect(fixture.componentInstance.circle.instance.getRadius()).toBe(8);
-    expect(fixture.componentInstance.style.instance.getImage()).toBe(
-      fixture.componentInstance.circle.instance,
+    expect(fixture.componentInstance.circle().instance.getRadius()).toBe(8);
+    expect(fixture.componentInstance.style().instance.getImage()).toBe(
+      fixture.componentInstance.circle().instance,
     );
   });
 
@@ -63,9 +61,9 @@ describe('StyleCircleComponent', () => {
 
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.circle.instance.getRadius()).toBe(12);
-    expect(fixture.componentInstance.style.instance.getImage()).toBe(
-      fixture.componentInstance.circle.instance,
+    expect(fixture.componentInstance.circle().instance.getRadius()).toBe(12);
+    expect(fixture.componentInstance.style().instance.getImage()).toBe(
+      fixture.componentInstance.circle().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/styles/circle.component.spec.ts
+++ b/projects/ngx-ol/src/lib/styles/circle.component.spec.ts
@@ -2,6 +2,7 @@ import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
+import { FeatureComponent } from '../feature.component';
 import { StyleComponent } from './style.component';
 import { StyleCircleComponent } from './circle.component';
 
@@ -31,6 +32,8 @@ class StyleCircleHostComponent {
   readonly circle = viewChild.required<StyleCircleComponent>(StyleCircleComponent);
 
   readonly style = viewChild.required<StyleComponent>(StyleComponent);
+
+  readonly feature = viewChild.required<FeatureComponent>(FeatureComponent);
 }
 
 describe('StyleCircleComponent', () => {
@@ -57,6 +60,8 @@ describe('StyleCircleComponent', () => {
   });
 
   it('updates the OpenLayers circle style when the radius binding changes', () => {
+    const revision = fixture.componentInstance.feature().instance.getRevision();
+
     fixture.componentInstance.radius.set(12);
 
     fixture.detectChanges(false);
@@ -65,5 +70,6 @@ describe('StyleCircleComponent', () => {
     expect(fixture.componentInstance.style().instance.getImage()).toBe(
       fixture.componentInstance.circle().instance,
     );
+    expect(fixture.componentInstance.feature().instance.getRevision()).toBeGreaterThan(revision);
   });
 });

--- a/projects/ngx-ol/src/lib/styles/circle.component.ts
+++ b/projects/ngx-ol/src/lib/styles/circle.component.ts
@@ -106,6 +106,7 @@ export class StyleCircleComponent implements AfterContentInit, OnChanges, OnDest
     if (changes.stroke) {
       this.instance.setStroke(changes.stroke.currentValue);
     }
+    this.host.update();
     // console.log('changes detected in aol-style-circle, setting new radius: ', changes['radius'].currentValue);
   }
 

--- a/projects/ngx-ol/src/lib/styles/circle.component.ts
+++ b/projects/ngx-ol/src/lib/styles/circle.component.ts
@@ -21,16 +21,16 @@ import { DeclutterMode } from 'ol/style/Style';
   template: ` <ng-content></ng-content> `,
 })
 export class StyleCircleComponent implements AfterContentInit, OnChanges, OnDestroy {
-  fill = input<Fill>();
-  radius = input.required<number>();
-  stroke = input<Stroke>();
-  displacement = input<number[]>();
-  scale = input<number | Size>();
-  rotation = input<number>();
-  rotateWithView = input<boolean>();
-  declutterMode = input<DeclutterMode>();
+  readonly fill = input<Fill>();
+  readonly radius = input.required<number>();
+  readonly stroke = input<Stroke>();
+  readonly displacement = input<number[]>();
+  readonly scale = input<number | Size>();
+  readonly rotation = input<number>();
+  readonly rotateWithView = input<boolean>();
+  readonly declutterMode = input<DeclutterMode>();
 
-  public componentType = 'style-circle';
+  readonly componentType: string = 'style-circle';
   public instance: Circle;
   private childFill?: Fill;
   private childStroke?: Stroke;

--- a/projects/ngx-ol/src/lib/styles/circle.component.ts
+++ b/projects/ngx-ol/src/lib/styles/circle.component.ts
@@ -1,10 +1,10 @@
 import {
-  Component,
-  Host,
   AfterContentInit,
+  Component,
   OnChanges,
   OnDestroy,
   SimpleChanges,
+  inject,
   input,
   signal,
 } from '@angular/core';
@@ -43,7 +43,7 @@ export class StyleCircleComponent implements AfterContentInit, OnChanges, OnDest
     this._instanceSignal.set(instance);
     return instance;
   }
-  constructor(@Host() private host: StyleComponent) {}
+  private readonly host = inject(StyleComponent, { host: true });
 
   setFill(fill: Fill) {
     this.childFill = fill;

--- a/projects/ngx-ol/src/lib/styles/circle.component.ts
+++ b/projects/ngx-ol/src/lib/styles/circle.component.ts
@@ -88,6 +88,24 @@ export class StyleCircleComponent implements AfterContentInit, OnChanges, OnDest
     if (changes.radius) {
       this.instance.setRadius(changes.radius.currentValue);
     }
+    if (changes.displacement) {
+      this.instance.setDisplacement(changes.displacement.currentValue);
+    }
+    if (changes.scale) {
+      this.instance.setScale(changes.scale.currentValue);
+    }
+    if (changes.rotation) {
+      this.instance.setRotation(changes.rotation.currentValue);
+    }
+    if (changes.rotateWithView?.currentValue !== undefined) {
+      this.instance.setRotateWithView(changes.rotateWithView.currentValue);
+    }
+    if (changes.fill) {
+      this.instance.setFill(changes.fill.currentValue);
+    }
+    if (changes.stroke) {
+      this.instance.setStroke(changes.stroke.currentValue);
+    }
     // console.log('changes detected in aol-style-circle, setting new radius: ', changes['radius'].currentValue);
   }
 

--- a/projects/ngx-ol/src/lib/styles/circle.component.ts
+++ b/projects/ngx-ol/src/lib/styles/circle.component.ts
@@ -1,11 +1,12 @@
 import {
   Component,
-  Input,
   Host,
   AfterContentInit,
   OnChanges,
   OnDestroy,
   SimpleChanges,
+  input,
+  signal,
 } from '@angular/core';
 import Circle from 'ol/style/Circle';
 import Fill from 'ol/style/Fill';
@@ -20,27 +21,45 @@ import { DeclutterMode } from 'ol/style/Style';
   template: ` <ng-content></ng-content> `,
 })
 export class StyleCircleComponent implements AfterContentInit, OnChanges, OnDestroy {
-  @Input()
-  fill?: Fill;
-  @Input()
-  radius: number;
-  @Input()
-  stroke?: Stroke;
-  @Input()
-  displacement?: number[];
-  @Input()
-  scale?: number | Size;
-  @Input()
-  rotation?: number;
-  @Input()
-  rotateWithView?: boolean;
-  @Input()
-  declutterMode?: DeclutterMode;
+  fill = input<Fill>();
+  radius = input.required<number>();
+  stroke = input<Stroke>();
+  displacement = input<number[]>();
+  scale = input<number | Size>();
+  rotation = input<number>();
+  rotateWithView = input<boolean>();
+  declutterMode = input<DeclutterMode>();
 
   public componentType = 'style-circle';
   public instance: Circle;
+  private childFill?: Fill;
+  private childStroke?: Stroke;
 
+  protected readonly _instanceSignal = signal<Circle | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Circle): Circle {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   constructor(@Host() private host: StyleComponent) {}
+
+  setFill(fill: Fill) {
+    this.childFill = fill;
+    if (this.instance) {
+      this.instance.setFill(fill);
+    }
+    this.host.update();
+  }
+
+  setStroke(stroke: Stroke) {
+    this.childStroke = stroke;
+    if (this.instance) {
+      this.instance.setStroke(stroke);
+    }
+    this.host.update();
+  }
 
   /**
    * WORK-AROUND: since the re-rendering is not triggered on style change
@@ -50,14 +69,14 @@ export class StyleCircleComponent implements AfterContentInit, OnChanges, OnDest
   update() {
     if (!!this.instance) {
       // console.log('setting ol.style.Circle instance\'s radius');
-      this.instance.setRadius(this.radius);
+      this.instance.setRadius(this.radius());
     }
     this.host.update();
   }
 
   ngAfterContentInit() {
     // console.log('creating ol.style.Circle instance with: ', this);
-    this.instance = new Circle(this.createOptions());
+    this.setInstance(new Circle(this.createOptions()));
     this.host.instance.setImage(this.instance);
     this.host.update();
   }
@@ -79,14 +98,14 @@ export class StyleCircleComponent implements AfterContentInit, OnChanges, OnDest
 
   private createOptions(): Options {
     return {
-      fill: this.fill,
-      radius: this.radius,
-      stroke: this.stroke,
-      displacement: this.displacement,
-      scale: this.scale,
-      rotation: this.rotation,
-      rotateWithView: this.rotateWithView,
-      declutterMode: this.declutterMode,
+      fill: this.childFill ?? this.fill(),
+      radius: this.radius(),
+      stroke: this.childStroke ?? this.stroke(),
+      displacement: this.displacement(),
+      scale: this.scale(),
+      rotation: this.rotation(),
+      rotateWithView: this.rotateWithView(),
+      declutterMode: this.declutterMode(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/styles/fill.component.spec.ts
+++ b/projects/ngx-ol/src/lib/styles/fill.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, QueryList, signal, ViewChild, ViewChildren } from '@angular/core';
+import { Component, signal, viewChild, viewChildren } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -30,11 +30,9 @@ class StyleFillHostComponent {
   zoom = 2;
   color = signal('#00ff00');
 
-  @ViewChild(StyleFillComponent)
-  fill!: StyleFillComponent;
+  readonly fill = viewChild.required<StyleFillComponent>(StyleFillComponent);
 
-  @ViewChild(StyleComponent)
-  style!: StyleComponent;
+  readonly style = viewChild.required<StyleComponent>(StyleComponent);
 }
 
 @Component({
@@ -75,14 +73,11 @@ class NestedStyleFillHostComponent {
   text = 'Label';
   textColor = '#0000ff';
 
-  @ViewChild(StyleCircleComponent)
-  circle!: StyleCircleComponent;
+  readonly circle = viewChild.required<StyleCircleComponent>(StyleCircleComponent);
 
-  @ViewChild(StyleTextComponent)
-  textStyle!: StyleTextComponent;
+  readonly textStyle = viewChild.required<StyleTextComponent>(StyleTextComponent);
 
-  @ViewChildren(StyleFillComponent)
-  fills!: QueryList<StyleFillComponent>;
+  readonly fills = viewChildren<StyleFillComponent>(StyleFillComponent);
 }
 
 describe('StyleFillComponent', () => {
@@ -106,9 +101,9 @@ describe('StyleFillComponent', () => {
   });
 
   it('creates a fill and applies it to the style host', () => {
-    expect(fixture.componentInstance.fill.instance.getColor()).toBe('#00ff00');
-    expect(fixture.componentInstance.style.instance.getFill()).toBe(
-      fixture.componentInstance.fill.instance,
+    expect(fixture.componentInstance.fill().instance.getColor()).toBe('#00ff00');
+    expect(fixture.componentInstance.style().instance.getFill()).toBe(
+      fixture.componentInstance.fill().instance,
     );
   });
 
@@ -117,9 +112,9 @@ describe('StyleFillComponent', () => {
 
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.fill.instance.getColor()).toBe('#0000ff');
-    expect(fixture.componentInstance.style.instance.getFill()).toBe(
-      fixture.componentInstance.fill.instance,
+    expect(fixture.componentInstance.fill().instance.getColor()).toBe('#0000ff');
+    expect(fixture.componentInstance.style().instance.getFill()).toBe(
+      fixture.componentInstance.fill().instance,
     );
   });
 
@@ -132,10 +127,10 @@ describe('StyleFillComponent', () => {
   it('applies fill children to circle and text style hosts', () => {
     const nestedFixture = TestBed.createComponent(NestedStyleFillHostComponent);
     nestedFixture.detectChanges();
-    const fills = nestedFixture.componentInstance.fills.toArray();
+    const fills = nestedFixture.componentInstance.fills();
 
-    expect(nestedFixture.componentInstance.circle.instance.getFill()).toBe(fills[0].instance);
-    expect(nestedFixture.componentInstance.textStyle.instance.getFill()).toBe(fills[1].instance);
+    expect(nestedFixture.componentInstance.circle().instance.getFill()).toBe(fills[0].instance);
+    expect(nestedFixture.componentInstance.textStyle().instance.getFill()).toBe(fills[1].instance);
 
     nestedFixture.destroy();
   });

--- a/projects/ngx-ol/src/lib/styles/fill.component.ts
+++ b/projects/ngx-ol/src/lib/styles/fill.component.ts
@@ -1,4 +1,12 @@
-import { Component, Input, Optional, OnInit, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  Optional,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import Fill from 'ol/style/Fill';
 import { Options } from 'ol/style/Fill';
 import { StyleComponent } from './style.component';
@@ -12,10 +20,21 @@ import { ColorLike, PatternDescriptor } from 'ol/colorlike';
   template: ` <div class="aol-style-fill"></div> `,
 })
 export class StyleFillComponent implements OnInit, OnChanges {
-  @Input()
-  color?: Color | ColorLike | PatternDescriptor | null;
+  color = input<Color | ColorLike | PatternDescriptor | null>();
 
   public instance: Fill;
+
+  protected readonly _instanceSignal = signal<Fill | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Fill): Fill {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   private readonly host: StyleComponent | StyleCircleComponent | StyleTextComponent;
 
   constructor(
@@ -38,7 +57,7 @@ export class StyleFillComponent implements OnInit, OnChanges {
 
   ngOnInit() {
     // console.log('creating ol.style.Fill instance with: ', this);
-    this.instance = new Fill(this.createOptions());
+    this.setInstance(new Fill(this.createOptions()));
     switch (this.host.componentType) {
       case 'style':
         this.host.instance.setFill(this.instance);
@@ -48,7 +67,7 @@ export class StyleFillComponent implements OnInit, OnChanges {
         this.host.instance.setFill(this.instance);
         break;
       case 'style-circle':
-        (this.host as StyleCircleComponent).fill = this.instance;
+        (this.host as StyleCircleComponent).setFill(this.instance);
         // console.log('setting ol.style.circle instance\'s fill:', this.host);
         break;
       default:
@@ -69,7 +88,7 @@ export class StyleFillComponent implements OnInit, OnChanges {
 
   private createOptions(): Options {
     return {
-      color: this.color,
+      color: this.color(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/styles/fill.component.ts
+++ b/projects/ngx-ol/src/lib/styles/fill.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  Optional,
-  OnInit,
-  OnChanges,
-  SimpleChanges,
-  input,
-  signal,
-} from '@angular/core';
+import { Component, OnInit, OnChanges, SimpleChanges, inject, input, signal } from '@angular/core';
 import Fill from 'ol/style/Fill';
 import { Options } from 'ol/style/Fill';
 import { StyleComponent } from './style.component';
@@ -36,21 +28,20 @@ export class StyleFillComponent implements OnInit, OnChanges {
     return instance;
   }
   private readonly host: StyleComponent | StyleCircleComponent | StyleTextComponent;
+  private readonly styleHost = inject(StyleComponent, { optional: true });
+  private readonly styleCircleHost = inject(StyleCircleComponent, { optional: true });
+  private readonly styleTextHost = inject(StyleTextComponent, { optional: true });
 
-  constructor(
-    @Optional() styleHost: StyleComponent,
-    @Optional() styleCircleHost: StyleCircleComponent,
-    @Optional() styleTextHost: StyleTextComponent,
-  ) {
-    if (!styleHost) {
+  constructor() {
+    if (!this.styleHost) {
       throw new Error('aol-style-fill must be a descendant of aol-style');
     }
-    if (!!styleTextHost) {
-      this.host = styleTextHost;
-    } else if (!!styleCircleHost) {
-      this.host = styleCircleHost;
+    if (!!this.styleTextHost) {
+      this.host = this.styleTextHost;
+    } else if (!!this.styleCircleHost) {
+      this.host = this.styleCircleHost;
     } else {
-      this.host = styleHost;
+      this.host = this.styleHost;
     }
     // console.log('creating aol-style-fill with: ', this);
   }

--- a/projects/ngx-ol/src/lib/styles/fill.component.ts
+++ b/projects/ngx-ol/src/lib/styles/fill.component.ts
@@ -12,7 +12,7 @@ import { ColorLike, PatternDescriptor } from 'ol/colorlike';
   template: ` <div class="aol-style-fill"></div> `,
 })
 export class StyleFillComponent implements OnInit, OnChanges {
-  color = input<Color | ColorLike | PatternDescriptor | null>();
+  readonly color = input<Color | ColorLike | PatternDescriptor | null>();
 
   public instance: Fill;
 

--- a/projects/ngx-ol/src/lib/styles/icon.component.spec.ts
+++ b/projects/ngx-ol/src/lib/styles/icon.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -36,11 +36,9 @@ class StyleIconHostComponent {
   rotation = signal(0);
   scale = signal(1);
 
-  @ViewChild(StyleIconComponent)
-  icon!: StyleIconComponent;
+  readonly icon = viewChild.required<StyleIconComponent>(StyleIconComponent);
 
-  @ViewChild(StyleComponent)
-  style!: StyleComponent;
+  readonly style = viewChild.required<StyleComponent>(StyleComponent);
 }
 
 describe('StyleIconComponent', () => {
@@ -60,14 +58,14 @@ describe('StyleIconComponent', () => {
   });
 
   it('creates an icon style and applies it to the style host', () => {
-    expect(fixture.componentInstance.icon.instance.getOpacity()).toBe(0.5);
-    expect(fixture.componentInstance.style.instance.getImage()).toBe(
-      fixture.componentInstance.icon.instance,
+    expect(fixture.componentInstance.icon().instance.getOpacity()).toBe(0.5);
+    expect(fixture.componentInstance.style().instance.getImage()).toBe(
+      fixture.componentInstance.icon().instance,
     );
   });
 
   it('updates the OpenLayers icon style when template bindings change', () => {
-    const previousIcon = fixture.componentInstance.icon.instance;
+    const previousIcon = fixture.componentInstance.icon().instance;
 
     fixture.componentInstance.opacity.set(0.75);
     fixture.componentInstance.rotation.set(1);
@@ -76,12 +74,12 @@ describe('StyleIconComponent', () => {
 
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.icon.instance).not.toBe(previousIcon);
-    expect(fixture.componentInstance.icon.instance.getOpacity()).toBe(0.75);
-    expect(fixture.componentInstance.icon.instance.getRotation()).toBe(1);
-    expect(fixture.componentInstance.icon.instance.getScale()).toBe(2);
-    expect(fixture.componentInstance.style.instance.getImage()).toBe(
-      fixture.componentInstance.icon.instance,
+    expect(fixture.componentInstance.icon().instance).not.toBe(previousIcon);
+    expect(fixture.componentInstance.icon().instance.getOpacity()).toBe(0.75);
+    expect(fixture.componentInstance.icon().instance.getRotation()).toBe(1);
+    expect(fixture.componentInstance.icon().instance.getScale()).toBe(2);
+    expect(fixture.componentInstance.style().instance.getImage()).toBe(
+      fixture.componentInstance.icon().instance,
     );
   });
 });

--- a/projects/ngx-ol/src/lib/styles/icon.component.ts
+++ b/projects/ngx-ol/src/lib/styles/icon.component.ts
@@ -57,8 +57,17 @@ export class StyleIconComponent implements OnInit, OnChanges {
     if (!this.instance) {
       return;
     }
+    if (changes.anchor) {
+      this.instance.setAnchor(changes.anchor.currentValue);
+    }
+    if (changes.displacement) {
+      this.instance.setDisplacement(changes.displacement.currentValue);
+    }
     if (changes.opacity) {
       this.instance.setOpacity(changes.opacity.currentValue);
+    }
+    if (changes.rotateWithView?.currentValue !== undefined) {
+      this.instance.setRotateWithView(changes.rotateWithView.currentValue);
     }
     if (changes.rotation) {
       this.instance.setRotation(changes.rotation.currentValue);

--- a/projects/ngx-ol/src/lib/styles/icon.component.ts
+++ b/projects/ngx-ol/src/lib/styles/icon.component.ts
@@ -1,4 +1,4 @@
-import { Component, Host, OnInit, OnChanges, SimpleChanges, input, signal } from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges, inject, input, signal } from '@angular/core';
 import Icon from 'ol/style/Icon';
 
 import { StyleComponent } from './style.component';
@@ -45,7 +45,7 @@ export class StyleIconComponent implements OnInit, OnChanges {
 
     return instance;
   }
-  constructor(@Host() private host: StyleComponent) {}
+  private readonly host = inject(StyleComponent, { host: true });
 
   ngOnInit() {
     // console.log('creating ol.style.Icon instance with: ', this);

--- a/projects/ngx-ol/src/lib/styles/icon.component.ts
+++ b/projects/ngx-ol/src/lib/styles/icon.component.ts
@@ -12,25 +12,25 @@ import { DeclutterMode } from 'ol/style/Style';
   template: ` <div class="aol-style-icon"></div> `,
 })
 export class StyleIconComponent implements OnInit, OnChanges {
-  anchor = input<[number, number]>();
-  anchorXUnits = input<IconAnchorUnits>();
-  anchorYUnits = input<IconAnchorUnits>();
-  anchorOrigin = input<IconOrigin>();
-  color = input<string | Color>();
-  crossOrigin = input<string | null>();
-  img = input<HTMLCanvasElement | HTMLImageElement | ImageBitmap>();
-  displacement = input<number[]>();
-  offset = input<[number, number]>();
-  offsetOrigin = input<IconOrigin>();
-  opacity = input<number>();
-  width = input<number>();
-  height = input<number>();
-  scale = input<number | Size>();
-  declutterMode = input<DeclutterMode>();
-  rotateWithView = input<boolean>();
-  rotation = input<number>();
-  size = input<[number, number]>();
-  src = input<string>();
+  readonly anchor = input<[number, number]>();
+  readonly anchorXUnits = input<IconAnchorUnits>();
+  readonly anchorYUnits = input<IconAnchorUnits>();
+  readonly anchorOrigin = input<IconOrigin>();
+  readonly color = input<string | Color>();
+  readonly crossOrigin = input<string | null>();
+  readonly img = input<HTMLCanvasElement | HTMLImageElement | ImageBitmap>();
+  readonly displacement = input<number[]>();
+  readonly offset = input<[number, number]>();
+  readonly offsetOrigin = input<IconOrigin>();
+  readonly opacity = input<number>();
+  readonly width = input<number>();
+  readonly height = input<number>();
+  readonly scale = input<number | Size>();
+  readonly declutterMode = input<DeclutterMode>();
+  readonly rotateWithView = input<boolean>();
+  readonly rotation = input<number>();
+  readonly size = input<[number, number]>();
+  readonly src = input<string>();
 
   public instance: Icon;
 

--- a/projects/ngx-ol/src/lib/styles/icon.component.ts
+++ b/projects/ngx-ol/src/lib/styles/icon.component.ts
@@ -1,6 +1,5 @@
-import { Component, Input, Host, OnInit, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Host, OnInit, OnChanges, SimpleChanges, input, signal } from '@angular/core';
 import Icon from 'ol/style/Icon';
-
 
 import { StyleComponent } from './style.component';
 import { IconAnchorUnits, IconOrigin, Options } from 'ol/style/Icon';
@@ -13,52 +12,44 @@ import { DeclutterMode } from 'ol/style/Style';
   template: ` <div class="aol-style-icon"></div> `,
 })
 export class StyleIconComponent implements OnInit, OnChanges {
-  @Input()
-  anchor?: [number, number];
-  @Input()
-  anchorXUnits?: IconAnchorUnits;
-  @Input()
-  anchorYUnits?: IconAnchorUnits;
-  @Input()
-  anchorOrigin?: IconOrigin;
-  @Input()
-  color?: string | Color;
-  @Input()
-  crossOrigin?: string | null;
-  @Input()
-  img?: HTMLCanvasElement | HTMLImageElement | ImageBitmap;
-  @Input()
-  displacement?: number[];
-  @Input()
-  offset?: [number, number];
-  @Input()
-  offsetOrigin?: IconOrigin;
-  @Input()
-  opacity?: number;
-  @Input()
-  width?: number;
-  @Input()
-  height?: number;
-  @Input()
-  scale?: number | Size;
-  @Input()
-  declutterMode?: DeclutterMode;
-  @Input()
-  rotateWithView?: boolean;
-  @Input()
-  rotation?: number;
-  @Input()
-  size?: [number, number];
-  @Input()
-  src?: string;
+  anchor = input<[number, number]>();
+  anchorXUnits = input<IconAnchorUnits>();
+  anchorYUnits = input<IconAnchorUnits>();
+  anchorOrigin = input<IconOrigin>();
+  color = input<string | Color>();
+  crossOrigin = input<string | null>();
+  img = input<HTMLCanvasElement | HTMLImageElement | ImageBitmap>();
+  displacement = input<number[]>();
+  offset = input<[number, number]>();
+  offsetOrigin = input<IconOrigin>();
+  opacity = input<number>();
+  width = input<number>();
+  height = input<number>();
+  scale = input<number | Size>();
+  declutterMode = input<DeclutterMode>();
+  rotateWithView = input<boolean>();
+  rotation = input<number>();
+  size = input<[number, number]>();
+  src = input<string>();
 
   public instance: Icon;
 
+  protected readonly _instanceSignal = signal<Icon | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Icon): Icon {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   constructor(@Host() private host: StyleComponent) {}
 
   ngOnInit() {
     // console.log('creating ol.style.Icon instance with: ', this);
-    this.instance = new Icon(this.createOptions());
+    this.setInstance(new Icon(this.createOptions()));
     this.host.instance.setImage(this.instance);
   }
 
@@ -76,7 +67,7 @@ export class StyleIconComponent implements OnInit, OnChanges {
       this.instance.setScale(changes.scale.currentValue);
     }
     if (changes.src) {
-      this.instance = new Icon(this.createOptions());
+      this.setInstance(new Icon(this.createOptions()));
       this.host.instance.setImage(this.instance);
     }
     this.host.update();
@@ -85,25 +76,25 @@ export class StyleIconComponent implements OnInit, OnChanges {
 
   private createOptions(): Options {
     return {
-      anchor: this.anchor,
-      anchorXUnits: this.anchorXUnits,
-      anchorYUnits: this.anchorYUnits,
-      anchorOrigin: this.anchorOrigin,
-      color: this.color,
-      crossOrigin: this.crossOrigin,
-      img: this.img,
-      displacement: this.displacement,
-      offset: this.offset,
-      offsetOrigin: this.offsetOrigin,
-      opacity: this.opacity,
-      width: this.width,
-      height: this.height,
-      scale: this.scale,
-      declutterMode: this.declutterMode,
-      rotateWithView: this.rotateWithView,
-      rotation: this.rotation,
-      size: this.size,
-      src: this.src,
+      anchor: this.anchor(),
+      anchorXUnits: this.anchorXUnits(),
+      anchorYUnits: this.anchorYUnits(),
+      anchorOrigin: this.anchorOrigin(),
+      color: this.color(),
+      crossOrigin: this.crossOrigin(),
+      img: this.img(),
+      displacement: this.displacement(),
+      offset: this.offset(),
+      offsetOrigin: this.offsetOrigin(),
+      opacity: this.opacity(),
+      width: this.width(),
+      height: this.height(),
+      scale: this.scale(),
+      declutterMode: this.declutterMode(),
+      rotateWithView: this.rotateWithView(),
+      rotation: this.rotation(),
+      size: this.size(),
+      src: this.src(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/styles/regularshape.component.spec.ts
+++ b/projects/ngx-ol/src/lib/styles/regularshape.component.spec.ts
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
 import { StyleComponent } from './style.component';
 import { StyleRegularShapeComponent } from './regularshape.component';
+import Fill from 'ol/style/Fill';
+import Stroke from 'ol/style/Stroke';
 
 @Component({
   template: `
@@ -17,12 +19,14 @@ import { StyleRegularShapeComponent } from './regularshape.component';
                 [angle]="angle()"
                 [declutterMode]="declutterMode()"
                 [displacement]="displacement()"
+                [fill]="fill()"
                 [points]="points()"
                 [radius]="radius()"
                 [radius2]="radius2()"
                 [rotateWithView]="rotateWithView()"
                 [rotation]="rotation()"
                 [scale]="scale()"
+                [stroke]="stroke()"
               ></aol-style-regularshape>
             </aol-style>
           </aol-feature>
@@ -39,12 +43,14 @@ class StyleRegularShapeHostComponent {
   angle = signal(0);
   declutterMode = signal<'declutter' | 'obstacle' | 'none'>('declutter');
   displacement = signal([0, 0]);
+  fill = signal(new Fill({ color: '#ff0000' }));
   points = signal(5);
   radius = signal(14);
   radius2 = signal(7);
   rotateWithView = signal(false);
   rotation = signal(0);
   scale = signal(1);
+  stroke = signal(new Stroke({ color: '#0000ff', width: 2 }));
 
   @ViewChild(StyleRegularShapeComponent)
   regularShape!: StyleRegularShapeComponent;
@@ -126,5 +132,21 @@ describe('StyleRegularShapeComponent', () => {
     expectRecreatedAfter(() => fixture.componentInstance.rotateWithView.set(true));
     expectRecreatedAfter(() => fixture.componentInstance.scale.set(2));
     expectRecreatedAfter(() => fixture.componentInstance.declutterMode.set('obstacle'));
+  });
+
+  it('updates fill and stroke without recreating the regular shape', () => {
+    const previousShape = fixture.componentInstance.regularShape.instance;
+    const nextFill = new Fill({ color: '#00ff00' });
+    const nextStroke = new Stroke({ color: '#111111', width: 4 });
+
+    fixture.componentInstance.fill.set(nextFill);
+    fixture.componentInstance.stroke.set(nextStroke);
+
+    fixture.detectChanges(false);
+
+    expect(fixture.componentInstance.regularShape.instance).toBe(previousShape);
+    expect(fixture.componentInstance.regularShape.instance.getFill()).toBe(nextFill);
+    expect(fixture.componentInstance.regularShape.instance.getStroke()).toBe(nextStroke);
+    expect(fixture.componentInstance.style.instance.getImage()).toBe(previousShape);
   });
 });

--- a/projects/ngx-ol/src/lib/styles/regularshape.component.spec.ts
+++ b/projects/ngx-ol/src/lib/styles/regularshape.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -52,11 +52,11 @@ class StyleRegularShapeHostComponent {
   scale = signal(1);
   stroke = signal(new Stroke({ color: '#0000ff', width: 2 }));
 
-  @ViewChild(StyleRegularShapeComponent)
-  regularShape!: StyleRegularShapeComponent;
+  readonly regularShape = viewChild.required<StyleRegularShapeComponent>(
+    StyleRegularShapeComponent,
+  );
 
-  @ViewChild(StyleComponent)
-  style!: StyleComponent;
+  readonly style = viewChild.required<StyleComponent>(StyleComponent);
 }
 
 describe('StyleRegularShapeComponent', () => {
@@ -76,18 +76,18 @@ describe('StyleRegularShapeComponent', () => {
   });
 
   it('creates a regular shape image style and applies it to the style host', () => {
-    expect(fixture.componentInstance.regularShape.instance.getRadius()).toBe(14);
-    expect(fixture.componentInstance.regularShape.instance.getDisplacement()).toEqual([0, 0]);
-    expect(fixture.componentInstance.regularShape.instance.getRotateWithView()).toBe(false);
-    expect(fixture.componentInstance.regularShape.instance.getRotation()).toBe(0);
-    expect(fixture.componentInstance.regularShape.instance.getScale()).toBe(1);
-    expect(fixture.componentInstance.style.instance.getImage()).toBe(
-      fixture.componentInstance.regularShape.instance,
+    expect(fixture.componentInstance.regularShape().instance.getRadius()).toBe(14);
+    expect(fixture.componentInstance.regularShape().instance.getDisplacement()).toEqual([0, 0]);
+    expect(fixture.componentInstance.regularShape().instance.getRotateWithView()).toBe(false);
+    expect(fixture.componentInstance.regularShape().instance.getRotation()).toBe(0);
+    expect(fixture.componentInstance.regularShape().instance.getScale()).toBe(1);
+    expect(fixture.componentInstance.style().instance.getImage()).toBe(
+      fixture.componentInstance.regularShape().instance,
     );
   });
 
   it('recreates and reapplies the OpenLayers regular shape when template bindings change', () => {
-    const previousShape = fixture.componentInstance.regularShape.instance;
+    const previousShape = fixture.componentInstance.regularShape().instance;
 
     fixture.componentInstance.angle.set(1);
     fixture.componentInstance.declutterMode.set('obstacle');
@@ -101,27 +101,27 @@ describe('StyleRegularShapeComponent', () => {
 
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.regularShape.instance).not.toBe(previousShape);
-    expect(fixture.componentInstance.regularShape.instance.getRadius()).toBe(18);
-    expect(fixture.componentInstance.regularShape.instance.getDisplacement()).toEqual([4, 8]);
-    expect(fixture.componentInstance.regularShape.instance.getRotateWithView()).toBe(true);
-    expect(fixture.componentInstance.regularShape.instance.getRotation()).toBe(2);
-    expect(fixture.componentInstance.regularShape.instance.getScale()).toBe(1.5);
-    expect(fixture.componentInstance.style.instance.getImage()).toBe(
-      fixture.componentInstance.regularShape.instance,
+    expect(fixture.componentInstance.regularShape().instance).not.toBe(previousShape);
+    expect(fixture.componentInstance.regularShape().instance.getRadius()).toBe(18);
+    expect(fixture.componentInstance.regularShape().instance.getDisplacement()).toEqual([4, 8]);
+    expect(fixture.componentInstance.regularShape().instance.getRotateWithView()).toBe(true);
+    expect(fixture.componentInstance.regularShape().instance.getRotation()).toBe(2);
+    expect(fixture.componentInstance.regularShape().instance.getScale()).toBe(1.5);
+    expect(fixture.componentInstance.style().instance.getImage()).toBe(
+      fixture.componentInstance.regularShape().instance,
     );
   });
 
   it('recreates the regular shape when each optional shape binding changes independently', () => {
     const expectRecreatedAfter = (updateBinding: () => void) => {
-      const previousShape = fixture.componentInstance.regularShape.instance;
+      const previousShape = fixture.componentInstance.regularShape().instance;
 
       updateBinding();
       fixture.detectChanges(false);
 
-      expect(fixture.componentInstance.regularShape.instance).not.toBe(previousShape);
-      expect(fixture.componentInstance.style.instance.getImage()).toBe(
-        fixture.componentInstance.regularShape.instance,
+      expect(fixture.componentInstance.regularShape().instance).not.toBe(previousShape);
+      expect(fixture.componentInstance.style().instance.getImage()).toBe(
+        fixture.componentInstance.regularShape().instance,
       );
     };
 
@@ -135,7 +135,7 @@ describe('StyleRegularShapeComponent', () => {
   });
 
   it('updates fill and stroke without recreating the regular shape', () => {
-    const previousShape = fixture.componentInstance.regularShape.instance;
+    const previousShape = fixture.componentInstance.regularShape().instance;
     const nextFill = new Fill({ color: '#00ff00' });
     const nextStroke = new Stroke({ color: '#111111', width: 4 });
 
@@ -144,9 +144,9 @@ describe('StyleRegularShapeComponent', () => {
 
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.regularShape.instance).toBe(previousShape);
-    expect(fixture.componentInstance.regularShape.instance.getFill()).toBe(nextFill);
-    expect(fixture.componentInstance.regularShape.instance.getStroke()).toBe(nextStroke);
-    expect(fixture.componentInstance.style.instance.getImage()).toBe(previousShape);
+    expect(fixture.componentInstance.regularShape().instance).toBe(previousShape);
+    expect(fixture.componentInstance.regularShape().instance.getFill()).toBe(nextFill);
+    expect(fixture.componentInstance.regularShape().instance.getStroke()).toBe(nextStroke);
+    expect(fixture.componentInstance.style().instance.getImage()).toBe(previousShape);
   });
 });

--- a/projects/ngx-ol/src/lib/styles/regularshape.component.ts
+++ b/projects/ngx-ol/src/lib/styles/regularshape.component.ts
@@ -58,7 +58,8 @@ export class StyleRegularShapeComponent implements AfterContentInit, OnChanges, 
 
   update() {
     if (this.instance) {
-      this.setInstance(new RegularShape(this.createOptions()));
+      this.instance.setFill(this.fill() ?? null);
+      this.instance.setStroke(this.stroke() ?? null);
       this.host.instance.setImage(this.instance);
     }
     this.host.update();
@@ -85,6 +86,29 @@ export class StyleRegularShapeComponent implements AfterContentInit, OnChanges, 
         !changes.scale &&
         !changes.declutterMode)
     ) {
+      return;
+    }
+
+    const requiresReload =
+      changes.points ||
+      changes.radius ||
+      changes.radius2 ||
+      changes.angle ||
+      changes.displacement ||
+      changes.rotation ||
+      changes.rotateWithView ||
+      changes.scale ||
+      changes.declutterMode;
+
+    if (!requiresReload) {
+      if (changes.fill) {
+        this.instance.setFill(changes.fill.currentValue ?? null);
+      }
+      if (changes.stroke) {
+        this.instance.setStroke(changes.stroke.currentValue ?? null);
+      }
+      this.host.instance.setImage(this.instance);
+      this.host.update();
       return;
     }
 

--- a/projects/ngx-ol/src/lib/styles/regularshape.component.ts
+++ b/projects/ngx-ol/src/lib/styles/regularshape.component.ts
@@ -21,29 +21,29 @@ import { StyleComponent } from './style.component';
   template: ` <ng-content></ng-content> `,
 })
 export class StyleRegularShapeComponent implements AfterContentInit, OnChanges, OnDestroy {
-  fill = input<Fill>();
+  readonly fill = input<Fill>();
 
-  points = input.required<number>();
+  readonly points = input.required<number>();
 
-  radius = input.required<number>();
+  readonly radius = input.required<number>();
 
-  radius2 = input<number>();
+  readonly radius2 = input<number>();
 
-  angle = input<number>();
+  readonly angle = input<number>();
 
-  displacement = input<number[]>();
+  readonly displacement = input<number[]>();
 
-  stroke = input<Stroke>();
+  readonly stroke = input<Stroke>();
 
-  rotation = input<number>();
+  readonly rotation = input<number>();
 
-  rotateWithView = input<boolean>();
+  readonly rotateWithView = input<boolean>();
 
-  scale = input<number | Size>();
+  readonly scale = input<number | Size>();
 
-  declutterMode = input<DeclutterMode>();
+  readonly declutterMode = input<DeclutterMode>();
 
-  public componentType = 'style-regularshape';
+  readonly componentType: string = 'style-regularshape';
   public instance: RegularShape;
 
   protected readonly _instanceSignal = signal<RegularShape | undefined>(undefined);

--- a/projects/ngx-ol/src/lib/styles/regularshape.component.ts
+++ b/projects/ngx-ol/src/lib/styles/regularshape.component.ts
@@ -2,10 +2,11 @@ import {
   AfterContentInit,
   Component,
   Host,
-  Input,
   OnChanges,
   OnDestroy,
   SimpleChanges,
+  input,
+  signal,
 } from '@angular/core';
 import type { Size } from 'ol/size';
 import Fill from 'ol/style/Fill';
@@ -20,54 +21,51 @@ import { StyleComponent } from './style.component';
   template: ` <ng-content></ng-content> `,
 })
 export class StyleRegularShapeComponent implements AfterContentInit, OnChanges, OnDestroy {
-  @Input()
-  fill?: Fill;
+  fill = input<Fill>();
 
-  @Input()
-  points: number;
+  points = input.required<number>();
 
-  @Input()
-  radius: number;
+  radius = input.required<number>();
 
-  @Input()
-  radius2?: number;
+  radius2 = input<number>();
 
-  @Input()
-  angle?: number;
+  angle = input<number>();
 
-  @Input()
-  displacement?: number[];
+  displacement = input<number[]>();
 
-  @Input()
-  stroke?: Stroke;
+  stroke = input<Stroke>();
 
-  @Input()
-  rotation?: number;
+  rotation = input<number>();
 
-  @Input()
-  rotateWithView?: boolean;
+  rotateWithView = input<boolean>();
 
-  @Input()
-  scale?: number | Size;
+  scale = input<number | Size>();
 
-  @Input()
-  declutterMode?: DeclutterMode;
+  declutterMode = input<DeclutterMode>();
 
   public componentType = 'style-regularshape';
   public instance: RegularShape;
 
+  protected readonly _instanceSignal = signal<RegularShape | undefined>(undefined);
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: RegularShape): RegularShape {
+    this.instance = instance;
+    this._instanceSignal.set(instance);
+    return instance;
+  }
   constructor(@Host() private host: StyleComponent) {}
 
   update() {
     if (this.instance) {
-      this.instance = new RegularShape(this.createOptions());
+      this.setInstance(new RegularShape(this.createOptions()));
       this.host.instance.setImage(this.instance);
     }
     this.host.update();
   }
 
   ngAfterContentInit() {
-    this.instance = new RegularShape(this.createOptions());
+    this.setInstance(new RegularShape(this.createOptions()));
     this.host.instance.setImage(this.instance);
     this.host.update();
   }
@@ -90,7 +88,7 @@ export class StyleRegularShapeComponent implements AfterContentInit, OnChanges, 
       return;
     }
 
-    this.instance = new RegularShape(this.createOptions());
+    this.setInstance(new RegularShape(this.createOptions()));
     this.host.instance.setImage(this.instance);
     this.host.update();
   }
@@ -99,17 +97,17 @@ export class StyleRegularShapeComponent implements AfterContentInit, OnChanges, 
 
   private createOptions(): Options {
     return {
-      fill: this.fill,
-      points: this.points,
-      radius: this.radius,
-      radius2: this.radius2,
-      angle: this.angle,
-      displacement: this.displacement,
-      stroke: this.stroke,
-      rotation: this.rotation,
-      rotateWithView: this.rotateWithView,
-      scale: this.scale,
-      declutterMode: this.declutterMode,
+      fill: this.fill(),
+      points: this.points(),
+      radius: this.radius(),
+      radius2: this.radius2(),
+      angle: this.angle(),
+      displacement: this.displacement(),
+      stroke: this.stroke(),
+      rotation: this.rotation(),
+      rotateWithView: this.rotateWithView(),
+      scale: this.scale(),
+      declutterMode: this.declutterMode(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/styles/regularshape.component.ts
+++ b/projects/ngx-ol/src/lib/styles/regularshape.component.ts
@@ -1,10 +1,10 @@
 import {
   AfterContentInit,
   Component,
-  Host,
   OnChanges,
   OnDestroy,
   SimpleChanges,
+  inject,
   input,
   signal,
 } from '@angular/core';
@@ -54,7 +54,7 @@ export class StyleRegularShapeComponent implements AfterContentInit, OnChanges, 
     this._instanceSignal.set(instance);
     return instance;
   }
-  constructor(@Host() private host: StyleComponent) {}
+  private readonly host = inject(StyleComponent, { host: true });
 
   update() {
     if (this.instance) {

--- a/projects/ngx-ol/src/lib/styles/stroke.component.spec.ts
+++ b/projects/ngx-ol/src/lib/styles/stroke.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, QueryList, signal, ViewChild, ViewChildren } from '@angular/core';
+import { Component, signal, viewChild, viewChildren } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -44,11 +44,9 @@ class StyleStrokeHostComponent {
   miterLimit = signal(4);
   width = signal(2);
 
-  @ViewChild(StyleStrokeComponent)
-  stroke!: StyleStrokeComponent;
+  readonly stroke = viewChild.required<StyleStrokeComponent>(StyleStrokeComponent);
 
-  @ViewChild(StyleComponent)
-  style!: StyleComponent;
+  readonly style = viewChild.required<StyleComponent>(StyleComponent);
 }
 
 @Component({
@@ -91,14 +89,11 @@ class NestedStyleStrokeHostComponent {
   textColor = '#0000ff';
   textWidth = 4;
 
-  @ViewChild(StyleCircleComponent)
-  circle!: StyleCircleComponent;
+  readonly circle = viewChild.required<StyleCircleComponent>(StyleCircleComponent);
 
-  @ViewChild(StyleTextComponent)
-  textStyle!: StyleTextComponent;
+  readonly textStyle = viewChild.required<StyleTextComponent>(StyleTextComponent);
 
-  @ViewChildren(StyleStrokeComponent)
-  strokes!: QueryList<StyleStrokeComponent>;
+  readonly strokes = viewChildren<StyleStrokeComponent>(StyleStrokeComponent);
 }
 
 describe('StyleStrokeComponent', () => {
@@ -122,15 +117,15 @@ describe('StyleStrokeComponent', () => {
   });
 
   it('creates a stroke and applies it to the style host', () => {
-    expect(fixture.componentInstance.stroke.instance.getColor()).toBe('#ff0000');
-    expect(fixture.componentInstance.stroke.instance.getLineDash()).toEqual([1, 2]);
-    expect(fixture.componentInstance.stroke.instance.getLineDashOffset()).toBe(0);
-    expect(fixture.componentInstance.stroke.instance.getLineCap()).toBe('round');
-    expect(fixture.componentInstance.stroke.instance.getLineJoin()).toBe('round');
-    expect(fixture.componentInstance.stroke.instance.getMiterLimit()).toBe(4);
-    expect(fixture.componentInstance.stroke.instance.getWidth()).toBe(2);
-    expect(fixture.componentInstance.style.instance.getStroke()).toBe(
-      fixture.componentInstance.stroke.instance,
+    expect(fixture.componentInstance.stroke().instance.getColor()).toBe('#ff0000');
+    expect(fixture.componentInstance.stroke().instance.getLineDash()).toEqual([1, 2]);
+    expect(fixture.componentInstance.stroke().instance.getLineDashOffset()).toBe(0);
+    expect(fixture.componentInstance.stroke().instance.getLineCap()).toBe('round');
+    expect(fixture.componentInstance.stroke().instance.getLineJoin()).toBe('round');
+    expect(fixture.componentInstance.stroke().instance.getMiterLimit()).toBe(4);
+    expect(fixture.componentInstance.stroke().instance.getWidth()).toBe(2);
+    expect(fixture.componentInstance.style().instance.getStroke()).toBe(
+      fixture.componentInstance.stroke().instance,
     );
   });
 
@@ -145,15 +140,15 @@ describe('StyleStrokeComponent', () => {
 
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.stroke.instance.getColor()).toBe('#0000ff');
-    expect(fixture.componentInstance.stroke.instance.getLineDash()).toEqual([4, 8]);
-    expect(fixture.componentInstance.stroke.instance.getLineDashOffset()).toBe(2);
-    expect(fixture.componentInstance.stroke.instance.getLineCap()).toBe('square');
-    expect(fixture.componentInstance.stroke.instance.getLineJoin()).toBe('bevel');
-    expect(fixture.componentInstance.stroke.instance.getMiterLimit()).toBe(8);
-    expect(fixture.componentInstance.stroke.instance.getWidth()).toBe(6);
-    expect(fixture.componentInstance.style.instance.getStroke()).toBe(
-      fixture.componentInstance.stroke.instance,
+    expect(fixture.componentInstance.stroke().instance.getColor()).toBe('#0000ff');
+    expect(fixture.componentInstance.stroke().instance.getLineDash()).toEqual([4, 8]);
+    expect(fixture.componentInstance.stroke().instance.getLineDashOffset()).toBe(2);
+    expect(fixture.componentInstance.stroke().instance.getLineCap()).toBe('square');
+    expect(fixture.componentInstance.stroke().instance.getLineJoin()).toBe('bevel');
+    expect(fixture.componentInstance.stroke().instance.getMiterLimit()).toBe(8);
+    expect(fixture.componentInstance.stroke().instance.getWidth()).toBe(6);
+    expect(fixture.componentInstance.style().instance.getStroke()).toBe(
+      fixture.componentInstance.stroke().instance,
     );
   });
 
@@ -166,10 +161,10 @@ describe('StyleStrokeComponent', () => {
   it('applies stroke children to circle and text style hosts', () => {
     const nestedFixture = TestBed.createComponent(NestedStyleStrokeHostComponent);
     nestedFixture.detectChanges();
-    const strokes = nestedFixture.componentInstance.strokes.toArray();
+    const strokes = nestedFixture.componentInstance.strokes();
 
-    expect(nestedFixture.componentInstance.circle.instance.getStroke()).toBe(strokes[0].instance);
-    expect(nestedFixture.componentInstance.textStyle.instance.getStroke()).toBe(
+    expect(nestedFixture.componentInstance.circle().instance.getStroke()).toBe(strokes[0].instance);
+    expect(nestedFixture.componentInstance.textStyle().instance.getStroke()).toBe(
       strokes[1].instance,
     );
 

--- a/projects/ngx-ol/src/lib/styles/stroke.component.ts
+++ b/projects/ngx-ol/src/lib/styles/stroke.component.ts
@@ -1,4 +1,12 @@
-import { Component, Input, Optional, OnInit, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  Optional,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import Stroke from 'ol/style/Stroke';
 import { Options } from 'ol/style/Stroke';
 import { StyleComponent } from './style.component';
@@ -12,22 +20,27 @@ import { ColorLike } from 'ol/colorlike';
   template: ` <div class="aol-style-stroke"></div> `,
 })
 export class StyleStrokeComponent implements OnInit, OnChanges {
-  @Input()
-  color?: Color | ColorLike;
-  @Input()
-  lineCap?: CanvasLineCap | undefined;
-  @Input()
-  lineDash?: number[];
-  @Input()
-  lineDashOffset?: number | undefined;
-  @Input()
-  lineJoin?: CanvasLineJoin | undefined;
-  @Input()
-  miterLimit?: number;
-  @Input()
-  width?: number;
+  color = input<Color | ColorLike>();
+  lineCap = input<CanvasLineCap | undefined>();
+  lineDash = input<number[]>();
+  lineDashOffset = input<number | undefined>();
+  lineJoin = input<CanvasLineJoin | undefined>();
+  miterLimit = input<number>();
+  width = input<number>();
 
   public instance: Stroke;
+
+  protected readonly _instanceSignal = signal<Stroke | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Stroke): Stroke {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   /* the typings do not have the setters */
   private readonly host: StyleComponent | StyleCircleComponent | StyleTextComponent;
 
@@ -51,7 +64,7 @@ export class StyleStrokeComponent implements OnInit, OnChanges {
 
   ngOnInit() {
     // console.log('creating ol.style.Stroke instance with: ', this);
-    this.instance = new Stroke(this.createOptions());
+    this.setInstance(new Stroke(this.createOptions()));
     switch (this.host.componentType) {
       case 'style':
         this.host.instance.setStroke(this.instance);
@@ -61,7 +74,7 @@ export class StyleStrokeComponent implements OnInit, OnChanges {
         this.host.instance.setStroke(this.instance);
         break;
       case 'style-circle':
-        (this.host as StyleCircleComponent).stroke = this.instance;
+        (this.host as StyleCircleComponent).setStroke(this.instance);
         // console.log('setting ol.style.circle instance\'s stroke:', this.host);
         break;
       default:
@@ -101,13 +114,13 @@ export class StyleStrokeComponent implements OnInit, OnChanges {
 
   private createOptions(): Options {
     return {
-      color: this.color,
-      lineCap: this.lineCap,
-      lineDash: this.lineDash,
-      lineDashOffset: this.lineDashOffset,
-      lineJoin: this.lineJoin,
-      miterLimit: this.miterLimit,
-      width: this.width,
+      color: this.color(),
+      lineCap: this.lineCap(),
+      lineDash: this.lineDash(),
+      lineDashOffset: this.lineDashOffset(),
+      lineJoin: this.lineJoin(),
+      miterLimit: this.miterLimit(),
+      width: this.width(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/styles/stroke.component.ts
+++ b/projects/ngx-ol/src/lib/styles/stroke.component.ts
@@ -12,13 +12,13 @@ import { ColorLike } from 'ol/colorlike';
   template: ` <div class="aol-style-stroke"></div> `,
 })
 export class StyleStrokeComponent implements OnInit, OnChanges {
-  color = input<Color | ColorLike>();
-  lineCap = input<CanvasLineCap | undefined>();
-  lineDash = input<number[]>();
-  lineDashOffset = input<number | undefined>();
-  lineJoin = input<CanvasLineJoin | undefined>();
-  miterLimit = input<number>();
-  width = input<number>();
+  readonly color = input<Color | ColorLike>();
+  readonly lineCap = input<CanvasLineCap | undefined>();
+  readonly lineDash = input<number[]>();
+  readonly lineDashOffset = input<number | undefined>();
+  readonly lineJoin = input<CanvasLineJoin | undefined>();
+  readonly miterLimit = input<number>();
+  readonly width = input<number>();
 
   public instance: Stroke;
 

--- a/projects/ngx-ol/src/lib/styles/stroke.component.ts
+++ b/projects/ngx-ol/src/lib/styles/stroke.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  Optional,
-  OnInit,
-  OnChanges,
-  SimpleChanges,
-  input,
-  signal,
-} from '@angular/core';
+import { Component, OnInit, OnChanges, SimpleChanges, inject, input, signal } from '@angular/core';
 import Stroke from 'ol/style/Stroke';
 import { Options } from 'ol/style/Stroke';
 import { StyleComponent } from './style.component';
@@ -43,21 +35,20 @@ export class StyleStrokeComponent implements OnInit, OnChanges {
   }
   /* the typings do not have the setters */
   private readonly host: StyleComponent | StyleCircleComponent | StyleTextComponent;
+  private readonly styleHost = inject(StyleComponent, { optional: true });
+  private readonly styleCircleHost = inject(StyleCircleComponent, { optional: true });
+  private readonly styleTextHost = inject(StyleTextComponent, { optional: true });
 
-  constructor(
-    @Optional() styleHost: StyleComponent,
-    @Optional() styleCircleHost: StyleCircleComponent,
-    @Optional() styleTextHost: StyleTextComponent,
-  ) {
-    if (!styleHost) {
+  constructor() {
+    if (!this.styleHost) {
       throw new Error('aol-style-stroke must be a descendant of aol-style');
     }
-    if (!!styleTextHost) {
-      this.host = styleTextHost;
-    } else if (!!styleCircleHost) {
-      this.host = styleCircleHost;
+    if (!!this.styleTextHost) {
+      this.host = this.styleTextHost;
+    } else if (!!this.styleCircleHost) {
+      this.host = this.styleCircleHost;
     } else {
-      this.host = styleHost;
+      this.host = this.styleHost;
     }
     // console.log('creating aol-style-stroke with: ', this);
   }

--- a/projects/ngx-ol/src/lib/styles/style.component.spec.ts
+++ b/projects/ngx-ol/src/lib/styles/style.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -26,11 +26,9 @@ class StyleHostComponent {
   zoom = 2;
   zIndex = 3;
 
-  @ViewChild(StyleComponent)
-  style!: StyleComponent;
+  readonly style = viewChild.required<StyleComponent>(StyleComponent);
 
-  @ViewChild(FeatureComponent)
-  feature!: FeatureComponent;
+  readonly feature = viewChild.required<FeatureComponent>(FeatureComponent);
 }
 
 @Component({
@@ -57,10 +55,10 @@ describe('StyleComponent', () => {
   });
 
   it('creates a style and attaches it to the host feature', () => {
-    expect(fixture.componentInstance.feature.instance.getStyle()).toBe(
-      fixture.componentInstance.style.instance,
+    expect(fixture.componentInstance.feature().instance.getStyle()).toBe(
+      fixture.componentInstance.style().instance,
     );
-    expect(fixture.componentInstance.style.instance.getZIndex()).toBe(3);
+    expect(fixture.componentInstance.style().instance.getZIndex()).toBe(3);
   });
 
   it('throws when rendered without a feature or layer host', () => {

--- a/projects/ngx-ol/src/lib/styles/style.component.ts
+++ b/projects/ngx-ol/src/lib/styles/style.component.ts
@@ -15,14 +15,14 @@ import { LayerVectorImageComponent } from '../layers/layervectorimage.component'
   template: ` <ng-content></ng-content> `,
 })
 export class StyleComponent implements OnInit, OnChanges {
-  geometry = input<string | Geometry | GeometryFunction>();
-  fill = input<Fill>();
-  image = input<Image>();
-  renderer = input<RenderFunction>();
-  hitDetectionRenderer = input<RenderFunction>();
-  stroke = input<Stroke>();
-  text = input<Text>();
-  zIndex = input<number>();
+  readonly geometry = input<string | Geometry | GeometryFunction>();
+  readonly fill = input<Fill>();
+  readonly image = input<Image>();
+  readonly renderer = input<RenderFunction>();
+  readonly hitDetectionRenderer = input<RenderFunction>();
+  readonly stroke = input<Stroke>();
+  readonly text = input<Text>();
+  readonly zIndex = input<number>();
 
   public instance: Style;
 
@@ -37,7 +37,7 @@ export class StyleComponent implements OnInit, OnChanges {
 
     return instance;
   }
-  public componentType = 'style';
+  readonly componentType: string = 'style';
   private readonly host: FeatureComponent | LayerVectorComponent | LayerVectorImageComponent;
   private readonly featureHost = inject(FeatureComponent, { optional: true });
   private readonly vectorLayer = inject(LayerVectorComponent, { optional: true });

--- a/projects/ngx-ol/src/lib/styles/style.component.ts
+++ b/projects/ngx-ol/src/lib/styles/style.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Optional, OnInit } from '@angular/core';
+import { Component, Optional, OnInit, input, signal } from '@angular/core';
 import Fill from 'ol/style/Fill';
 import Image from 'ol/style/Image';
 import Stroke from 'ol/style/Stroke';
@@ -15,24 +15,28 @@ import { LayerVectorImageComponent } from '../layers/layervectorimage.component'
   template: ` <ng-content></ng-content> `,
 })
 export class StyleComponent implements OnInit {
-  @Input()
-  geometry?: string | Geometry | GeometryFunction;
-  @Input()
-  fill?: Fill;
-  @Input()
-  image?: Image;
-  @Input()
-  renderer?: RenderFunction;
-  @Input()
-  hitDetectionRenderer?: RenderFunction;
-  @Input()
-  stroke?: Stroke;
-  @Input()
-  text?: Text;
-  @Input()
-  zIndex?: number;
+  geometry = input<string | Geometry | GeometryFunction>();
+  fill = input<Fill>();
+  image = input<Image>();
+  renderer = input<RenderFunction>();
+  hitDetectionRenderer = input<RenderFunction>();
+  stroke = input<Stroke>();
+  text = input<Text>();
+  zIndex = input<number>();
 
   public instance: Style;
+
+  protected readonly _instanceSignal = signal<Style | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Style): Style {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   public componentType = 'style';
   private readonly host: FeatureComponent | LayerVectorComponent;
 
@@ -55,20 +59,20 @@ export class StyleComponent implements OnInit {
 
   ngOnInit() {
     // console.log('creating aol-style instance with: ', this);
-    this.instance = new Style(this.createOptions());
+    this.setInstance(new Style(this.createOptions()));
     this.host.instance.setStyle(this.instance);
   }
 
   private createOptions(): Options {
     return {
-      geometry: this.geometry,
-      fill: this.fill,
-      image: this.image,
-      renderer: this.renderer,
-      hitDetectionRenderer: this.hitDetectionRenderer,
-      stroke: this.stroke,
-      text: this.text,
-      zIndex: this.zIndex,
+      geometry: this.geometry(),
+      fill: this.fill(),
+      image: this.image(),
+      renderer: this.renderer(),
+      hitDetectionRenderer: this.hitDetectionRenderer(),
+      stroke: this.stroke(),
+      text: this.text(),
+      zIndex: this.zIndex(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/styles/style.component.ts
+++ b/projects/ngx-ol/src/lib/styles/style.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  Optional,
-  OnChanges,
-  OnInit,
-  SimpleChanges,
-  input,
-  signal,
-} from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges, inject, input, signal } from '@angular/core';
 import Fill from 'ol/style/Fill';
 import Image from 'ol/style/Image';
 import Stroke from 'ol/style/Stroke';
@@ -46,15 +38,14 @@ export class StyleComponent implements OnInit, OnChanges {
     return instance;
   }
   public componentType = 'style';
-  private readonly host: FeatureComponent | LayerVectorComponent;
+  private readonly host: FeatureComponent | LayerVectorComponent | LayerVectorImageComponent;
+  private readonly featureHost = inject(FeatureComponent, { optional: true });
+  private readonly vectorLayer = inject(LayerVectorComponent, { optional: true });
+  private readonly vectorImageLayer = inject(LayerVectorImageComponent, { optional: true });
 
-  constructor(
-    @Optional() featureHost: FeatureComponent,
-    @Optional() vectorLayer: LayerVectorComponent,
-    @Optional() vectorImageLayer: LayerVectorImageComponent,
-  ) {
+  constructor() {
     // console.log('creating aol-style');
-    this.host = featureHost || vectorLayer || vectorImageLayer;
+    this.host = (this.featureHost || this.vectorLayer || this.vectorImageLayer)!;
     if (!this.host) {
       throw new Error('aol-style must be applied to a feature or a layer');
     }

--- a/projects/ngx-ol/src/lib/styles/style.component.ts
+++ b/projects/ngx-ol/src/lib/styles/style.component.ts
@@ -1,4 +1,12 @@
-import { Component, Optional, OnInit, input, signal } from '@angular/core';
+import {
+  Component,
+  Optional,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import Fill from 'ol/style/Fill';
 import Image from 'ol/style/Image';
 import Stroke from 'ol/style/Stroke';
@@ -14,7 +22,7 @@ import { LayerVectorImageComponent } from '../layers/layervectorimage.component'
   selector: 'aol-style',
   template: ` <ng-content></ng-content> `,
 })
-export class StyleComponent implements OnInit {
+export class StyleComponent implements OnInit, OnChanges {
   geometry = input<string | Geometry | GeometryFunction>();
   fill = input<Fill>();
   image = input<Image>();
@@ -61,6 +69,37 @@ export class StyleComponent implements OnInit {
     // console.log('creating aol-style instance with: ', this);
     this.setInstance(new Style(this.createOptions()));
     this.host.instance.setStyle(this.instance);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (!this.instance) {
+      return;
+    }
+    if (changes.geometry) {
+      this.instance.setGeometry(changes.geometry.currentValue);
+    }
+    if (changes.fill) {
+      this.instance.setFill(changes.fill.currentValue);
+    }
+    if (changes.image) {
+      this.instance.setImage(changes.image.currentValue);
+    }
+    if (changes.renderer) {
+      this.instance.setRenderer(changes.renderer.currentValue);
+    }
+    if (changes.hitDetectionRenderer) {
+      this.instance.setHitDetectionRenderer(changes.hitDetectionRenderer.currentValue);
+    }
+    if (changes.stroke) {
+      this.instance.setStroke(changes.stroke.currentValue);
+    }
+    if (changes.text) {
+      this.instance.setText(changes.text.currentValue);
+    }
+    if (changes.zIndex) {
+      this.instance.setZIndex(changes.zIndex.currentValue);
+    }
+    this.update();
   }
 
   private createOptions(): Options {

--- a/projects/ngx-ol/src/lib/styles/text.component.spec.ts
+++ b/projects/ngx-ol/src/lib/styles/text.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../../public-api';
@@ -44,11 +44,9 @@ class StyleTextHostComponent {
   textAlign = signal<CanvasTextAlign>('center');
   textBaseline = signal<CanvasTextBaseline>('middle');
 
-  @ViewChild(StyleTextComponent)
-  textStyle!: StyleTextComponent;
+  readonly textStyle = viewChild.required<StyleTextComponent>(StyleTextComponent);
 
-  @ViewChild(StyleComponent)
-  style!: StyleComponent;
+  readonly style = viewChild.required<StyleComponent>(StyleComponent);
 }
 
 @Component({
@@ -75,12 +73,12 @@ describe('StyleTextComponent', () => {
   });
 
   it('creates a text style and applies it to the style host', () => {
-    expect(fixture.componentInstance.textStyle.instance.getText()).toBe('Label');
-    expect(fixture.componentInstance.textStyle.instance.getFont()).toBe('12px sans-serif');
-    expect(fixture.componentInstance.textStyle.instance.getTextAlign()).toBe('center');
-    expect(fixture.componentInstance.textStyle.instance.getTextBaseline()).toBe('middle');
-    expect(fixture.componentInstance.style.instance.getText()).toBe(
-      fixture.componentInstance.textStyle.instance,
+    expect(fixture.componentInstance.textStyle().instance.getText()).toBe('Label');
+    expect(fixture.componentInstance.textStyle().instance.getFont()).toBe('12px sans-serif');
+    expect(fixture.componentInstance.textStyle().instance.getTextAlign()).toBe('center');
+    expect(fixture.componentInstance.textStyle().instance.getTextBaseline()).toBe('middle');
+    expect(fixture.componentInstance.style().instance.getText()).toBe(
+      fixture.componentInstance.textStyle().instance,
     );
   });
 
@@ -96,16 +94,16 @@ describe('StyleTextComponent', () => {
 
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.textStyle.instance.getText()).toBe('Updated label');
-    expect(fixture.componentInstance.textStyle.instance.getFont()).toBe('14px serif');
-    expect(fixture.componentInstance.textStyle.instance.getOffsetX()).toBe(10);
-    expect(fixture.componentInstance.textStyle.instance.getOffsetY()).toBe(20);
-    expect(fixture.componentInstance.textStyle.instance.getScale()).toBe(2);
-    expect(fixture.componentInstance.textStyle.instance.getRotation()).toBe(1);
-    expect(fixture.componentInstance.textStyle.instance.getTextAlign()).toBe('left');
-    expect(fixture.componentInstance.textStyle.instance.getTextBaseline()).toBe('top');
-    expect(fixture.componentInstance.style.instance.getText()).toBe(
-      fixture.componentInstance.textStyle.instance,
+    expect(fixture.componentInstance.textStyle().instance.getText()).toBe('Updated label');
+    expect(fixture.componentInstance.textStyle().instance.getFont()).toBe('14px serif');
+    expect(fixture.componentInstance.textStyle().instance.getOffsetX()).toBe(10);
+    expect(fixture.componentInstance.textStyle().instance.getOffsetY()).toBe(20);
+    expect(fixture.componentInstance.textStyle().instance.getScale()).toBe(2);
+    expect(fixture.componentInstance.textStyle().instance.getRotation()).toBe(1);
+    expect(fixture.componentInstance.textStyle().instance.getTextAlign()).toBe('left');
+    expect(fixture.componentInstance.textStyle().instance.getTextBaseline()).toBe('top');
+    expect(fixture.componentInstance.style().instance.getText()).toBe(
+      fixture.componentInstance.textStyle().instance,
     );
   });
 
@@ -114,17 +112,17 @@ describe('StyleTextComponent', () => {
 
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.textStyle.instance.getFont()).toBe('16px serif');
-    expect(fixture.componentInstance.textStyle.instance.getTextBaseline()).toBe('middle');
+    expect(fixture.componentInstance.textStyle().instance.getFont()).toBe('16px serif');
+    expect(fixture.componentInstance.textStyle().instance.getTextBaseline()).toBe('middle');
 
     fixture.componentInstance.textBaseline.set('bottom');
 
     fixture.detectChanges(false);
 
-    expect(fixture.componentInstance.textStyle.instance.getFont()).toBe('16px serif');
-    expect(fixture.componentInstance.textStyle.instance.getTextBaseline()).toBe('bottom');
-    expect(fixture.componentInstance.style.instance.getText()).toBe(
-      fixture.componentInstance.textStyle.instance,
+    expect(fixture.componentInstance.textStyle().instance.getFont()).toBe('16px serif');
+    expect(fixture.componentInstance.textStyle().instance.getTextBaseline()).toBe('bottom');
+    expect(fixture.componentInstance.style().instance.getText()).toBe(
+      fixture.componentInstance.textStyle().instance,
     );
   });
 

--- a/projects/ngx-ol/src/lib/styles/text.component.ts
+++ b/projects/ngx-ol/src/lib/styles/text.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  Optional,
-  OnInit,
-  OnChanges,
-  SimpleChanges,
-  input,
-  signal,
-} from '@angular/core';
+import { Component, OnInit, OnChanges, SimpleChanges, inject, input, signal } from '@angular/core';
 import Fill from 'ol/style/Fill';
 import Stroke from 'ol/style/Stroke';
 import Text from 'ol/style/Text';
@@ -55,9 +47,10 @@ export class StyleTextComponent implements OnInit, OnChanges {
     return instance;
   }
   public componentType = 'style-text';
+  private readonly host = inject(StyleComponent, { optional: true })!;
 
-  constructor(@Optional() private host: StyleComponent) {
-    if (!host) {
+  constructor() {
+    if (!this.host) {
       throw new Error('aol-style-text must be a descendant of aol-style');
     }
     // console.log('creating aol-style-text with: ', this);

--- a/projects/ngx-ol/src/lib/styles/text.component.ts
+++ b/projects/ngx-ol/src/lib/styles/text.component.ts
@@ -76,11 +76,26 @@ export class StyleTextComponent implements OnInit, OnChanges {
     if (changes.font) {
       this.instance.setFont(changes.font.currentValue);
     }
+    if (changes.maxAngle?.currentValue !== undefined) {
+      this.instance.setMaxAngle(changes.maxAngle.currentValue);
+    }
     if (changes.offsetX) {
       this.instance.setOffsetX(changes.offsetX.currentValue);
     }
     if (changes.offsetY) {
       this.instance.setOffsetY(changes.offsetY.currentValue);
+    }
+    if (changes.overflow?.currentValue !== undefined) {
+      this.instance.setOverflow(changes.overflow.currentValue);
+    }
+    if (changes.placement?.currentValue !== undefined) {
+      this.instance.setPlacement(changes.placement.currentValue);
+    }
+    if (changes.repeat) {
+      this.instance.setRepeat(changes.repeat.currentValue);
+    }
+    if (changes.rotateWithView?.currentValue !== undefined) {
+      this.instance.setRotateWithView(changes.rotateWithView.currentValue);
     }
     if (changes.scale) {
       this.instance.setScale(changes.scale.currentValue);
@@ -94,8 +109,26 @@ export class StyleTextComponent implements OnInit, OnChanges {
     if (changes.textAlign) {
       this.instance.setTextAlign(changes.textAlign.currentValue);
     }
+    if (changes.justify) {
+      this.instance.setJustify(changes.justify.currentValue);
+    }
     if (changes.textBaseline) {
       this.instance.setTextBaseline(changes.textBaseline.currentValue);
+    }
+    if (changes.fill) {
+      this.instance.setFill(changes.fill.currentValue);
+    }
+    if (changes.stroke) {
+      this.instance.setStroke(changes.stroke.currentValue);
+    }
+    if (changes.backgroundFill) {
+      this.instance.setBackgroundFill(changes.backgroundFill.currentValue);
+    }
+    if (changes.backgroundStroke) {
+      this.instance.setBackgroundStroke(changes.backgroundStroke.currentValue);
+    }
+    if (changes.padding) {
+      this.instance.setPadding(changes.padding.currentValue);
     }
     this.host.update();
     // console.log('changes detected in aol-style-text, setting new properties: ', changes);

--- a/projects/ngx-ol/src/lib/styles/text.component.ts
+++ b/projects/ngx-ol/src/lib/styles/text.component.ts
@@ -1,4 +1,12 @@
-import { Component, Input, Optional, OnInit, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  Optional,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+  input,
+  signal,
+} from '@angular/core';
 import Fill from 'ol/style/Fill';
 import Stroke from 'ol/style/Stroke';
 import Text from 'ol/style/Text';
@@ -12,48 +20,40 @@ import { Size } from 'ol/size';
   template: ` <div class="aol-style-text"></div> `,
 })
 export class StyleTextComponent implements OnInit, OnChanges {
-  @Input()
-  font?: string | undefined;
-  @Input()
-  maxAngle?: number | undefined;
-  @Input()
-  offsetX?: number | undefined;
-  @Input()
-  offsetY?: number | undefined;
-  @Input()
-  overflow?: boolean | undefined;
-  @Input()
-  placement?: TextPlacement | undefined;
-  @Input()
-  repeat?: number | undefined;
-  @Input()
-  scale?: number | Size | undefined;
-  @Input()
-  rotateWithView?: boolean | undefined;
-  @Input()
-  rotation?: number | undefined;
-  @Input()
-  text?: string | string[] | undefined;
-  @Input()
-  textAlign?: CanvasTextAlign | undefined;
-  @Input()
-  justify?: TextJustify | undefined;
-  @Input()
-  textBaseline?: CanvasTextBaseline | undefined;
-  @Input()
-  fill?: Fill | undefined;
-  @Input()
-  stroke?: Stroke | undefined;
-  @Input()
-  backgroundFill?: Fill | undefined;
-  @Input()
-  backgroundStroke?: Stroke | undefined;
-  @Input()
-  padding?: number[] | undefined;
-  @Input()
-  declutterMode?: DeclutterMode | undefined;
+  font = input<string | undefined>();
+  maxAngle = input<number | undefined>();
+  offsetX = input<number | undefined>();
+  offsetY = input<number | undefined>();
+  overflow = input<boolean | undefined>();
+  placement = input<TextPlacement | undefined>();
+  repeat = input<number | undefined>();
+  scale = input<number | Size | undefined>();
+  rotateWithView = input<boolean | undefined>();
+  rotation = input<number | undefined>();
+  text = input<string | string[] | undefined>();
+  textAlign = input<CanvasTextAlign | undefined>();
+  justify = input<TextJustify | undefined>();
+  textBaseline = input<CanvasTextBaseline | undefined>();
+  fill = input<Fill | undefined>();
+  stroke = input<Stroke | undefined>();
+  backgroundFill = input<Fill | undefined>();
+  backgroundStroke = input<Stroke | undefined>();
+  padding = input<number[] | undefined>();
+  declutterMode = input<DeclutterMode | undefined>();
 
   public instance: Text;
+
+  protected readonly _instanceSignal = signal<Text | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: Text): Text {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   public componentType = 'style-text';
 
   constructor(@Optional() private host: StyleComponent) {
@@ -65,7 +65,7 @@ export class StyleTextComponent implements OnInit, OnChanges {
 
   ngOnInit() {
     // console.log('creating ol.style.Text instance with: ', this);
-    this.instance = new Text(this.createOptions());
+    this.setInstance(new Text(this.createOptions()));
     this.host.instance.setText(this.instance);
   }
 
@@ -105,26 +105,26 @@ export class StyleTextComponent implements OnInit, OnChanges {
 
   private createOptions(): Options {
     return {
-      font: this.font,
-      maxAngle: this.maxAngle,
-      offsetX: this.offsetX,
-      offsetY: this.offsetY,
-      overflow: this.overflow,
-      placement: this.placement,
-      repeat: this.repeat,
-      scale: this.scale,
-      rotateWithView: this.rotateWithView,
-      rotation: this.rotation,
-      text: this.text,
-      textAlign: this.textAlign,
-      justify: this.justify,
-      textBaseline: this.textBaseline,
-      fill: this.fill,
-      stroke: this.stroke,
-      backgroundFill: this.backgroundFill,
-      backgroundStroke: this.backgroundStroke,
-      padding: this.padding,
-      declutterMode: this.declutterMode,
+      font: this.font(),
+      maxAngle: this.maxAngle(),
+      offsetX: this.offsetX(),
+      offsetY: this.offsetY(),
+      overflow: this.overflow(),
+      placement: this.placement(),
+      repeat: this.repeat(),
+      scale: this.scale(),
+      rotateWithView: this.rotateWithView(),
+      rotation: this.rotation(),
+      text: this.text(),
+      textAlign: this.textAlign(),
+      justify: this.justify(),
+      textBaseline: this.textBaseline(),
+      fill: this.fill(),
+      stroke: this.stroke(),
+      backgroundFill: this.backgroundFill(),
+      backgroundStroke: this.backgroundStroke(),
+      padding: this.padding(),
+      declutterMode: this.declutterMode(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/styles/text.component.ts
+++ b/projects/ngx-ol/src/lib/styles/text.component.ts
@@ -12,26 +12,26 @@ import { Size } from 'ol/size';
   template: ` <div class="aol-style-text"></div> `,
 })
 export class StyleTextComponent implements OnInit, OnChanges {
-  font = input<string | undefined>();
-  maxAngle = input<number | undefined>();
-  offsetX = input<number | undefined>();
-  offsetY = input<number | undefined>();
-  overflow = input<boolean | undefined>();
-  placement = input<TextPlacement | undefined>();
-  repeat = input<number | undefined>();
-  scale = input<number | Size | undefined>();
-  rotateWithView = input<boolean | undefined>();
-  rotation = input<number | undefined>();
-  text = input<string | string[] | undefined>();
-  textAlign = input<CanvasTextAlign | undefined>();
-  justify = input<TextJustify | undefined>();
-  textBaseline = input<CanvasTextBaseline | undefined>();
-  fill = input<Fill | undefined>();
-  stroke = input<Stroke | undefined>();
-  backgroundFill = input<Fill | undefined>();
-  backgroundStroke = input<Stroke | undefined>();
-  padding = input<number[] | undefined>();
-  declutterMode = input<DeclutterMode | undefined>();
+  readonly font = input<string | undefined>();
+  readonly maxAngle = input<number | undefined>();
+  readonly offsetX = input<number | undefined>();
+  readonly offsetY = input<number | undefined>();
+  readonly overflow = input<boolean | undefined>();
+  readonly placement = input<TextPlacement | undefined>();
+  readonly repeat = input<number | undefined>();
+  readonly scale = input<number | Size | undefined>();
+  readonly rotateWithView = input<boolean | undefined>();
+  readonly rotation = input<number | undefined>();
+  readonly text = input<string | string[] | undefined>();
+  readonly textAlign = input<CanvasTextAlign | undefined>();
+  readonly justify = input<TextJustify | undefined>();
+  readonly textBaseline = input<CanvasTextBaseline | undefined>();
+  readonly fill = input<Fill | undefined>();
+  readonly stroke = input<Stroke | undefined>();
+  readonly backgroundFill = input<Fill | undefined>();
+  readonly backgroundStroke = input<Stroke | undefined>();
+  readonly padding = input<number[] | undefined>();
+  readonly declutterMode = input<DeclutterMode | undefined>();
 
   public instance: Text;
 
@@ -46,7 +46,7 @@ export class StyleTextComponent implements OnInit, OnChanges {
 
     return instance;
   }
-  public componentType = 'style-text';
+  readonly componentType: string = 'style-text';
   private readonly host = inject(StyleComponent, { optional: true })!;
 
   constructor() {

--- a/projects/ngx-ol/src/lib/tilegrid.component.spec.ts
+++ b/projects/ngx-ol/src/lib/tilegrid.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AngularOpenlayersModule } from '../public-api';
@@ -13,8 +13,7 @@ class TileGridHostComponent {
   resolutions = [2, 1];
   origin: [number, number] = [0, 0];
 
-  @ViewChild(TileGridComponent)
-  tileGrid!: TileGridComponent;
+  readonly tileGrid = viewChild.required<TileGridComponent>(TileGridComponent);
 }
 
 describe('TileGridComponent', () => {
@@ -34,6 +33,6 @@ describe('TileGridComponent', () => {
   });
 
   it('creates a tile grid from template bindings', () => {
-    expect(fixture.componentInstance.tileGrid.instance.getResolutions()).toEqual([2, 1]);
+    expect(fixture.componentInstance.tileGrid().instance.getResolutions()).toEqual([2, 1]);
   });
 });

--- a/projects/ngx-ol/src/lib/tilegrid.component.ts
+++ b/projects/ngx-ol/src/lib/tilegrid.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges, input, signal } from '@angular/core';
 import { createXYZ, XYZOptions } from 'ol/tilegrid';
 import TileGrid, { Options } from 'ol/tilegrid/TileGrid';
 import { Extent } from 'ol/extent';
@@ -10,29 +10,30 @@ import { Size } from 'ol/size';
   template: '',
 })
 export class TileGridComponent implements OnInit, OnChanges {
-  @Input()
-  extent?: Extent;
-  @Input()
-  maxZoom: number;
-  @Input()
-  minZoom?: number;
-  @Input()
-  maxResolution: number;
-  @Input()
-  tileSize?: number | Size;
-  @Input()
-  origin?: Coordinate;
-  @Input()
-  origins?: Coordinate[];
-  @Input()
-  resolutions: number[];
-  @Input()
-  sizes?: Size[];
-  @Input()
-  tileSizes?: (number | Size)[];
+  extent = input<Extent>();
+  maxZoom = input<number>();
+  minZoom = input<number>();
+  maxResolution = input<number>();
+  tileSize = input<number | Size>();
+  origin = input<Coordinate>();
+  origins = input<Coordinate[]>();
+  resolutions = input<number[]>();
+  sizes = input<Size[]>();
+  tileSizes = input<(number | Size)[]>();
 
   instance: TileGrid;
 
+  protected readonly _instanceSignal = signal<TileGrid | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: TileGrid): TileGrid {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   ngOnInit() {
     this.createInstance();
   }
@@ -42,33 +43,33 @@ export class TileGridComponent implements OnInit, OnChanges {
   }
 
   protected createInstance() {
-    if (!this.resolutions) {
-      this.instance = createXYZ(this.createXYZOptions());
+    if (!this.resolutions()) {
+      this.setInstance(createXYZ(this.createXYZOptions()));
     } else {
-      this.instance = new TileGrid(this.createTileGridOptions());
+      this.setInstance(new TileGrid(this.createTileGridOptions()));
     }
   }
 
   private createXYZOptions(): XYZOptions {
     return {
-      extent: this.extent,
-      maxResolution: this.maxResolution,
-      maxZoom: this.maxZoom,
-      minZoom: this.minZoom,
-      tileSize: this.tileSize,
+      extent: this.extent(),
+      maxResolution: this.maxResolution(),
+      maxZoom: this.maxZoom(),
+      minZoom: this.minZoom(),
+      tileSize: this.tileSize(),
     };
   }
 
   private createTileGridOptions(): Options {
     return {
-      extent: this.extent,
-      minZoom: this.minZoom,
-      origin: this.origin,
-      origins: this.origins,
-      resolutions: this.resolutions,
-      sizes: this.sizes,
-      tileSize: this.tileSize,
-      tileSizes: this.tileSizes,
+      extent: this.extent(),
+      minZoom: this.minZoom(),
+      origin: this.origin(),
+      origins: this.origins(),
+      resolutions: this.resolutions()!,
+      sizes: this.sizes(),
+      tileSize: this.tileSize(),
+      tileSizes: this.tileSizes(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/tilegrid.component.ts
+++ b/projects/ngx-ol/src/lib/tilegrid.component.ts
@@ -10,16 +10,16 @@ import { Size } from 'ol/size';
   template: '',
 })
 export class TileGridComponent implements OnInit, OnChanges {
-  extent = input<Extent>();
-  maxZoom = input<number>();
-  minZoom = input<number>();
-  maxResolution = input<number>();
-  tileSize = input<number | Size>();
-  origin = input<Coordinate>();
-  origins = input<Coordinate[]>();
-  resolutions = input<number[]>();
-  sizes = input<Size[]>();
-  tileSizes = input<(number | Size)[]>();
+  readonly extent = input<Extent>();
+  readonly maxZoom = input<number>();
+  readonly minZoom = input<number>();
+  readonly maxResolution = input<number>();
+  readonly tileSize = input<number | Size>();
+  readonly origin = input<Coordinate>();
+  readonly origins = input<Coordinate[]>();
+  readonly resolutions = input<number[]>();
+  readonly sizes = input<Size[]>();
+  readonly tileSizes = input<(number | Size)[]>();
 
   instance: TileGrid;
 

--- a/projects/ngx-ol/src/lib/tilegrid.component.ts
+++ b/projects/ngx-ol/src/lib/tilegrid.component.ts
@@ -35,14 +35,14 @@ export class TileGridComponent implements OnInit, OnChanges {
     return instance;
   }
   ngOnInit() {
-    this.createInstance();
+    this.initializeInstance();
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    this.createInstance();
+    this.initializeInstance();
   }
 
-  protected createInstance() {
+  protected initializeInstance() {
     if (!this.resolutions()) {
       this.setInstance(createXYZ(this.createXYZOptions()));
     } else {

--- a/projects/ngx-ol/src/lib/tilegridwmts.component.spec.ts
+++ b/projects/ngx-ol/src/lib/tilegridwmts.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import WMTS from 'ol/tilegrid/WMTS';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -21,8 +21,7 @@ class TileGridWmtsHostComponent {
   matrixIds = ['0', '1'];
   origin: [number, number] = [0, 0];
 
-  @ViewChild(TileGridWMTSComponent)
-  tileGrid!: TileGridWMTSComponent;
+  readonly tileGrid = viewChild.required<TileGridWMTSComponent>(TileGridWMTSComponent);
 }
 
 describe('TileGridWMTSComponent', () => {
@@ -42,6 +41,6 @@ describe('TileGridWMTSComponent', () => {
   });
 
   it('creates a WMTS tile grid from template bindings', () => {
-    expect(fixture.componentInstance.tileGrid.instance).toBeInstanceOf(WMTS);
+    expect(fixture.componentInstance.tileGrid().instance).toBeInstanceOf(WMTS);
   });
 });

--- a/projects/ngx-ol/src/lib/tilegridwmts.component.ts
+++ b/projects/ngx-ol/src/lib/tilegridwmts.component.ts
@@ -9,13 +9,13 @@ import { Size } from 'ol/size';
   template: '',
 })
 export class TileGridWMTSComponent extends TileGridComponent implements OnInit, OnChanges {
-  origin = input<Coordinate>();
-  origins = input<Coordinate[]>();
-  resolutions = input<number[]>();
-  matrixIds = input.required<string[]>();
-  sizes = input<Size[]>();
-  tileSize = input<number | Size>();
-  tileSizes = input<(number | Size)[]>();
+  readonly origin = input<Coordinate>();
+  readonly origins = input<Coordinate[]>();
+  readonly resolutions = input<number[]>();
+  readonly matrixIds = input.required<string[]>();
+  readonly sizes = input<Size[]>();
+  readonly tileSize = input<number | Size>();
+  readonly tileSizes = input<(number | Size)[]>();
 
   instance: WMTS;
 

--- a/projects/ngx-ol/src/lib/tilegridwmts.component.ts
+++ b/projects/ngx-ol/src/lib/tilegridwmts.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, input, signal } from '@angular/core';
+import { Component, OnChanges, OnInit, input, signal } from '@angular/core';
 import WMTS, { Options } from 'ol/tilegrid/WMTS';
 import { TileGridComponent } from './tilegrid.component';
 import { Coordinate } from 'ol/coordinate';
@@ -8,7 +8,7 @@ import { Size } from 'ol/size';
   selector: 'aol-tilegrid-wmts',
   template: '',
 })
-export class TileGridWMTSComponent extends TileGridComponent implements OnInit {
+export class TileGridWMTSComponent extends TileGridComponent implements OnInit, OnChanges {
   origin = input<Coordinate>();
   origins = input<Coordinate[]>();
   resolutions = input<number[]>();
@@ -31,6 +31,10 @@ export class TileGridWMTSComponent extends TileGridComponent implements OnInit {
     return instance;
   }
   ngOnInit() {
+    this.setInstance(new WMTS(this.createOptions()));
+  }
+
+  ngOnChanges() {
     this.setInstance(new WMTS(this.createOptions()));
   }
 

--- a/projects/ngx-ol/src/lib/tilegridwmts.component.ts
+++ b/projects/ngx-ol/src/lib/tilegridwmts.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, OnInit, input, signal } from '@angular/core';
 import WMTS, { Options } from 'ol/tilegrid/WMTS';
 import { TileGridComponent } from './tilegrid.component';
 import { Coordinate } from 'ol/coordinate';
@@ -9,37 +9,41 @@ import { Size } from 'ol/size';
   template: '',
 })
 export class TileGridWMTSComponent extends TileGridComponent implements OnInit {
-  @Input()
-  origin?: Coordinate;
-  @Input()
-  origins?: Coordinate[];
-  @Input()
-  resolutions: number[];
-  @Input()
-  matrixIds: string[];
-  @Input()
-  sizes?: Size[];
-  @Input()
-  tileSize?: number | Size;
-  @Input()
-  tileSizes?: (number | Size)[];
+  origin = input<Coordinate>();
+  origins = input<Coordinate[]>();
+  resolutions = input<number[]>();
+  matrixIds = input.required<string[]>();
+  sizes = input<Size[]>();
+  tileSize = input<number | Size>();
+  tileSizes = input<(number | Size)[]>();
 
   instance: WMTS;
 
+  protected readonly _instanceSignal = signal<WMTS | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: WMTS): WMTS {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   ngOnInit() {
-    this.instance = new WMTS(this.createOptions());
+    this.setInstance(new WMTS(this.createOptions()));
   }
 
   private createOptions(): Options {
     return {
-      extent: this.extent,
-      origin: this.origin,
-      origins: this.origins,
-      resolutions: this.resolutions,
-      matrixIds: this.matrixIds,
-      sizes: this.sizes,
-      tileSize: this.tileSize,
-      tileSizes: this.tileSizes,
+      extent: this.extent(),
+      origin: this.origin(),
+      origins: this.origins(),
+      resolutions: this.resolutions()!,
+      matrixIds: this.matrixIds(),
+      sizes: this.sizes(),
+      tileSize: this.tileSize(),
+      tileSizes: this.tileSizes(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/view.component.spec.ts
+++ b/projects/ngx-ol/src/lib/view.component.spec.ts
@@ -100,6 +100,32 @@ describe('ViewComponent', () => {
     );
   });
 
+  it('keeps forwarding view outputs after a projection-triggered rebuild', () => {
+    fixture.componentInstance.projection.set('EPSG:4326');
+    fixture.detectChanges();
+
+    fixture.componentInstance.change.mockClear();
+    fixture.componentInstance.centerChanged.mockClear();
+    fixture.componentInstance.resolutionChanged.mockClear();
+    fixture.componentInstance.rotationChanged.mockClear();
+    fixture.componentInstance.error.mockClear();
+    fixture.componentInstance.propertyChange.mockClear();
+
+    fixture.componentInstance.view.instance.dispatchEvent('change');
+    fixture.componentInstance.view.instance.dispatchEvent('change:center');
+    fixture.componentInstance.view.instance.dispatchEvent('change:resolution');
+    fixture.componentInstance.view.instance.dispatchEvent('change:rotation');
+    fixture.componentInstance.view.instance.dispatchEvent('error');
+    fixture.componentInstance.view.instance.dispatchEvent('propertychange');
+
+    expect(fixture.componentInstance.change).toHaveBeenCalledOnce();
+    expect(fixture.componentInstance.centerChanged).toHaveBeenCalledOnce();
+    expect(fixture.componentInstance.resolutionChanged).toHaveBeenCalledOnce();
+    expect(fixture.componentInstance.rotationChanged).toHaveBeenCalledOnce();
+    expect(fixture.componentInstance.error).toHaveBeenCalledOnce();
+    expect(fixture.componentInstance.propertyChange).toHaveBeenCalledOnce();
+  });
+
   it('animates zoom changes when zoom animation is enabled', () => {
     const animate = vi.spyOn(fixture.componentInstance.view.instance, 'animate');
 
@@ -111,18 +137,24 @@ describe('ViewComponent', () => {
     expect(animate).toHaveBeenCalledWith({ zoom: 6 });
   });
 
-  it('updates OpenLayers view constraints and state from specialized bindings', () => {
+  it('updates OpenLayers view constraints from specialized bindings', () => {
     fixture.componentInstance.maxZoom.set(12);
     fixture.componentInstance.minZoom.set(1);
-    fixture.componentInstance.resolution.set(4);
     fixture.componentInstance.rotation.set(0.5);
 
     fixture.detectChanges();
 
     expect(fixture.componentInstance.view.instance.getMaxZoom()).toBe(12);
     expect(fixture.componentInstance.view.instance.getMinZoom()).toBe(1);
-    expect(fixture.componentInstance.view.instance.getResolution()).toBe(4);
     expect(fixture.componentInstance.view.instance.getRotation()).toBe(0.5);
+  });
+
+  it('updates OpenLayers view resolution from the resolution binding', () => {
+    fixture.componentInstance.resolution.set(4);
+
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.view.instance.getResolution()).toBe(4);
   });
 
   it('forwards OpenLayers view events through template outputs', () => {

--- a/projects/ngx-ol/src/lib/view.component.spec.ts
+++ b/projects/ngx-ol/src/lib/view.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild } from '@angular/core';
+import { Component, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AngularOpenlayersModule } from '../public-api';
@@ -45,11 +45,9 @@ class ViewHostComponent {
   error = vi.fn();
   propertyChange = vi.fn();
 
-  @ViewChild(ViewComponent)
-  view!: ViewComponent;
+  readonly view = viewChild.required<ViewComponent>(ViewComponent);
 
-  @ViewChild(MapComponent)
-  map!: MapComponent;
+  readonly map = viewChild.required<MapComponent>(MapComponent);
 }
 
 describe('ViewComponent', () => {
@@ -69,11 +67,11 @@ describe('ViewComponent', () => {
   });
 
   it('creates a view from template bindings and attaches it to the map', () => {
-    expect(fixture.componentInstance.map.instance.getView()).toBe(
-      fixture.componentInstance.view.instance,
+    expect(fixture.componentInstance.map().instance.getView()).toBe(
+      fixture.componentInstance.view().instance,
     );
-    expect(fixture.componentInstance.view.instance.getZoom()).toBe(3);
-    expect(fixture.componentInstance.view.instance.getCenter()).toEqual([10, 20]);
+    expect(fixture.componentInstance.view().instance.getZoom()).toBe(3);
+    expect(fixture.componentInstance.view().instance.getCenter()).toEqual([10, 20]);
   });
 
   it('updates OpenLayers view state when template bindings change', () => {
@@ -82,21 +80,21 @@ describe('ViewComponent', () => {
 
     fixture.detectChanges();
 
-    expect(fixture.componentInstance.view.instance.getCenter()).toEqual([30, 40]);
-    expect(fixture.componentInstance.view.instance.getZoom()).toBe(5);
+    expect(fixture.componentInstance.view().instance.getCenter()).toEqual([30, 40]);
+    expect(fixture.componentInstance.view().instance.getZoom()).toBe(5);
   });
 
   it('recreates and reattaches the OpenLayers view when projection changes', () => {
-    const previousView = fixture.componentInstance.view.instance;
+    const previousView = fixture.componentInstance.view().instance;
 
     fixture.componentInstance.projection.set('EPSG:4326');
 
     fixture.detectChanges();
 
-    expect(fixture.componentInstance.view.instance).not.toBe(previousView);
-    expect(fixture.componentInstance.view.instance.getProjection().getCode()).toBe('EPSG:4326');
-    expect(fixture.componentInstance.map.instance.getView()).toBe(
-      fixture.componentInstance.view.instance,
+    expect(fixture.componentInstance.view().instance).not.toBe(previousView);
+    expect(fixture.componentInstance.view().instance.getProjection().getCode()).toBe('EPSG:4326');
+    expect(fixture.componentInstance.map().instance.getView()).toBe(
+      fixture.componentInstance.view().instance,
     );
   });
 
@@ -111,12 +109,12 @@ describe('ViewComponent', () => {
     fixture.componentInstance.error.mockClear();
     fixture.componentInstance.propertyChange.mockClear();
 
-    fixture.componentInstance.view.instance.dispatchEvent('change');
-    fixture.componentInstance.view.instance.dispatchEvent('change:center');
-    fixture.componentInstance.view.instance.dispatchEvent('change:resolution');
-    fixture.componentInstance.view.instance.dispatchEvent('change:rotation');
-    fixture.componentInstance.view.instance.dispatchEvent('error');
-    fixture.componentInstance.view.instance.dispatchEvent('propertychange');
+    fixture.componentInstance.view().instance.dispatchEvent('change');
+    fixture.componentInstance.view().instance.dispatchEvent('change:center');
+    fixture.componentInstance.view().instance.dispatchEvent('change:resolution');
+    fixture.componentInstance.view().instance.dispatchEvent('change:rotation');
+    fixture.componentInstance.view().instance.dispatchEvent('error');
+    fixture.componentInstance.view().instance.dispatchEvent('propertychange');
 
     expect(fixture.componentInstance.change).toHaveBeenCalledOnce();
     expect(fixture.componentInstance.centerChanged).toHaveBeenCalledOnce();
@@ -127,7 +125,7 @@ describe('ViewComponent', () => {
   });
 
   it('animates zoom changes when zoom animation is enabled', () => {
-    const animate = vi.spyOn(fixture.componentInstance.view.instance, 'animate');
+    const animate = vi.spyOn(fixture.componentInstance.view().instance, 'animate');
 
     fixture.componentInstance.zoomAnimation.set(true);
     fixture.componentInstance.zoom.set(6);
@@ -144,9 +142,9 @@ describe('ViewComponent', () => {
 
     fixture.detectChanges();
 
-    expect(fixture.componentInstance.view.instance.getMaxZoom()).toBe(12);
-    expect(fixture.componentInstance.view.instance.getMinZoom()).toBe(1);
-    expect(fixture.componentInstance.view.instance.getRotation()).toBe(0.5);
+    expect(fixture.componentInstance.view().instance.getMaxZoom()).toBe(12);
+    expect(fixture.componentInstance.view().instance.getMinZoom()).toBe(1);
+    expect(fixture.componentInstance.view().instance.getRotation()).toBe(0.5);
   });
 
   it('updates OpenLayers view resolution from the resolution binding', () => {
@@ -154,16 +152,16 @@ describe('ViewComponent', () => {
 
     fixture.detectChanges();
 
-    expect(fixture.componentInstance.view.instance.getResolution()).toBe(4);
+    expect(fixture.componentInstance.view().instance.getResolution()).toBe(4);
   });
 
   it('forwards OpenLayers view events through template outputs', () => {
-    fixture.componentInstance.view.instance.dispatchEvent('change');
-    fixture.componentInstance.view.instance.dispatchEvent('change:center');
-    fixture.componentInstance.view.instance.dispatchEvent('change:resolution');
-    fixture.componentInstance.view.instance.dispatchEvent('change:rotation');
-    fixture.componentInstance.view.instance.dispatchEvent('error');
-    fixture.componentInstance.view.instance.dispatchEvent('propertychange');
+    fixture.componentInstance.view().instance.dispatchEvent('change');
+    fixture.componentInstance.view().instance.dispatchEvent('change:center');
+    fixture.componentInstance.view().instance.dispatchEvent('change:resolution');
+    fixture.componentInstance.view().instance.dispatchEvent('change:rotation');
+    fixture.componentInstance.view().instance.dispatchEvent('error');
+    fixture.componentInstance.view().instance.dispatchEvent('propertychange');
 
     expect(fixture.componentInstance.change).toHaveBeenCalledOnce();
     expect(fixture.componentInstance.centerChanged).toHaveBeenCalledOnce();

--- a/projects/ngx-ol/src/lib/view.component.ts
+++ b/projects/ngx-ol/src/lib/view.component.ts
@@ -7,6 +7,7 @@ import {
   input,
   output,
   signal,
+  inject,
 } from '@angular/core';
 import View, { ViewOptions } from 'ol/View';
 import { MapComponent } from './map.component';
@@ -70,7 +71,7 @@ export class ViewComponent implements OnInit, OnChanges, OnDestroy {
   public componentType = 'view';
   private eventKeys: EventsKey[] = [];
 
-  constructor(private host: MapComponent) {}
+  private readonly host = inject(MapComponent);
 
   ngOnInit() {
     // console.log('creating ol.View instance with: ', this);

--- a/projects/ngx-ol/src/lib/view.component.ts
+++ b/projects/ngx-ol/src/lib/view.component.ts
@@ -14,6 +14,8 @@ import { ObjectEvent } from 'ol/Object';
 import { Extent } from 'ol/extent';
 import { Coordinate } from 'ol/coordinate';
 import BaseEvent from 'ol/events/Event';
+import type { EventsKey } from 'ol/events';
+import { unByKey } from 'ol/Observable';
 import { ProjectionLike } from 'ol/proj';
 
 @Component({
@@ -66,26 +68,16 @@ export class ViewComponent implements OnInit, OnChanges, OnDestroy {
     return instance;
   }
   public componentType = 'view';
+  private eventKeys: EventsKey[] = [];
 
   constructor(private host: MapComponent) {}
 
   ngOnInit() {
     // console.log('creating ol.View instance with: ', this);
-    this.setInstance(new View(this.createOptions()));
-    this.host.instance.setView(this.instance);
-
-    this.instance.on('change', (event: BaseEvent) => this.olChange.emit(event));
-    this.instance.on('change:center', (event: ObjectEvent) => this.changeCenter.emit(event));
-    this.instance.on('change:resolution', (event: ObjectEvent) =>
-      this.changeResolution.emit(event),
-    );
-    this.instance.on('change:rotation', (event: ObjectEvent) => this.changeRotation.emit(event));
-    this.instance.on('error', (event: BaseEvent) => this.olError.emit(event));
-    this.instance.on('propertychange', (event: ObjectEvent) => this.propertyChange.emit(event));
+    this.initializeInstance();
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    const properties: { [index: string]: any } = {};
     if (!this.instance) {
       return;
     }
@@ -103,8 +95,7 @@ export class ViewComponent implements OnInit, OnChanges, OnDestroy {
             }
             break;
           case 'projection':
-            this.setInstance(new View(this.createOptions()));
-            this.host.instance.setView(this.instance);
+            this.initializeInstance();
             break;
           case 'center':
             /** Work-around: setting the center via setProperties does not work. */
@@ -128,17 +119,40 @@ export class ViewComponent implements OnInit, OnChanges, OnDestroy {
           default:
             break;
         }
-        if (key !== 'zoomAnimation') {
-          properties[key] = changes[key].currentValue;
-        }
       }
     }
-    // console.log('changes detected in aol-view, setting new properties: ', properties);
-    this.instance.setProperties(properties, false);
   }
 
   ngOnDestroy() {
+    this.unbindInstanceEvents();
     // console.log('removing aol-view');
+  }
+
+  private initializeInstance() {
+    this.unbindInstanceEvents();
+    this.setInstance(new View(this.createOptions()));
+    this.host.instance.setView(this.instance);
+    this.bindInstanceEvents();
+  }
+
+  private bindInstanceEvents() {
+    this.eventKeys = [
+      this.instance.on('change', (event: BaseEvent) => this.olChange.emit(event)),
+      this.instance.on('change:center', (event: ObjectEvent) => this.changeCenter.emit(event)),
+      this.instance.on('change:resolution', (event: ObjectEvent) =>
+        this.changeResolution.emit(event),
+      ),
+      this.instance.on('change:rotation', (event: ObjectEvent) => this.changeRotation.emit(event)),
+      this.instance.on('error', (event: BaseEvent) => this.olError.emit(event)),
+      this.instance.on('propertychange', (event: ObjectEvent) => this.propertyChange.emit(event)),
+    ];
+  }
+
+  private unbindInstanceEvents() {
+    if (this.eventKeys.length) {
+      unByKey(this.eventKeys);
+      this.eventKeys = [];
+    }
   }
 
   private createOptions(): ViewOptions {

--- a/projects/ngx-ol/src/lib/view.component.ts
+++ b/projects/ngx-ol/src/lib/view.component.ts
@@ -1,12 +1,12 @@
 import {
   Component,
-  Input,
   OnInit,
   OnChanges,
   OnDestroy,
   SimpleChanges,
-  EventEmitter,
-  Output,
+  input,
+  output,
+  signal,
 } from '@angular/core';
 import View, { ViewOptions } from 'ol/View';
 import { MapComponent } from './map.component';
@@ -21,73 +21,57 @@ import { ProjectionLike } from 'ol/proj';
   template: ` <ng-content></ng-content> `,
 })
 export class ViewComponent implements OnInit, OnChanges, OnDestroy {
-  @Input()
-  constrainRotation: boolean | number;
-  @Input()
-  enableRotation: boolean;
-  @Input()
-  extent?: Extent;
-  @Input()
-  maxResolution: number;
-  @Input()
-  minResolution: number;
-  @Input()
-  maxZoom: number;
-  @Input()
-  minZoom: number;
-  @Input()
-  resolution?: number;
-  @Input()
-  resolutions: number[] | undefined;
-  @Input()
-  rotation: number;
-  @Input()
-  zoom?: number;
-  @Input()
-  zoomFactor: number;
-  @Input()
-  center?: Coordinate;
-  @Input()
-  projection: ProjectionLike;
-  @Input()
-  constrainOnlyCenter: boolean;
-  @Input()
-  smoothExtentConstraint: boolean;
-  @Input()
-  constrainResolution: boolean;
-  @Input()
-  smoothResolutionConstraint: boolean;
-  @Input()
-  showFullExtent: boolean;
-  @Input()
-  multiWorld: boolean;
-  @Input()
-  padding?: number[];
+  constrainRotation = input<boolean | number>();
+  enableRotation = input<boolean>();
+  extent = input<Extent>();
+  maxResolution = input<number>();
+  minResolution = input<number>();
+  maxZoom = input<number>();
+  minZoom = input<number>();
+  resolution = input<number>();
+  resolutions = input<number[] | undefined>();
+  rotation = input<number>();
+  zoom = input<number>();
+  zoomFactor = input<number>();
+  center = input<Coordinate>();
+  projection = input<ProjectionLike>();
+  constrainOnlyCenter = input<boolean>();
+  smoothExtentConstraint = input<boolean>();
+  constrainResolution = input<boolean>();
+  smoothResolutionConstraint = input<boolean>();
+  showFullExtent = input<boolean>();
+  multiWorld = input<boolean>();
+  padding = input<number[]>();
 
-  @Input()
-  zoomAnimation = false;
+  zoomAnimation = input(false);
 
-  @Output()
-  olChange = new EventEmitter<BaseEvent>();
-  @Output()
-  changeCenter = new EventEmitter<ObjectEvent>();
-  @Output()
-  changeResolution = new EventEmitter<ObjectEvent>();
-  @Output()
-  changeRotation = new EventEmitter<ObjectEvent>();
-  @Output()
-  olError = new EventEmitter<BaseEvent>();
-  @Output()
-  propertyChange = new EventEmitter<ObjectEvent>();
+  olChange = output<BaseEvent>();
+  changeCenter = output<ObjectEvent>();
+  changeResolution = output<ObjectEvent>();
+  changeRotation = output<ObjectEvent>();
+  olError = output<BaseEvent>();
+  propertyChange = output<ObjectEvent>();
 
   public instance: View;
+
+  protected readonly _instanceSignal = signal<View | undefined>(undefined);
+
+  readonly instanceSignal = this._instanceSignal.asReadonly();
+
+  protected setInstance(instance: View): View {
+    this.instance = instance;
+
+    this._instanceSignal.set(instance);
+
+    return instance;
+  }
   public componentType = 'view';
 
   constructor(private host: MapComponent) {}
 
   ngOnInit() {
     // console.log('creating ol.View instance with: ', this);
-    this.instance = new View(this.createOptions());
+    this.setInstance(new View(this.createOptions()));
     this.host.instance.setView(this.instance);
 
     this.instance.on('change', (event: BaseEvent) => this.olChange.emit(event));
@@ -112,14 +96,14 @@ export class ViewComponent implements OnInit, OnChanges, OnDestroy {
             break;
           case 'zoom':
             /** Work-around: setting the zoom via setProperties does not work. */
-            if (this.zoomAnimation) {
+            if (this.zoomAnimation()) {
               this.instance.animate({ zoom: changes[key].currentValue });
             } else {
               this.instance.setZoom(changes[key].currentValue);
             }
             break;
           case 'projection':
-            this.instance = new View(this.createOptions());
+            this.setInstance(new View(this.createOptions()));
             this.host.instance.setView(this.instance);
             break;
           case 'center':
@@ -155,52 +139,28 @@ export class ViewComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private createOptions(): ViewOptions {
-    const {
-      center,
-      constrainOnlyCenter,
-      constrainResolution,
-      constrainRotation,
-      enableRotation,
-      extent,
-      maxResolution,
-      maxZoom,
-      minResolution,
-      minZoom,
-      multiWorld,
-      padding,
-      projection,
-      resolution,
-      resolutions,
-      rotation,
-      showFullExtent,
-      smoothExtentConstraint,
-      smoothResolutionConstraint,
-      zoom,
-      zoomFactor,
-    } = this;
-
     return {
-      center,
-      constrainOnlyCenter,
-      constrainResolution,
-      constrainRotation,
-      enableRotation,
-      extent,
-      maxResolution,
-      maxZoom,
-      minResolution,
-      minZoom,
-      multiWorld,
-      padding,
-      projection,
-      resolution,
-      resolutions,
-      rotation,
-      showFullExtent,
-      smoothExtentConstraint,
-      smoothResolutionConstraint,
-      zoom,
-      zoomFactor,
+      center: this.center(),
+      constrainOnlyCenter: this.constrainOnlyCenter(),
+      constrainResolution: this.constrainResolution(),
+      constrainRotation: this.constrainRotation(),
+      enableRotation: this.enableRotation(),
+      extent: this.extent(),
+      maxResolution: this.maxResolution(),
+      maxZoom: this.maxZoom(),
+      minResolution: this.minResolution(),
+      minZoom: this.minZoom(),
+      multiWorld: this.multiWorld(),
+      padding: this.padding(),
+      projection: this.projection(),
+      resolution: this.resolution(),
+      resolutions: this.resolutions(),
+      rotation: this.rotation(),
+      showFullExtent: this.showFullExtent(),
+      smoothExtentConstraint: this.smoothExtentConstraint(),
+      smoothResolutionConstraint: this.smoothResolutionConstraint(),
+      zoom: this.zoom(),
+      zoomFactor: this.zoomFactor(),
     };
   }
 }

--- a/projects/ngx-ol/src/lib/view.component.ts
+++ b/projects/ngx-ol/src/lib/view.component.ts
@@ -24,36 +24,36 @@ import { ProjectionLike } from 'ol/proj';
   template: ` <ng-content></ng-content> `,
 })
 export class ViewComponent implements OnInit, OnChanges, OnDestroy {
-  constrainRotation = input<boolean | number>();
-  enableRotation = input<boolean>();
-  extent = input<Extent>();
-  maxResolution = input<number>();
-  minResolution = input<number>();
-  maxZoom = input<number>();
-  minZoom = input<number>();
-  resolution = input<number>();
-  resolutions = input<number[] | undefined>();
-  rotation = input<number>();
-  zoom = input<number>();
-  zoomFactor = input<number>();
-  center = input<Coordinate>();
-  projection = input<ProjectionLike>();
-  constrainOnlyCenter = input<boolean>();
-  smoothExtentConstraint = input<boolean>();
-  constrainResolution = input<boolean>();
-  smoothResolutionConstraint = input<boolean>();
-  showFullExtent = input<boolean>();
-  multiWorld = input<boolean>();
-  padding = input<number[]>();
+  readonly constrainRotation = input<boolean | number>();
+  readonly enableRotation = input<boolean>();
+  readonly extent = input<Extent>();
+  readonly maxResolution = input<number>();
+  readonly minResolution = input<number>();
+  readonly maxZoom = input<number>();
+  readonly minZoom = input<number>();
+  readonly resolution = input<number>();
+  readonly resolutions = input<number[] | undefined>();
+  readonly rotation = input<number>();
+  readonly zoom = input<number>();
+  readonly zoomFactor = input<number>();
+  readonly center = input<Coordinate>();
+  readonly projection = input<ProjectionLike>();
+  readonly constrainOnlyCenter = input<boolean>();
+  readonly smoothExtentConstraint = input<boolean>();
+  readonly constrainResolution = input<boolean>();
+  readonly smoothResolutionConstraint = input<boolean>();
+  readonly showFullExtent = input<boolean>();
+  readonly multiWorld = input<boolean>();
+  readonly padding = input<number[]>();
 
-  zoomAnimation = input(false);
+  readonly zoomAnimation = input(false);
 
-  olChange = output<BaseEvent>();
-  changeCenter = output<ObjectEvent>();
-  changeResolution = output<ObjectEvent>();
-  changeRotation = output<ObjectEvent>();
-  olError = output<BaseEvent>();
-  propertyChange = output<ObjectEvent>();
+  readonly olChange = output<BaseEvent>();
+  readonly changeCenter = output<ObjectEvent>();
+  readonly changeResolution = output<ObjectEvent>();
+  readonly changeRotation = output<ObjectEvent>();
+  readonly olError = output<BaseEvent>();
+  readonly propertyChange = output<ObjectEvent>();
 
   public instance: View;
 
@@ -68,7 +68,7 @@ export class ViewComponent implements OnInit, OnChanges, OnDestroy {
 
     return instance;
   }
-  public componentType = 'view';
+  readonly componentType: string = 'view';
   private eventKeys: EventsKey[] = [];
 
   private readonly host = inject(MapComponent);

--- a/projects/ngx-ol/src/lib/view.component.ts
+++ b/projects/ngx-ol/src/lib/view.component.ts
@@ -116,6 +116,9 @@ export class ViewComponent implements OnInit, OnChanges, OnDestroy {
           case 'minZoom':
             this.instance.setMinZoom(changes[key].currentValue);
             break;
+          case 'constrainResolution':
+            this.instance.setConstrainResolution(changes[key].currentValue);
+            break;
           case 'resolution':
             this.instance.setResolution(changes[key].currentValue);
             break;

--- a/public/tile-json/carto-dark.json
+++ b/public/tile-json/carto-dark.json
@@ -1,0 +1,11 @@
+{
+  "tilejson": "2.2.0",
+  "name": "CARTO Dark",
+  "scheme": "xyz",
+  "tiles": ["https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"],
+  "minzoom": 0,
+  "maxzoom": 19,
+  "bounds": [-180, -85.05112877980659, 180, 85.05112877980659],
+  "center": [0, 0, 2],
+  "attribution": "&copy; OpenStreetMap contributors &copy; CARTO"
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -21,6 +21,7 @@ import { Home } from './home/home';
 import { ImageStatic } from './image-static/image-static';
 import { ImageWms } from './image-wms/image-wms';
 import { IndividualImports } from './individual-imports/individual-imports';
+import { InstanceSignalDemo } from './instance-signal/instance-signal';
 import { Iiif } from './iiif/iiif';
 import { LinkInteractionDemo } from './link-interaction/link-interaction';
 import { MapPosition } from './map-position/map-position';
@@ -99,6 +100,7 @@ export const routes: Routes = [
   { path: 'utf-grid', component: Utfgrid },
   { path: 'image-static', component: ImageStatic },
   { path: 'map-interactions', component: MapInteractions },
+  { path: 'instance-signal', component: InstanceSignalDemo },
   { path: 'dbl-click-drag-zoom', component: DblClickDragZoomDemo },
   { path: 'pinch-rotate', component: PinchRotateDemo },
   { path: 'link-interaction', component: LinkInteractionDemo },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -33,6 +33,13 @@ import { Overlay } from './overlay/overlay';
 import { Overview } from './overview/overview';
 import { PinchRotateDemo } from './pinch-rotate/pinch-rotate';
 import { Raster } from './raster/raster';
+import { ReactiveControls } from './reactive-controls/reactive-controls';
+import { ReactiveDrawings } from './reactive-drawings/reactive-drawings';
+import { ReactiveInteractions } from './reactive-interactions/reactive-interactions';
+import { ReactiveOverlays } from './reactive-overlays/reactive-overlays';
+import { ReactiveSources } from './reactive-sources/reactive-sources';
+import { ReactiveStyles } from './reactive-styles/reactive-styles';
+import { ReactiveViewLayers } from './reactive-view-layers/reactive-view-layers';
 import { RegularShapeDemo } from './regular-shape/regular-shape';
 import { SelectInteraction } from './select-interaction/select-interaction';
 import { SideBySide } from './side-by-side/side-by-side';
@@ -72,6 +79,15 @@ export const routes: Routes = [
   { path: 'clickable-feature', component: ClickableFeatureDemo },
   { path: 'cluster', component: Cluster },
   { path: 'raster', component: Raster },
+  { path: 'reactive-sources', component: ReactiveSources },
+  { path: 'reactive-layers', component: ReactiveViewLayers },
+  { path: 'reactive-controls', component: ReactiveControls },
+  { path: 'reactive-interactions', component: ReactiveInteractions },
+  { path: 'reactive-drawings', component: ReactiveDrawings },
+  { path: 'reactive-overlays', component: ReactiveOverlays },
+  { path: 'reactive-styles', component: ReactiveStyles },
+  { path: 'reactive-services', redirectTo: 'reactive-sources' },
+  { path: 'reactive-view-layers', redirectTo: 'reactive-layers' },
   { path: 'arcgis-image', component: ArcgisImage },
   { path: 'arcgis-tiled', component: ArcgisTiled },
   { path: 'tile-arcgis-rest', component: TileArcgisRest },

--- a/src/app/demos.ts
+++ b/src/app/demos.ts
@@ -90,6 +90,13 @@ const DEMO_DEFINITIONS: readonly DemoDefinition[] = [
     keywords: ['position', 'center', 'zoom', 'forms'],
   },
   {
+    path: '/instance-signal',
+    label: 'Instance Signal',
+    description:
+      'Uses instanceSignal to wait for the underlying OpenLayers map instance and call OL APIs safely.',
+    keywords: ['instance', 'signal', 'map', 'openlayers', 'escape-hatch'],
+  },
+  {
     path: '/cursor-position',
     label: 'Cursor Position',
     description: 'Move your pointer over the map to see its current coordinate.',
@@ -112,7 +119,8 @@ const DEMO_DEFINITIONS: readonly DemoDefinition[] = [
   {
     path: '/clickable-feature',
     label: 'Clickable Feature',
-    description: 'Shows how aol-feature emits olClick, singleClick, and dblClick when clickable is enabled.',
+    description:
+      'Shows how aol-feature emits olClick, singleClick, and dblClick when clickable is enabled.',
     keywords: ['feature', 'click', 'singleclick', 'dblclick', 'events'],
   },
   {
@@ -325,8 +333,7 @@ const DEMO_DEFINITIONS: readonly DemoDefinition[] = [
   {
     path: '/reactive-drawings',
     label: 'Reactive Drawings',
-    description:
-      'Kitchen-sink drawing demo for draw, modify, snap, and translate options.',
+    description: 'Kitchen-sink drawing demo for draw, modify, snap, and translate options.',
     keywords: ['reactive', 'drawings', 'draw', 'modify', 'snap', 'translate'],
   },
   {

--- a/src/app/demos.ts
+++ b/src/app/demos.ts
@@ -13,6 +13,7 @@ const GITHUB_SOURCE_BASE = 'https://github.com/compassinformatics/ngx-ol/blob/ma
 const SOURCE_PATH_OVERRIDES: Readonly<Record<string, string>> = {
   '/basic': 'src/app/basic-map/basic-map.ts',
   '/advanced': 'src/app/advanced-map/advanced-map.ts',
+  '/reactive-layers': 'src/app/reactive-view-layers/reactive-view-layers.ts',
   '/utf-grid': 'src/app/utfgrid/utfgrid.ts',
 };
 
@@ -294,6 +295,52 @@ const DEMO_DEFINITIONS: readonly DemoDefinition[] = [
     label: 'Raster',
     description: 'Applies raster operations so you can see derived image output update live.',
     keywords: ['raster', 'operation', 'brightness', 'contrast'],
+  },
+  {
+    path: '/reactive-sources',
+    label: 'Reactive Sources',
+    description:
+      'Kitchen-sink source demo for XYZ, WMS, vector, ArcGIS REST, TileJSON, and WMTS updates.',
+    keywords: ['reactive', 'sources', 'xyz', 'wms', 'vector', 'arcgis', 'tilejson', 'wmts'],
+  },
+  {
+    path: '/reactive-layers',
+    label: 'Reactive Layers',
+    description:
+      'Kitchen-sink demo for live view constraints, layer state, vector layers, and heatmap settings.',
+    keywords: ['reactive', 'view', 'layers', 'heatmap', 'opacity', 'visibility'],
+  },
+  {
+    path: '/reactive-controls',
+    label: 'Reactive Controls',
+    description: 'Kitchen-sink map UI demo for live OpenLayers control inputs.',
+    keywords: ['reactive', 'controls', 'overview', 'scaleline', 'attribution'],
+  },
+  {
+    path: '/reactive-interactions',
+    label: 'Reactive Interactions',
+    description: 'Kitchen-sink interaction demo for navigation and selection options.',
+    keywords: ['reactive', 'interactions', 'navigation', 'select', 'mousewheel'],
+  },
+  {
+    path: '/reactive-drawings',
+    label: 'Reactive Drawings',
+    description:
+      'Kitchen-sink drawing demo for draw, modify, snap, and translate options.',
+    keywords: ['reactive', 'drawings', 'draw', 'modify', 'snap', 'translate'],
+  },
+  {
+    path: '/reactive-styles',
+    label: 'Reactive Styles',
+    description:
+      'Kitchen-sink style and geometry demo for live coordinates, strokes, fills, text, and circle styles.',
+    keywords: ['reactive', 'styles', 'geometry', 'text', 'stroke', 'fill'],
+  },
+  {
+    path: '/reactive-overlays',
+    label: 'Reactive Overlays',
+    description: 'Kitchen-sink overlay demo for position, offset, and positioning inputs.',
+    keywords: ['reactive', 'overlays', 'position', 'offset', 'popup'],
   },
 
   // Map utilities and comparison

--- a/src/app/instance-signal/instance-signal.html
+++ b/src/app/instance-signal/instance-signal.html
@@ -1,0 +1,51 @@
+<div class="layout demo-layout">
+  <aol-map #map class="map demo-map" tabindex="0">
+    <aol-view [center]="center" [zoom]="initialZoom"></aol-view>
+
+    <aol-layer-tile>
+      <aol-source-osm></aol-source-osm>
+    </aol-layer-tile>
+
+    <aol-interaction-default></aol-interaction-default>
+    <aol-control-defaults></aol-control-defaults>
+  </aol-map>
+
+  <aside class="panel demo-panel">
+    <h2>Instance signal</h2>
+    <p>
+      `instanceSignal` exposes the underlying OpenLayers object once ngx-ol has created it.
+      `instance` remains available as the direct escape hatch, while the signal gives templates and
+      reactive code a safe readiness check.
+    </p>
+
+    @if (map.instanceSignal(); as mapInstance) {
+      <div class="status is-ready">OpenLayers map instance is ready.</div>
+
+      <dl class="instance-details">
+        <div>
+          <dt>Layers</dt>
+          <dd>{{ mapInstance.getLayers().getLength() }}</dd>
+        </div>
+        <div>
+          <dt>Controls</dt>
+          <dd>{{ mapInstance.getControls().getLength() }}</dd>
+        </div>
+        <div>
+          <dt>Interactions</dt>
+          <dd>{{ mapInstance.getInteractions().getLength() }}</dd>
+        </div>
+      </dl>
+
+      <fieldset>
+        <legend>Call OpenLayers APIs</legend>
+        <button type="button" (click)="fitIreland()">Fit Ireland</button>
+        <button type="button" (click)="rotate()">Rotate view</button>
+        <button type="button" (click)="resetRotation()">Reset rotation</button>
+      </fieldset>
+
+      <pre><code>this.mapComponent().instanceSignal()?.getView()</code></pre>
+    } @else {
+      <div class="status">Waiting for ngx-ol to create the OpenLayers map instance.</div>
+    }
+  </aside>
+</div>

--- a/src/app/instance-signal/instance-signal.less
+++ b/src/app/instance-signal/instance-signal.less
@@ -1,0 +1,71 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.panel {
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
+}
+
+.panel h2,
+.panel p,
+.panel fieldset,
+.panel dl {
+  margin: 0;
+}
+
+.panel fieldset {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.panel button {
+  min-height: 2rem;
+}
+
+.status {
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgb(148 163 184 / 0.35);
+  border-radius: 0.65rem;
+  background: rgb(248 250 252 / 0.85);
+}
+
+.status.is-ready {
+  border-color: rgb(34 197 94 / 0.4);
+  background: rgb(220 252 231 / 0.8);
+}
+
+.instance-details {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.instance-details div {
+  padding: 0.65rem;
+  border-radius: 0.65rem;
+  background: #f8fafc;
+}
+
+.instance-details dt {
+  color: #475569;
+  font-size: 0.8rem;
+}
+
+.instance-details dd {
+  margin: 0.15rem 0 0;
+  color: #0f172a;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+pre {
+  margin: 0;
+  padding: 0.65rem;
+  overflow: auto;
+  border-radius: 0.65rem;
+  background: #0f172a;
+  color: #e2e8f0;
+}

--- a/src/app/instance-signal/instance-signal.ts
+++ b/src/app/instance-signal/instance-signal.ts
@@ -1,0 +1,47 @@
+import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
+import { AngularOpenlayersModule, MapComponent } from 'ngx-ol';
+import type { Coordinate } from 'ol/coordinate';
+import { transform, transformExtent } from 'ol/proj';
+
+@Component({
+  selector: 'app-instance-signal',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AngularOpenlayersModule],
+  templateUrl: './instance-signal.html',
+  styleUrl: './instance-signal.less',
+})
+export class InstanceSignalDemo {
+  protected readonly center: Coordinate = transform([-7.8, 53.4], 'EPSG:4326', 'EPSG:3857');
+  protected readonly initialZoom = 6;
+  protected readonly mapComponent = viewChild.required(MapComponent);
+
+  protected fitIreland(): void {
+    this.mapComponent()
+      .instanceSignal()
+      ?.getView()
+      .fit(transformExtent([-10.8, 51.2, -5.2, 55.6], 'EPSG:4326', 'EPSG:3857'), {
+        duration: 350,
+        padding: [48, 48, 48, 48],
+      });
+  }
+
+  protected rotate(): void {
+    const view = this.mapComponent().instanceSignal()?.getView();
+
+    if (!view) {
+      return;
+    }
+
+    view.animate({
+      rotation: view.getRotation() + Math.PI / 8,
+      duration: 250,
+    });
+  }
+
+  protected resetRotation(): void {
+    this.mapComponent().instanceSignal()?.getView().animate({
+      rotation: 0,
+      duration: 250,
+    });
+  }
+}

--- a/src/app/reactive-controls/reactive-controls.html
+++ b/src/app/reactive-controls/reactive-controls.html
@@ -1,0 +1,83 @@
+<div class="layout demo-layout">
+  <aol-map class="map demo-map" tabindex="0">
+    <aol-view [zoom]="zoom()" [center]="center()"></aol-view>
+
+    <aol-layer-tile>
+      <aol-source-osm></aol-source-osm>
+    </aol-layer-tile>
+
+    <aol-interaction-default></aol-interaction-default>
+
+    <aol-control-overviewmap
+      [collapsed]="overviewCollapsed()"
+      [collapsible]="overviewCollapsible()"
+      [rotateWithView]="overviewRotateWithView()"
+    ></aol-control-overviewmap>
+    <aol-control-scaleline [units]="scaleUnits()"></aol-control-scaleline>
+    <aol-control-mouseposition [projection]="mouseProjection()"></aol-control-mouseposition>
+    <aol-control-zoom></aol-control-zoom>
+    <aol-control-attribution
+      [collapsed]="attributionCollapsed()"
+      [collapsible]="true"
+    ></aol-control-attribution>
+  </aol-map>
+
+  <aside class="panel demo-panel">
+    <h2>Reactive controls</h2>
+    <p>Use this page for OpenLayers controls only.</p>
+
+    <fieldset>
+      <legend>Overview map</legend>
+      <button type="button" (click)="toggleOverviewCollapsed()">
+        {{ overviewCollapsed() ? 'Expand' : 'Collapse' }} overview
+      </button>
+      <label>
+        <input
+          type="checkbox"
+          [checked]="overviewCollapsible()"
+          (change)="toggleOverviewCollapsible()"
+        />
+        Collapsible
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          [checked]="overviewRotateWithView()"
+          (change)="toggleOverviewRotation()"
+        />
+        Rotate with view
+      </label>
+    </fieldset>
+
+    <fieldset>
+      <legend>Scale and mouse position</legend>
+      <label for="reactive-scale-units">Scale units</label>
+      <select
+        id="reactive-scale-units"
+        [value]="scaleUnits()"
+        (change)="setScaleUnits($any($event.target).value)"
+      >
+        <option value="metric">Metric</option>
+        <option value="imperial">Imperial</option>
+        <option value="nautical">Nautical</option>
+      </select>
+
+      <label for="reactive-mouse-projection">Mouse projection</label>
+      <select
+        id="reactive-mouse-projection"
+        [value]="mouseProjection()"
+        (change)="setMouseProjection($any($event.target).value)"
+      >
+        <option value="EPSG:4326">EPSG:4326</option>
+        <option value="EPSG:3857">EPSG:3857</option>
+      </select>
+    </fieldset>
+
+    <fieldset>
+      <legend>Attribution</legend>
+      <button type="button" (click)="toggleAttribution()">
+        {{ attributionCollapsed() ? 'Expand' : 'Collapse' }} attribution
+      </button>
+    </fieldset>
+  </aside>
+</div>

--- a/src/app/reactive-controls/reactive-controls.less
+++ b/src/app/reactive-controls/reactive-controls.less
@@ -1,0 +1,38 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.panel {
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
+}
+
+.panel h2,
+.panel p,
+.panel fieldset,
+.panel label {
+  margin: 0;
+}
+
+.panel fieldset {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.panel label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.panel fieldset label:has(input[type='checkbox']) {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.panel button,
+.panel select {
+  min-height: 2rem;
+}

--- a/src/app/reactive-controls/reactive-controls.spec.ts
+++ b/src/app/reactive-controls/reactive-controls.spec.ts
@@ -1,0 +1,24 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReactiveControls } from './reactive-controls';
+
+describe('ReactiveControls', () => {
+  let component: ReactiveControls;
+  let fixture: ComponentFixture<ReactiveControls>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveControls],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReactiveControls);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/reactive-controls/reactive-controls.ts
+++ b/src/app/reactive-controls/reactive-controls.ts
@@ -1,0 +1,47 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { AngularOpenlayersModule } from 'ngx-ol';
+import type { Coordinate } from 'ol/coordinate';
+import type { Units } from 'ol/control/ScaleLine';
+import { transform } from 'ol/proj';
+
+@Component({
+  selector: 'app-reactive-controls',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AngularOpenlayersModule],
+  templateUrl: './reactive-controls.html',
+  styleUrl: './reactive-controls.less',
+})
+export class ReactiveControls {
+  readonly center = signal<Coordinate>(transform([-3.2, 54.8], 'EPSG:4326', 'EPSG:3857'));
+  readonly zoom = signal(6);
+  readonly scaleUnits = signal<Units>('metric');
+  readonly overviewCollapsed = signal(false);
+  readonly overviewCollapsible = signal(true);
+  readonly overviewRotateWithView = signal(false);
+  readonly attributionCollapsed = signal(false);
+  readonly mouseProjection = signal('EPSG:4326');
+
+  protected setScaleUnits(units: Units): void {
+    this.scaleUnits.set(units);
+  }
+
+  protected setMouseProjection(projection: string): void {
+    this.mouseProjection.set(projection);
+  }
+
+  protected toggleOverviewCollapsed(): void {
+    this.overviewCollapsed.update((collapsed) => !collapsed);
+  }
+
+  protected toggleOverviewCollapsible(): void {
+    this.overviewCollapsible.update((collapsible) => !collapsible);
+  }
+
+  protected toggleOverviewRotation(): void {
+    this.overviewRotateWithView.update((rotateWithView) => !rotateWithView);
+  }
+
+  protected toggleAttribution(): void {
+    this.attributionCollapsed.update((collapsed) => !collapsed);
+  }
+}

--- a/src/app/reactive-drawings/reactive-drawings.html
+++ b/src/app/reactive-drawings/reactive-drawings.html
@@ -1,0 +1,181 @@
+<div class="layout demo-layout">
+  <aol-map class="map demo-map" tabindex="0">
+    <aol-view [zoom]="zoom()" [center]="center()"></aol-view>
+
+    <aol-layer-tile>
+      <aol-source-osm></aol-source-osm>
+    </aol-layer-tile>
+
+    <aol-layer-vector>
+      <aol-source-vector [features]="featureCollection"></aol-source-vector>
+      <aol-style>
+        <aol-style-circle [radius]="8">
+          <aol-style-stroke color="#0f172a" [width]="2"></aol-style-stroke>
+          <aol-style-fill color="#facc15"></aol-style-fill>
+        </aol-style-circle>
+        <aol-style-stroke color="#2563eb" [width]="3"></aol-style-stroke>
+        <aol-style-fill color="rgba(37, 99, 235, 0.18)"></aol-style-fill>
+      </aol-style>
+    </aol-layer-vector>
+
+    <aol-interaction-default></aol-interaction-default>
+
+    @if (drawEnabled()) {
+      <aol-interaction-draw
+        [type]="drawType()"
+        [features]="featureCollection"
+        [trace]="drawTrace()"
+        [freehand]="drawFreehand()"
+        [snapTolerance]="drawSnapTolerance()"
+        (drawStart)="interactionStarted('Draw')"
+        (drawEnd)="interactionEnded('Draw')"
+      ></aol-interaction-draw>
+    }
+
+    @if (modifyEnabled()) {
+      <aol-interaction-modify
+        [features]="featureCollection"
+        [pixelTolerance]="modifyPixelTolerance()"
+        (modifyStart)="interactionStarted('Modify')"
+        (modifyEnd)="interactionEnded('Modify')"
+      ></aol-interaction-modify>
+    }
+
+    @if (snapEnabled()) {
+      <aol-interaction-snap
+        [features]="featureCollection"
+        [edge]="snapEdges()"
+        [vertex]="snapVertices()"
+        [pixelTolerance]="snapPixelTolerance()"
+      ></aol-interaction-snap>
+    }
+
+    @if (translateEnabled()) {
+      <aol-interaction-translate
+        [features]="featureCollection"
+        [hitTolerance]="translateHitTolerance()"
+        (translateStart)="interactionStarted('Translate')"
+        (translateEnd)="interactionEnded('Translate')"
+      ></aol-interaction-translate>
+    }
+
+    <aol-control-scaleline></aol-control-scaleline>
+    <aol-control-zoom></aol-control-zoom>
+    <aol-control-attribution></aol-control-attribution>
+  </aol-map>
+
+  <aside class="panel demo-panel">
+    <h2>Reactive drawings</h2>
+    <p>
+      Use this page for drawing and editing interactions: draw, modify, snap, and translate.
+    </p>
+
+    <fieldset>
+      <legend>Draw</legend>
+      <label>
+        <input type="checkbox" [checked]="drawEnabled()" (change)="toggleDrawEnabled()" />
+        Enable draw interaction
+      </label>
+
+      <label for="reactive-draw-type">Draw type</label>
+      <select
+        id="reactive-draw-type"
+        [value]="drawType()"
+        (change)="setDrawType($any($event.target).value)"
+      >
+        <option value="Point">Point</option>
+        <option value="LineString">LineString</option>
+        <option value="Polygon">Polygon</option>
+      </select>
+
+      <label>
+        <input type="checkbox" [checked]="drawTrace()" (change)="toggleDrawTrace()" />
+        Trace existing geometry
+      </label>
+      <label>
+        <input type="checkbox" [checked]="drawFreehand()" (change)="toggleDrawFreehand()" />
+        Freehand mode
+      </label>
+
+      <label for="reactive-draw-snap">Draw snap tolerance: {{ drawSnapTolerance() }}</label>
+      <input
+        id="reactive-draw-snap"
+        type="range"
+        min="4"
+        max="32"
+        [value]="drawSnapTolerance()"
+        (input)="setDrawSnapTolerance($any($event.target).valueAsNumber)"
+      />
+    </fieldset>
+
+    <fieldset>
+      <legend>Modify and snap</legend>
+      <label>
+        <input type="checkbox" [checked]="modifyEnabled()" (change)="toggleModifyEnabled()" />
+        Enable modify interaction
+      </label>
+      <label for="reactive-modify-tolerance">
+        Modify pixel tolerance: {{ modifyPixelTolerance() }}
+      </label>
+      <input
+        id="reactive-modify-tolerance"
+        type="range"
+        min="2"
+        max="32"
+        [value]="modifyPixelTolerance()"
+        (input)="setModifyPixelTolerance($any($event.target).valueAsNumber)"
+      />
+
+      <label>
+        <input type="checkbox" [checked]="snapEnabled()" (change)="toggleSnapEnabled()" />
+        Enable snap interaction
+      </label>
+      <label>
+        <input type="checkbox" [checked]="snapEdges()" (change)="toggleSnapEdges()" />
+        Snap to edges
+      </label>
+      <label>
+        <input type="checkbox" [checked]="snapVertices()" (change)="toggleSnapVertices()" />
+        Snap to vertices
+      </label>
+      <label for="reactive-snap-tolerance">Snap pixel tolerance: {{ snapPixelTolerance() }}</label>
+      <input
+        id="reactive-snap-tolerance"
+        type="range"
+        min="2"
+        max="32"
+        [value]="snapPixelTolerance()"
+        (input)="setSnapPixelTolerance($any($event.target).valueAsNumber)"
+      />
+    </fieldset>
+
+    <fieldset>
+      <legend>Translate</legend>
+      <label>
+        <input
+          type="checkbox"
+          [checked]="translateEnabled()"
+          (change)="toggleTranslateEnabled()"
+        />
+        Enable translate interaction
+      </label>
+      <label for="reactive-translate-tolerance">
+        Translate hit tolerance: {{ translateHitTolerance() }}
+      </label>
+      <input
+        id="reactive-translate-tolerance"
+        type="range"
+        min="0"
+        max="32"
+        [value]="translateHitTolerance()"
+        (input)="setTranslateHitTolerance($any($event.target).valueAsNumber)"
+      />
+    </fieldset>
+
+    <section class="status" aria-live="polite">
+      <p>{{ status() }}</p>
+      <p>Features: {{ featureCollection.getLength() }}</p>
+      <button type="button" (click)="resetFeatures()">Reset features</button>
+    </section>
+  </aside>
+</div>

--- a/src/app/reactive-drawings/reactive-drawings.less
+++ b/src/app/reactive-drawings/reactive-drawings.less
@@ -1,0 +1,46 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.panel {
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
+}
+
+.panel h2,
+.panel p,
+.panel fieldset,
+.panel label {
+  margin: 0;
+}
+
+.panel fieldset {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.panel label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.panel fieldset label:has(input[type='checkbox']) {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.panel button,
+.panel select {
+  min-height: 2rem;
+}
+
+.status {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.75rem;
+  border-radius: 0.8rem;
+  background: rgb(15 23 42 / 0.08);
+}

--- a/src/app/reactive-drawings/reactive-drawings.spec.ts
+++ b/src/app/reactive-drawings/reactive-drawings.spec.ts
@@ -1,0 +1,24 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReactiveDrawings } from './reactive-drawings';
+
+describe('ReactiveDrawings', () => {
+  let component: ReactiveDrawings;
+  let fixture: ComponentFixture<ReactiveDrawings>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveDrawings],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReactiveDrawings);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/reactive-drawings/reactive-drawings.ts
+++ b/src/app/reactive-drawings/reactive-drawings.ts
@@ -1,0 +1,130 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { AngularOpenlayersModule } from 'ngx-ol';
+import Collection from 'ol/Collection';
+import Feature from 'ol/Feature';
+import type { Coordinate } from 'ol/coordinate';
+import type { Type as GeometryType } from 'ol/geom/Geometry';
+import Point from 'ol/geom/Point';
+import Polygon from 'ol/geom/Polygon';
+import { transform } from 'ol/proj';
+
+type DrawType = Extract<GeometryType, 'Point' | 'LineString' | 'Polygon'>;
+
+@Component({
+  selector: 'app-reactive-drawings',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AngularOpenlayersModule],
+  templateUrl: './reactive-drawings.html',
+  styleUrl: './reactive-drawings.less',
+})
+export class ReactiveDrawings {
+  readonly center = signal<Coordinate>(transform([-2.2, 53.1], 'EPSG:4326', 'EPSG:3857'));
+  readonly zoom = signal(6);
+  readonly drawEnabled = signal(false);
+  readonly drawType = signal<DrawType>('Polygon');
+  readonly drawTrace = signal(false);
+  readonly drawFreehand = signal(false);
+  readonly drawSnapTolerance = signal(12);
+  readonly modifyEnabled = signal(true);
+  readonly modifyPixelTolerance = signal(10);
+  readonly snapEnabled = signal(true);
+  readonly snapEdges = signal(true);
+  readonly snapVertices = signal(true);
+  readonly snapPixelTolerance = signal(10);
+  readonly translateEnabled = signal(false);
+  readonly translateHitTolerance = signal(6);
+  readonly status = signal('Toggle drawing interactions, draw features, or drag existing geometry.');
+  readonly featureCollection = new Collection<Feature>([
+    new Feature({
+      geometry: new Point(transform([-4.4, 54], 'EPSG:4326', 'EPSG:3857')),
+    }),
+    new Feature({
+      geometry: createPolygon(),
+    }),
+  ]);
+
+  protected toggleDrawEnabled(): void {
+    this.drawEnabled.update((enabled) => !enabled);
+  }
+
+  protected setDrawType(type: DrawType): void {
+    this.drawType.set(type);
+  }
+
+  protected toggleDrawTrace(): void {
+    this.drawTrace.update((enabled) => !enabled);
+  }
+
+  protected toggleDrawFreehand(): void {
+    this.drawFreehand.update((enabled) => !enabled);
+  }
+
+  protected setDrawSnapTolerance(tolerance: number): void {
+    this.drawSnapTolerance.set(tolerance);
+  }
+
+  protected toggleModifyEnabled(): void {
+    this.modifyEnabled.update((enabled) => !enabled);
+  }
+
+  protected setModifyPixelTolerance(tolerance: number): void {
+    this.modifyPixelTolerance.set(tolerance);
+  }
+
+  protected toggleSnapEnabled(): void {
+    this.snapEnabled.update((enabled) => !enabled);
+  }
+
+  protected toggleSnapEdges(): void {
+    this.snapEdges.update((enabled) => !enabled);
+  }
+
+  protected toggleSnapVertices(): void {
+    this.snapVertices.update((enabled) => !enabled);
+  }
+
+  protected setSnapPixelTolerance(tolerance: number): void {
+    this.snapPixelTolerance.set(tolerance);
+  }
+
+  protected toggleTranslateEnabled(): void {
+    this.translateEnabled.update((enabled) => !enabled);
+  }
+
+  protected setTranslateHitTolerance(tolerance: number): void {
+    this.translateHitTolerance.set(tolerance);
+  }
+
+  protected resetFeatures(): void {
+    this.featureCollection.clear();
+    this.featureCollection.extend([
+      new Feature({
+        geometry: new Point(transform([-4.4, 54], 'EPSG:4326', 'EPSG:3857')),
+      }),
+      new Feature({
+        geometry: createPolygon(),
+      }),
+    ]);
+    this.status.set('Features reset.');
+  }
+
+  protected interactionStarted(name: string): void {
+    this.status.set(`${name} started.`);
+  }
+
+  protected interactionEnded(name: string): void {
+    this.status.set(`${name} ended. Features in collection: ${this.featureCollection.getLength()}.`);
+  }
+}
+
+function createPolygon(): Polygon {
+  return new Polygon([
+    [
+      transform([-3.9, 52.7], 'EPSG:4326', 'EPSG:3857'),
+      transform([-1.4, 52.7], 'EPSG:4326', 'EPSG:3857'),
+      transform([-1.4, 54.2], 'EPSG:4326', 'EPSG:3857'),
+      transform([-3.9, 54.2], 'EPSG:4326', 'EPSG:3857'),
+      transform([-3.9, 52.7], 'EPSG:4326', 'EPSG:3857'),
+    ],
+  ]);
+}

--- a/src/app/reactive-interactions/reactive-interactions.html
+++ b/src/app/reactive-interactions/reactive-interactions.html
@@ -1,0 +1,103 @@
+<div class="layout demo-layout">
+  <aol-map class="map demo-map" tabindex="0">
+    <aol-view [zoom]="zoom()" [center]="center()"></aol-view>
+
+    <aol-layer-tile>
+      <aol-source-osm></aol-source-osm>
+    </aol-layer-tile>
+
+    <aol-layer-vector>
+      <aol-source-vector [features]="features"></aol-source-vector>
+      <aol-style>
+        <aol-style-circle [radius]="9">
+          <aol-style-stroke color="#0f172a" [width]="2"></aol-style-stroke>
+          <aol-style-fill color="#facc15"></aol-style-fill>
+        </aol-style-circle>
+      </aol-style>
+    </aol-layer-vector>
+
+    <aol-interaction-default
+      [dragPan]="defaultDragPan()"
+      [mouseWheelZoom]="defaultMouseWheelZoom()"
+      [doubleClickZoom]="defaultDoubleClickZoom()"
+    ></aol-interaction-default>
+    <aol-interaction-mousewheelzoom [useAnchor]="mouseWheelAnchor()"></aol-interaction-mousewheelzoom>
+    @if (selectEnabled()) {
+      <aol-interaction-select
+        [hitTolerance]="selectHitTolerance()"
+        (olSelect)="selectChanged()"
+      ></aol-interaction-select>
+    }
+
+    <aol-control-scaleline></aol-control-scaleline>
+    <aol-control-zoom></aol-control-zoom>
+    <aol-control-attribution></aol-control-attribution>
+  </aol-map>
+
+  <aside class="panel demo-panel">
+    <h2>Reactive interactions</h2>
+    <p>Use this page for navigation and selection interactions only.</p>
+
+    <fieldset>
+      <legend>Default navigation</legend>
+      <label>
+        <input type="checkbox" [checked]="defaultDragPan()" (change)="toggleDefaultDragPan()" />
+        Drag pan
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          [checked]="defaultMouseWheelZoom()"
+          (change)="toggleDefaultMouseWheelZoom()"
+        />
+        Default mouse wheel zoom
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          [checked]="defaultDoubleClickZoom()"
+          (change)="toggleDefaultDoubleClickZoom()"
+        />
+        Double-click zoom
+      </label>
+    </fieldset>
+
+    <fieldset>
+      <legend>Mouse wheel zoom</legend>
+      <label>
+        <input
+          type="checkbox"
+          [checked]="mouseWheelAnchor()"
+          (change)="toggleMouseWheelAnchor()"
+        />
+        Enable mouse-location zoom anchor
+      </label>
+      <p class="hint">
+        When false, wheel zooming uses the center of the map instead of the mouse location.
+      </p>
+      <button type="button" (click)="resetWheelTestView()">Reset wheel test view</button>
+    </fieldset>
+
+    <fieldset>
+      <legend>Select</legend>
+      <label>
+        <input type="checkbox" [checked]="selectEnabled()" (change)="toggleSelectEnabled()" />
+        Enable select interaction
+      </label>
+
+      <label for="reactive-hit-tolerance">Select hit tolerance: {{ selectHitTolerance() }}</label>
+      <input
+        id="reactive-hit-tolerance"
+        type="range"
+        min="0"
+        max="24"
+        [value]="selectHitTolerance()"
+        (input)="setSelectHitTolerance($any($event.target).valueAsNumber)"
+      />
+    </fieldset>
+
+    <section class="status" aria-live="polite">
+      <p>{{ status() }}</p>
+    </section>
+  </aside>
+</div>

--- a/src/app/reactive-interactions/reactive-interactions.less
+++ b/src/app/reactive-interactions/reactive-interactions.less
@@ -1,0 +1,46 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.panel {
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
+}
+
+.panel h2,
+.panel p,
+.panel fieldset,
+.panel label {
+  margin: 0;
+}
+
+.panel fieldset {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.panel label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.panel fieldset label:has(input[type='checkbox']) {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.panel button,
+.panel select {
+  min-height: 2rem;
+}
+
+.status {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.75rem;
+  border-radius: 0.8rem;
+  background: rgb(15 23 42 / 0.08);
+}

--- a/src/app/reactive-interactions/reactive-interactions.spec.ts
+++ b/src/app/reactive-interactions/reactive-interactions.spec.ts
@@ -1,0 +1,24 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReactiveInteractions } from './reactive-interactions';
+
+describe('ReactiveInteractions', () => {
+  let component: ReactiveInteractions;
+  let fixture: ComponentFixture<ReactiveInteractions>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveInteractions],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReactiveInteractions);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/reactive-interactions/reactive-interactions.ts
+++ b/src/app/reactive-interactions/reactive-interactions.ts
@@ -1,0 +1,64 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { AngularOpenlayersModule } from 'ngx-ol';
+import Feature from 'ol/Feature';
+import type { Coordinate } from 'ol/coordinate';
+import Point from 'ol/geom/Point';
+import { transform } from 'ol/proj';
+
+@Component({
+  selector: 'app-reactive-interactions',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AngularOpenlayersModule],
+  templateUrl: './reactive-interactions.html',
+  styleUrl: './reactive-interactions.less',
+})
+export class ReactiveInteractions {
+  readonly center = signal<Coordinate>(transform([-2.2, 53.1], 'EPSG:4326', 'EPSG:3857'));
+  readonly zoom = signal(6);
+  readonly defaultDragPan = signal(true);
+  readonly defaultMouseWheelZoom = signal(false);
+  readonly defaultDoubleClickZoom = signal(true);
+  readonly mouseWheelAnchor = signal(true);
+  readonly selectEnabled = signal(true);
+  readonly selectHitTolerance = signal(4);
+  readonly status = signal('Toggle navigation and selection interactions.');
+  readonly features = [
+    new Feature({
+      geometry: new Point(transform([-4.4, 54], 'EPSG:4326', 'EPSG:3857')),
+      name: 'Selectable point',
+    }),
+  ];
+
+  protected toggleDefaultDragPan(): void {
+    this.defaultDragPan.update((enabled) => !enabled);
+  }
+
+  protected toggleDefaultMouseWheelZoom(): void {
+    this.defaultMouseWheelZoom.update((enabled) => !enabled);
+  }
+
+  protected toggleDefaultDoubleClickZoom(): void {
+    this.defaultDoubleClickZoom.update((enabled) => !enabled);
+  }
+
+  protected toggleMouseWheelAnchor(): void {
+    this.mouseWheelAnchor.update((useAnchor) => !useAnchor);
+  }
+
+  protected toggleSelectEnabled(): void {
+    this.selectEnabled.update((enabled) => !enabled);
+  }
+
+  protected setSelectHitTolerance(hitTolerance: number): void {
+    this.selectHitTolerance.set(hitTolerance);
+  }
+
+  protected resetWheelTestView(): void {
+    this.center.set(transform([-2.2, 53.1], 'EPSG:4326', 'EPSG:3857'));
+    this.zoom.set(6);
+  }
+
+  protected selectChanged(): void {
+    this.status.set(`Select interaction changed at ${new Date().toLocaleTimeString()}.`);
+  }
+}

--- a/src/app/reactive-overlays/reactive-overlays.html
+++ b/src/app/reactive-overlays/reactive-overlays.html
@@ -1,0 +1,82 @@
+<div class="layout demo-layout">
+  <aol-map class="map demo-map">
+    <aol-view [zoom]="zoom()" [center]="center()"></aol-view>
+
+    <aol-layer-tile>
+      <aol-source-osm></aol-source-osm>
+    </aol-layer-tile>
+
+    <aol-layer-vector>
+      <aol-source-vector>
+        <aol-feature>
+          <aol-geometry-point>
+            <aol-coordinate [x]="marker()[0]" [y]="marker()[1]"></aol-coordinate>
+          </aol-geometry-point>
+          <aol-style>
+            <aol-style-circle [radius]="10">
+              <aol-style-stroke color="#0f172a" [width]="2"></aol-style-stroke>
+              <aol-style-fill color="#facc15"></aol-style-fill>
+            </aol-style-circle>
+          </aol-style>
+        </aol-feature>
+      </aol-source-vector>
+    </aol-layer-vector>
+
+    <aol-overlay
+      [position]="marker()"
+      [offset]="overlayOffset()"
+      [positioning]="overlayPositioning()"
+    >
+      <aol-content>
+        <div class="map-callout">Reactive overlay</div>
+      </aol-content>
+    </aol-overlay>
+
+    <aol-interaction-default></aol-interaction-default>
+    <aol-control-scaleline></aol-control-scaleline>
+    <aol-control-zoom></aol-control-zoom>
+    <aol-control-attribution></aol-control-attribution>
+  </aol-map>
+
+  <aside class="panel demo-panel">
+    <h2>Reactive overlays</h2>
+    <p>Use this page for overlay position, offset, and positioning reactivity.</p>
+
+    <fieldset>
+      <legend>Overlay</legend>
+      <button type="button" (click)="moveOverlay()">Move overlay and feature</button>
+      <button type="button" (click)="resetOverlay()">Reset overlay</button>
+
+      <label for="reactive-overlay-positioning">Positioning</label>
+      <select
+        id="reactive-overlay-positioning"
+        [value]="overlayPositioning()"
+        (change)="setOverlayPositioning($any($event.target).value)"
+      >
+        <option value="bottom-left">Bottom left</option>
+        <option value="top-right">Top right</option>
+        <option value="center-center">Center</option>
+      </select>
+
+      <label for="reactive-offset-x">Offset X: {{ overlayOffset()[0] }}</label>
+      <input
+        id="reactive-offset-x"
+        type="range"
+        min="-60"
+        max="60"
+        [value]="overlayOffset()[0]"
+        (input)="setOffsetX($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-offset-y">Offset Y: {{ overlayOffset()[1] }}</label>
+      <input
+        id="reactive-offset-y"
+        type="range"
+        min="-60"
+        max="60"
+        [value]="overlayOffset()[1]"
+        (input)="setOffsetY($any($event.target).valueAsNumber)"
+      />
+    </fieldset>
+  </aside>
+</div>

--- a/src/app/reactive-overlays/reactive-overlays.less
+++ b/src/app/reactive-overlays/reactive-overlays.less
@@ -1,0 +1,42 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.panel {
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
+}
+
+.panel h2,
+.panel p,
+.panel fieldset,
+.panel label {
+  margin: 0;
+}
+
+.panel fieldset {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.panel label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.panel button,
+.panel select {
+  min-height: 2rem;
+}
+
+.map-callout {
+  padding: 0.45rem 0.65rem;
+  border: 2px solid #0f172a;
+  border-radius: 999px;
+  background: #facc15;
+  color: #0f172a;
+  font-weight: 700;
+  white-space: nowrap;
+}

--- a/src/app/reactive-overlays/reactive-overlays.spec.ts
+++ b/src/app/reactive-overlays/reactive-overlays.spec.ts
@@ -1,0 +1,24 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReactiveOverlays } from './reactive-overlays';
+
+describe('ReactiveOverlays', () => {
+  let component: ReactiveOverlays;
+  let fixture: ComponentFixture<ReactiveOverlays>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveOverlays],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReactiveOverlays);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/reactive-overlays/reactive-overlays.ts
+++ b/src/app/reactive-overlays/reactive-overlays.ts
@@ -1,0 +1,40 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { AngularOpenlayersModule } from 'ngx-ol';
+import type { Coordinate } from 'ol/coordinate';
+import type { Positioning } from 'ol/Overlay';
+import { transform } from 'ol/proj';
+
+@Component({
+  selector: 'app-reactive-overlays',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AngularOpenlayersModule],
+  templateUrl: './reactive-overlays.html',
+  styleUrl: './reactive-overlays.less',
+})
+export class ReactiveOverlays {
+  readonly center = signal<Coordinate>(transform([-3.2, 54.8], 'EPSG:4326', 'EPSG:3857'));
+  readonly zoom = signal(6);
+  readonly marker = signal<Coordinate>(transform([-5.35, 56.05], 'EPSG:4326', 'EPSG:3857'));
+  readonly overlayOffset = signal<[number, number]>([14, -18]);
+  readonly overlayPositioning = signal<Positioning>('bottom-left');
+
+  protected setOverlayPositioning(positioning: Positioning): void {
+    this.overlayPositioning.set(positioning);
+  }
+
+  protected moveOverlay(): void {
+    this.marker.update((coordinate) => [coordinate[0] + 120000, coordinate[1] + 55000]);
+  }
+
+  protected resetOverlay(): void {
+    this.marker.set(transform([-5.35, 56.05], 'EPSG:4326', 'EPSG:3857'));
+  }
+
+  protected setOffsetX(offsetX: number): void {
+    this.overlayOffset.update((offset) => [offsetX, offset[1]]);
+  }
+
+  protected setOffsetY(offsetY: number): void {
+    this.overlayOffset.update((offset) => [offset[0], offsetY]);
+  }
+}

--- a/src/app/reactive-sources/reactive-sources.html
+++ b/src/app/reactive-sources/reactive-sources.html
@@ -1,0 +1,233 @@
+<div class="layout demo-layout">
+  <aol-map class="map demo-map">
+    <aol-view [zoom]="zoom()" [center]="center()"></aol-view>
+
+    @switch (sourceKind()) {
+      @case ('tile-wms') {
+        <aol-layer-tile>
+          <aol-source-tilewms
+            url="https://ahocevar.com/geoserver/wms"
+            [params]="localWmsParams()"
+            serverType="geoserver"
+            crossOrigin=""
+          ></aol-source-tilewms>
+        </aol-layer-tile>
+      }
+      @case ('vector') {
+        <aol-layer-vector>
+          <aol-source-vector [features]="features()"></aol-source-vector>
+          <aol-style>
+            <aol-style-circle [radius]="8">
+              <aol-style-stroke color="#111827" [width]="2"></aol-style-stroke>
+              <aol-style-fill color="#f97316"></aol-style-fill>
+            </aol-style-circle>
+          </aol-style>
+        </aol-layer-vector>
+      }
+      @case ('image-wms') {
+        <aol-layer-image [extent]="imageExtent()">
+          <aol-source-imagewms
+            url="https://gis.epa.ie/geoserver/EPA/wms"
+            serverType="geoserver"
+            [params]="epaWmsParams()"
+            [ratio]="wmsRatio()"
+            (imageLoadStart)="imageLoadStart()"
+            (imageLoadEnd)="imageLoadEnd()"
+            (imageLoadError)="imageLoadError()"
+          ></aol-source-imagewms>
+        </aol-layer-image>
+      }
+      @case ('image-arcgis') {
+        <aol-layer-image>
+          <aol-source-imagearcgisrest
+            url="https://sampleserver6.arcgisonline.com/ArcGIS/rest/services/USA/MapServer"
+            [params]="arcgisParams()"
+            [hidpi]="arcgisHidpi()"
+            (imageLoadStart)="imageLoadStart()"
+            (imageLoadEnd)="imageLoadEnd()"
+            (imageLoadError)="imageLoadError()"
+          ></aol-source-imagearcgisrest>
+        </aol-layer-image>
+      }
+      @case ('tile-arcgis') {
+        <aol-layer-tile>
+          <aol-source-tilearcgisrest
+            url="https://sampleserver6.arcgisonline.com/ArcGIS/rest/services/USA/MapServer"
+            [params]="arcgisParams()"
+            [hidpi]="arcgisHidpi()"
+          ></aol-source-tilearcgisrest>
+        </aol-layer-tile>
+      }
+      @case ('tile-json') {
+        <aol-layer-tile>
+          <aol-source-tilejson [url]="tileJsonUrl"></aol-source-tilejson>
+        </aol-layer-tile>
+      }
+      @case ('wmts') {
+        <aol-layer-tile>
+          <aol-source-tilewmts
+            layer="MODIS_Terra_CorrectedReflectance_TrueColor"
+            [style]="'default'"
+            matrixSet="GoogleMapsCompatible_Level9"
+            format="image/jpeg"
+            [url]="wmtsUrl"
+            [dimensions]="wmtsDimensions()"
+            (tileLoadStart)="tileLoadStart()"
+            (tileLoadEnd)="tileLoadEnd()"
+            (tileLoadError)="tileLoadError()"
+          >
+            <aol-tilegrid-wmts
+              [origin]="[-20037508.342789244, 20037508.342789244]"
+              [resolutions]="wmtsResolutions"
+              [matrixIds]="wmtsMatrixIds"
+              [tileSize]="256"
+            ></aol-tilegrid-wmts>
+          </aol-source-tilewmts>
+        </aol-layer-tile>
+      }
+    }
+
+    <aol-interaction-default></aol-interaction-default>
+    <aol-control-scaleline></aol-control-scaleline>
+    <aol-control-zoom></aol-control-zoom>
+    <aol-control-attribution></aol-control-attribution>
+  </aol-map>
+
+  <aside class="panel demo-panel">
+    <h2>Reactive sources</h2>
+    <p>
+      Use this page for source-only reactivity: live setters, source reloads, and source-specific
+      loading events.
+    </p>
+
+    <fieldset>
+      <legend>Source type</legend>
+      <label for="reactive-source-kind">Source</label>
+      <select
+        id="reactive-source-kind"
+        [value]="sourceKind()"
+        (change)="setSourceKind($any($event.target).value)"
+      >
+        <option value="tile-wms">Tile WMS</option>
+        <option value="vector">Vector features</option>
+        <option value="image-wms">Image WMS</option>
+        <option value="image-arcgis">Image ArcGIS REST</option>
+        <option value="tile-arcgis">Tile ArcGIS REST</option>
+        <option value="tile-json">TileJSON</option>
+        <option value="wmts">WMTS</option>
+      </select>
+      <button type="button" (click)="resetView()">Reset view to source extent</button>
+    </fieldset>
+
+    @if (sourceKind() === 'tile-wms') {
+      <fieldset>
+        <legend>Tile WMS</legend>
+        <label for="reactive-local-wms-layer">Layer</label>
+        <select
+          id="reactive-local-wms-layer"
+          [value]="localWmsLayer()"
+          (change)="setLocalWmsLayer($any($event.target).value)"
+        >
+          <option value="topp:states">US states</option>
+          <option value="ne:ne">Natural Earth</option>
+        </select>
+      </fieldset>
+    }
+
+    @if (sourceKind() === 'vector') {
+      <fieldset>
+        <legend>Vector source</legend>
+        <label for="reactive-feature-count">Features: {{ featureCount() }}</label>
+        <input
+          id="reactive-feature-count"
+          type="range"
+          min="1"
+          max="6"
+          [value]="featureCount()"
+          (input)="setFeatureCount($any($event.target).valueAsNumber)"
+        />
+      </fieldset>
+    }
+
+    @if (sourceKind() === 'image-wms') {
+      <fieldset>
+        <legend>Image WMS</legend>
+        <label for="reactive-epa-wms-layer">Layer</label>
+        <select
+          id="reactive-epa-wms-layer"
+          [value]="epaWmsLayer()"
+          (change)="setEpaWmsLayer($any($event.target).value)"
+        >
+          <option value="EPA:ADMIN_County">County boundaries</option>
+          <option value="EPA:WFD_Catchments">WFD catchments</option>
+        </select>
+
+        <label for="reactive-wms-ratio">Image ratio: {{ wmsRatio() }}</label>
+        <input
+          id="reactive-wms-ratio"
+          type="range"
+          min="1"
+          max="2"
+          step="0.1"
+          [value]="wmsRatio()"
+          (input)="setWmsRatio($any($event.target).valueAsNumber)"
+        />
+      </fieldset>
+    }
+
+    @if (sourceKind() === 'image-arcgis' || sourceKind() === 'tile-arcgis') {
+      <fieldset>
+        <legend>ArcGIS REST</legend>
+        <label for="reactive-arcgis-layer">Layer id</label>
+        <select
+          id="reactive-arcgis-layer"
+          [value]="arcgisLayer()"
+          (change)="setArcgisLayer($any($event.target).value)"
+        >
+          <option value="0">Cities</option>
+          <option value="2">States</option>
+          <option value="3">Counties</option>
+        </select>
+        <label>
+          <input type="checkbox" [checked]="arcgisHidpi()" (change)="toggleArcgisHidpi()" />
+          HiDPI rendering
+        </label>
+      </fieldset>
+    }
+
+    @if (sourceKind() === 'tile-json') {
+      <fieldset>
+        <legend>TileJSON</legend>
+        <p class="hint">TileJSON is loaded from {{ tileJsonUrl }}.</p>
+        <p class="hint">
+          The metadata URL is constructor-only in this wrapper because OpenLayers does not expose a
+          clear setter for reloading TileJSON metadata.
+        </p>
+      </fieldset>
+    }
+
+    @if (sourceKind() === 'wmts') {
+      <fieldset>
+        <legend>WMTS</legend>
+        <label for="reactive-wmts-time">Time dimension</label>
+        <select
+          id="reactive-wmts-time"
+          [value]="wmtsTime()"
+          (change)="setWmtsTime($any($event.target).value)"
+        >
+          <option value="2024-01-01">2024-01-01</option>
+          <option value="2024-06-01">2024-06-01</option>
+          <option value="2024-09-01">2024-09-01</option>
+        </select>
+        <p class="hint">
+          Uses NASA GIBS true-colour imagery so the <code>TIME</code> dimension has a visible
+          effect.
+        </p>
+      </fieldset>
+    }
+
+    <section class="status" aria-live="polite">
+      <p>{{ sourceStatus() }}</p>
+    </section>
+  </aside>
+</div>

--- a/src/app/reactive-sources/reactive-sources.less
+++ b/src/app/reactive-sources/reactive-sources.less
@@ -1,0 +1,48 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.panel {
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
+}
+
+.panel h2,
+.panel p,
+.panel fieldset,
+.panel label {
+  margin: 0;
+}
+
+.panel fieldset {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.panel label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.panel fieldset label {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.panel button,
+.panel select {
+  min-height: 2rem;
+}
+
+.status {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  border-radius: 0.8rem;
+  background: rgb(15 23 42 / 0.08);
+  color: #334155;
+  font-size: 0.9rem;
+}

--- a/src/app/reactive-sources/reactive-sources.spec.ts
+++ b/src/app/reactive-sources/reactive-sources.spec.ts
@@ -1,0 +1,24 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReactiveSources } from './reactive-sources';
+
+describe('ReactiveSources', () => {
+  let component: ReactiveSources;
+  let fixture: ComponentFixture<ReactiveSources>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveSources],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReactiveSources);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/reactive-sources/reactive-sources.ts
+++ b/src/app/reactive-sources/reactive-sources.ts
@@ -1,0 +1,208 @@
+import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
+import { AngularOpenlayersModule } from 'ngx-ol';
+import Feature from 'ol/Feature';
+import type { Coordinate } from 'ol/coordinate';
+import type { Extent } from 'ol/extent';
+import Point from 'ol/geom/Point';
+import { transform } from 'ol/proj';
+
+type SourceKind =
+  | 'tile-wms'
+  | 'vector'
+  | 'image-wms'
+  | 'image-arcgis'
+  | 'tile-arcgis'
+  | 'tile-json'
+  | 'wmts';
+type LocalWmsLayer = 'topp:states' | 'ne:ne';
+type EpaWmsLayer = 'EPA:ADMIN_County' | 'EPA:WFD_Catchments';
+type ArcgisLayer = '0' | '2' | '3';
+
+const FEATURE_COORDINATES: readonly [number, number][] = [
+  [-122.4194, 37.7749],
+  [-118.2437, 34.0522],
+  [-112.074, 33.4484],
+  [-104.9903, 39.7392],
+  [-96.797, 32.7767],
+  [-87.6298, 41.8781],
+];
+
+const SOURCE_VIEWS: Record<SourceKind, { center: Coordinate; zoom: number }> = {
+  'tile-wms': {
+    center: transform([-99, 39], 'EPSG:4326', 'EPSG:3857'),
+    zoom: 4,
+  },
+  vector: {
+    center: transform([-99, 39], 'EPSG:4326', 'EPSG:3857'),
+    zoom: 4,
+  },
+  'image-wms': {
+    center: transform([-4.8, 53.4], 'EPSG:4326', 'EPSG:3857'),
+    zoom: 6,
+  },
+  'image-arcgis': {
+    center: transform([-98, 39], 'EPSG:4326', 'EPSG:3857'),
+    zoom: 4,
+  },
+  'tile-arcgis': {
+    center: transform([-98, 39], 'EPSG:4326', 'EPSG:3857'),
+    zoom: 4,
+  },
+  'tile-json': {
+    center: transform([-2.269282, 46.987247], 'EPSG:4326', 'EPSG:3857'),
+    zoom: 3,
+  },
+  wmts: {
+    center: transform([-5.3, 51.7], 'EPSG:4326', 'EPSG:3857'),
+    zoom: 5.75,
+  },
+};
+
+@Component({
+  selector: 'app-reactive-sources',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AngularOpenlayersModule],
+  templateUrl: './reactive-sources.html',
+  styleUrl: './reactive-sources.less',
+})
+export class ReactiveSources {
+  readonly center = signal<Coordinate>(SOURCE_VIEWS['tile-wms'].center);
+  readonly zoom = signal(SOURCE_VIEWS['tile-wms'].zoom);
+  readonly sourceKind = signal<SourceKind>('tile-wms');
+  readonly localWmsLayer = signal<LocalWmsLayer>('topp:states');
+  readonly epaWmsLayer = signal<EpaWmsLayer>('EPA:ADMIN_County');
+  readonly wmsRatio = signal(1);
+  readonly arcgisLayer = signal<ArcgisLayer>('2');
+  readonly arcgisHidpi = signal(true);
+  readonly tileJsonUrl = 'tile-json/carto-light.json';
+  readonly wmtsTime = signal('2024-01-01');
+  readonly wmtsUrl = 'https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/wmts.cgi';
+  readonly featureCount = signal(3);
+  readonly sourceStatus = signal('Tile WMS source selected. Change params and watch the map update.');
+  readonly imageExtent = signal<Extent>([-1250000, 6250000, 500000, 7600000]);
+  readonly localWmsParams = computed(() => ({
+    FORMAT: 'image/png',
+    LAYERS: this.localWmsLayer(),
+    TRANSPARENT: true,
+  }));
+  readonly epaWmsParams = computed(() => ({ LAYERS: this.epaWmsLayer() }));
+  readonly arcgisParams = computed(() => ({ LAYERS: `show:${this.arcgisLayer()}` }));
+  readonly wmtsDimensions = computed(() => ({ TIME: this.wmtsTime() }));
+  readonly features = computed(() =>
+    FEATURE_COORDINATES.slice(0, this.featureCount()).map(
+      (coordinate, index) =>
+        new Feature({
+          geometry: new Point(transform(coordinate, 'EPSG:4326', 'EPSG:3857')),
+          name: `Reactive point ${index + 1}`,
+        }),
+    ),
+  );
+  readonly wmtsMatrixIds = Array.from({ length: 10 }, (_, index) => index.toString());
+  readonly wmtsResolutions = [
+    156543.03392804097,
+    78271.51696402048,
+    39135.75848201024,
+    19567.87924100512,
+    9783.93962050256,
+    4891.96981025128,
+    2445.98490512564,
+    1222.99245256282,
+    611.49622628141,
+    305.748113140705,
+  ];
+
+  protected setSourceKind(sourceKind: SourceKind): void {
+    this.sourceKind.set(sourceKind);
+    this.setView(sourceKind);
+    this.sourceStatus.set(this.getSourceStatus(sourceKind));
+  }
+
+  protected resetView(): void {
+    this.setView(this.sourceKind());
+  }
+
+  protected setLocalWmsLayer(layer: LocalWmsLayer): void {
+    this.localWmsLayer.set(layer);
+    this.sourceStatus.set(`Tile WMS params changed to ${layer}.`);
+  }
+
+  protected setEpaWmsLayer(layer: EpaWmsLayer): void {
+    this.epaWmsLayer.set(layer);
+    this.sourceStatus.set(`Image WMS params changed to ${layer}.`);
+  }
+
+  protected setWmsRatio(ratio: number): void {
+    this.wmsRatio.set(ratio);
+    this.sourceStatus.set(`Image WMS ratio changed to ${ratio}.`);
+  }
+
+  protected setFeatureCount(count: number): void {
+    this.featureCount.set(count);
+    this.sourceStatus.set(`Vector source now has ${count} features.`);
+  }
+
+  protected setArcgisLayer(layer: ArcgisLayer): void {
+    this.arcgisLayer.set(layer);
+    this.sourceStatus.set(`ArcGIS layer params changed to show:${layer}.`);
+  }
+
+  protected toggleArcgisHidpi(): void {
+    this.arcgisHidpi.update((hidpi) => !hidpi);
+    this.sourceStatus.set(`ArcGIS HiDPI rendering ${this.arcgisHidpi() ? 'enabled' : 'disabled'}.`);
+  }
+
+  protected setWmtsTime(time: string): void {
+    this.wmtsTime.set(time);
+    this.sourceStatus.set(`WMTS TIME dimension changed to ${time}.`);
+  }
+
+  protected imageLoadStart(): void {
+    this.sourceStatus.set('Loading image...');
+  }
+
+  protected imageLoadEnd(): void {
+    this.sourceStatus.set(`Image loaded at ${new Date().toLocaleTimeString()}`);
+  }
+
+  protected imageLoadError(): void {
+    this.sourceStatus.set(`Image load error at ${new Date().toLocaleTimeString()}`);
+  }
+
+  protected tileLoadStart(): void {
+    this.sourceStatus.set('Loading tiles...');
+  }
+
+  protected tileLoadEnd(): void {
+    this.sourceStatus.set(`Tiles loaded at ${new Date().toLocaleTimeString()}`);
+  }
+
+  protected tileLoadError(): void {
+    this.sourceStatus.set(`Tile load error at ${new Date().toLocaleTimeString()}`);
+  }
+
+  private setView(sourceKind: SourceKind): void {
+    const view = SOURCE_VIEWS[sourceKind];
+
+    this.center.set(view.center);
+    this.zoom.set(view.zoom);
+  }
+
+  private getSourceStatus(sourceKind: SourceKind): string {
+    switch (sourceKind) {
+      case 'tile-wms':
+        return 'Tile WMS source selected. Change params and watch the map update.';
+      case 'vector':
+        return `Vector source selected with ${this.featureCount()} features.`;
+      case 'image-wms':
+        return 'Image WMS source selected. Image load events will update this status.';
+      case 'image-arcgis':
+        return 'Image ArcGIS REST source selected. Image load events will update this status.';
+      case 'tile-arcgis':
+        return 'Tile ArcGIS REST source selected. Change params and watch the map update.';
+      case 'tile-json':
+        return `TileJSON source selected: ${this.tileJsonUrl}`;
+      case 'wmts':
+        return 'WMTS source selected. Tile load events will update this status.';
+    }
+  }
+}

--- a/src/app/reactive-styles/reactive-styles.html
+++ b/src/app/reactive-styles/reactive-styles.html
@@ -1,0 +1,244 @@
+<div class="layout demo-layout">
+  <aol-map class="map demo-map">
+    <aol-view [zoom]="zoom()" [center]="center()"></aol-view>
+
+    <aol-layer-tile>
+      <aol-source-osm></aol-source-osm>
+    </aol-layer-tile>
+
+    <aol-layer-vector>
+      <aol-source-vector>
+        <aol-feature>
+          <aol-geometry-point>
+            <aol-coordinate [x]="point()[0]" [y]="point()[1]" srid="EPSG:4326"></aol-coordinate>
+          </aol-geometry-point>
+          <aol-style>
+            <aol-style-circle
+              [radius]="markerRadius()"
+              [rotation]="markerRotation()"
+              [rotateWithView]="true"
+            >
+              <aol-style-stroke color="#0f172a" [width]="2"></aol-style-stroke>
+              <aol-style-fill color="#fde047"></aol-style-fill>
+            </aol-style-circle>
+            <aol-style-text
+              [text]="labelText()"
+              [scale]="labelScale()"
+              [offsetY]="labelOffsetY()"
+              [rotation]="labelRotation()"
+              [placement]="labelPlacement()"
+              textAlign="center"
+              textBaseline="middle"
+            >
+              <aol-style-fill color="#111827"></aol-style-fill>
+              <aol-style-stroke color="#ffffff" [width]="4"></aol-style-stroke>
+            </aol-style-text>
+          </aol-style>
+        </aol-feature>
+
+        <aol-feature>
+          <aol-geometry-linestring>
+            <aol-collection-coordinates [coordinates]="line()" srid="EPSG:4326">
+            </aol-collection-coordinates>
+          </aol-geometry-linestring>
+          <aol-style>
+            <aol-style-stroke
+              color="#f97316"
+              [width]="strokeWidth()"
+              [lineDash]="strokeDashPattern()"
+              lineCap="round"
+              lineJoin="round"
+            ></aol-style-stroke>
+          </aol-style>
+        </aol-feature>
+
+        <aol-feature>
+          <aol-geometry-polygon>
+            <aol-collection-coordinates [coordinates]="polygon()" srid="EPSG:4326">
+            </aol-collection-coordinates>
+          </aol-geometry-polygon>
+          <aol-style>
+            <aol-style-stroke color="#0369a1" [width]="strokeWidth()"></aol-style-stroke>
+            <aol-style-fill [color]="fillColor()"></aol-style-fill>
+          </aol-style>
+        </aol-feature>
+
+        <aol-feature>
+          <aol-geometry-circle [radius]="circleRadius()">
+            <aol-coordinate [x]="-2.6" [y]="53.3" srid="EPSG:4326"></aol-coordinate>
+          </aol-geometry-circle>
+          <aol-style>
+            <aol-style-stroke color="#16a34a" [width]="strokeWidth()"></aol-style-stroke>
+            <aol-style-fill color="rgb(22 163 74 / 0.18)"></aol-style-fill>
+          </aol-style>
+        </aol-feature>
+      </aol-source-vector>
+    </aol-layer-vector>
+
+    <aol-interaction-default></aol-interaction-default>
+    <aol-control-scaleline></aol-control-scaleline>
+    <aol-control-zoom></aol-control-zoom>
+    <aol-control-attribution></aol-control-attribution>
+  </aol-map>
+
+  <aside class="panel demo-panel">
+    <h2>Reactive styles and geometry</h2>
+    <p>Change geometry coordinates and style properties without replacing template components.</p>
+
+    <fieldset>
+      <legend>Point geometry</legend>
+      <label for="reactive-point-lon">Longitude: {{ point()[0] }}</label>
+      <input
+        id="reactive-point-lon"
+        type="range"
+        min="-7"
+        max="-1"
+        step="0.1"
+        [value]="point()[0]"
+        (input)="setPointLongitude($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-point-lat">Latitude: {{ point()[1] }}</label>
+      <input
+        id="reactive-point-lat"
+        type="range"
+        min="52"
+        max="56"
+        step="0.1"
+        [value]="point()[1]"
+        (input)="setPointLatitude($any($event.target).valueAsNumber)"
+      />
+    </fieldset>
+
+    <fieldset>
+      <legend>Shape geometry</legend>
+      <label for="reactive-polygon-offset">Polygon offset: {{ polygonOffset() }}</label>
+      <input
+        id="reactive-polygon-offset"
+        type="range"
+        min="-1"
+        max="1"
+        step="0.05"
+        [value]="polygonOffset()"
+        (input)="setPolygonOffset($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-circle-radius">Circle radius: {{ circleRadius() }}</label>
+      <input
+        id="reactive-circle-radius"
+        type="range"
+        min="50000"
+        max="350000"
+        step="10000"
+        [value]="circleRadius()"
+        (input)="setCircleRadius($any($event.target).valueAsNumber)"
+      />
+    </fieldset>
+
+    <fieldset>
+      <legend>Marker style</legend>
+      <label for="reactive-marker-radius">Radius: {{ markerRadius() }}</label>
+      <input
+        id="reactive-marker-radius"
+        type="range"
+        min="4"
+        max="24"
+        [value]="markerRadius()"
+        (input)="setMarkerRadius($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-marker-rotation">Rotation: {{ markerRotation() }}</label>
+      <input
+        id="reactive-marker-rotation"
+        type="range"
+        min="0"
+        max="6.28"
+        step="0.1"
+        [value]="markerRotation()"
+        (input)="setMarkerRotation($any($event.target).valueAsNumber)"
+      />
+    </fieldset>
+
+    <fieldset>
+      <legend>Stroke and fill</legend>
+      <label>
+        <input type="checkbox" [checked]="strokeDash()" (change)="toggleStrokeDash()" />
+        Dashed line
+      </label>
+
+      <label for="reactive-stroke-width">Stroke width: {{ strokeWidth() }}</label>
+      <input
+        id="reactive-stroke-width"
+        type="range"
+        min="1"
+        max="12"
+        [value]="strokeWidth()"
+        (input)="setStrokeWidth($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-fill-opacity">Fill opacity: {{ fillOpacity() }}</label>
+      <input
+        id="reactive-fill-opacity"
+        type="range"
+        min="0"
+        max="0.8"
+        step="0.02"
+        [value]="fillOpacity()"
+        (input)="setFillOpacity($any($event.target).valueAsNumber)"
+      />
+    </fieldset>
+
+    <fieldset>
+      <legend>Text style</legend>
+      <label for="reactive-label-text">Label text</label>
+      <input
+        id="reactive-label-text"
+        type="text"
+        [value]="labelText()"
+        (input)="setLabelText($any($event.target).value)"
+      />
+
+      <label for="reactive-label-placement">Placement</label>
+      <select
+        id="reactive-label-placement"
+        [value]="labelPlacement()"
+        (change)="setLabelPlacement($any($event.target).value)"
+      >
+        <option value="point">Point</option>
+        <option value="line">Line</option>
+      </select>
+
+      <label for="reactive-label-scale">Scale: {{ labelScale() }}</label>
+      <input
+        id="reactive-label-scale"
+        type="range"
+        min="0.6"
+        max="3"
+        step="0.1"
+        [value]="labelScale()"
+        (input)="setLabelScale($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-label-offset">Offset Y: {{ labelOffsetY() }}</label>
+      <input
+        id="reactive-label-offset"
+        type="range"
+        min="-60"
+        max="60"
+        [value]="labelOffsetY()"
+        (input)="setLabelOffsetY($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-label-rotation">Rotation: {{ labelRotation() }}</label>
+      <input
+        id="reactive-label-rotation"
+        type="range"
+        min="-3.14"
+        max="3.14"
+        step="0.1"
+        [value]="labelRotation()"
+        (input)="setLabelRotation($any($event.target).valueAsNumber)"
+      />
+    </fieldset>
+  </aside>
+</div>

--- a/src/app/reactive-styles/reactive-styles.less
+++ b/src/app/reactive-styles/reactive-styles.less
@@ -1,0 +1,33 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.panel {
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
+}
+
+.panel h2,
+.panel p,
+.panel fieldset,
+.panel label {
+  margin: 0;
+}
+
+.panel fieldset {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.panel label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.panel fieldset label:has(input[type='checkbox']) {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}

--- a/src/app/reactive-styles/reactive-styles.spec.ts
+++ b/src/app/reactive-styles/reactive-styles.spec.ts
@@ -1,0 +1,24 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReactiveStyles } from './reactive-styles';
+
+describe('ReactiveStyles', () => {
+  let component: ReactiveStyles;
+  let fixture: ComponentFixture<ReactiveStyles>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveStyles],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReactiveStyles);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/reactive-styles/reactive-styles.ts
+++ b/src/app/reactive-styles/reactive-styles.ts
@@ -1,0 +1,106 @@
+import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
+import { AngularOpenlayersModule } from 'ngx-ol';
+import type { Coordinate } from 'ol/coordinate';
+import { transform } from 'ol/proj';
+
+@Component({
+  selector: 'app-reactive-styles',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AngularOpenlayersModule],
+  templateUrl: './reactive-styles.html',
+  styleUrl: './reactive-styles.less',
+})
+export class ReactiveStyles {
+  readonly center = signal<Coordinate>(transform([-4, 53.7], 'EPSG:4326', 'EPSG:3857'));
+  readonly zoom = signal(6);
+  readonly point = signal<[number, number]>([-4.2, 54.4]);
+  readonly line = signal([
+    [-6.4, 52.8],
+    [-4.1, 53.7],
+    [-1.7, 55],
+  ]);
+  readonly polygonOffset = signal(0);
+  readonly circleRadius = signal(150000);
+  readonly markerRadius = signal(10);
+  readonly markerRotation = signal(0);
+  readonly strokeWidth = signal(3);
+  readonly strokeDash = signal(false);
+  readonly fillOpacity = signal(0.28);
+  readonly labelText = signal('Reactive style');
+  readonly labelScale = signal(1.2);
+  readonly labelOffsetY = signal(-22);
+  readonly labelRotation = signal(0);
+  readonly labelPlacement = signal<'point' | 'line'>('point');
+
+  readonly polygon = computed(() => {
+    const offset = this.polygonOffset();
+
+    return [
+      [
+        [-5.8 + offset, 53.1],
+        [-3.4 + offset, 52.7],
+        [-2.6 + offset, 54.2],
+        [-4.6 + offset, 55.1],
+        [-5.8 + offset, 53.1],
+      ],
+    ];
+  });
+  readonly strokeDashPattern = computed(() => (this.strokeDash() ? [12, 8] : undefined));
+  readonly fillColor = computed(() => `rgb(14 165 233 / ${this.fillOpacity()})`);
+
+  protected setPointLongitude(longitude: number): void {
+    this.point.update((point) => [longitude, point[1]]);
+  }
+
+  protected setPointLatitude(latitude: number): void {
+    this.point.update((point) => [point[0], latitude]);
+  }
+
+  protected setPolygonOffset(offset: number): void {
+    this.polygonOffset.set(offset);
+  }
+
+  protected setCircleRadius(radius: number): void {
+    this.circleRadius.set(radius);
+  }
+
+  protected setMarkerRadius(radius: number): void {
+    this.markerRadius.set(radius);
+  }
+
+  protected setMarkerRotation(rotation: number): void {
+    this.markerRotation.set(rotation);
+  }
+
+  protected setStrokeWidth(width: number): void {
+    this.strokeWidth.set(width);
+  }
+
+  protected toggleStrokeDash(): void {
+    this.strokeDash.update((enabled) => !enabled);
+  }
+
+  protected setFillOpacity(opacity: number): void {
+    this.fillOpacity.set(opacity);
+  }
+
+  protected setLabelText(text: string): void {
+    this.labelText.set(text);
+  }
+
+  protected setLabelScale(scale: number): void {
+    this.labelScale.set(scale);
+  }
+
+  protected setLabelOffsetY(offset: number): void {
+    this.labelOffsetY.set(offset);
+  }
+
+  protected setLabelRotation(rotation: number): void {
+    this.labelRotation.set(rotation);
+  }
+
+  protected setLabelPlacement(placement: 'point' | 'line'): void {
+    this.labelPlacement.set(placement);
+  }
+}

--- a/src/app/reactive-view-layers/reactive-view-layers.html
+++ b/src/app/reactive-view-layers/reactive-view-layers.html
@@ -1,0 +1,201 @@
+<div class="layout demo-layout">
+  <aol-map class="map demo-map">
+    <aol-view
+      [zoom]="zoom()"
+      [center]="center()"
+      [rotation]="rotation()"
+      [minZoom]="minZoom()"
+      [maxZoom]="maxZoom()"
+      [constrainResolution]="false"
+    ></aol-view>
+
+    <aol-layer-tile>
+      <aol-source-osm></aol-source-osm>
+    </aol-layer-tile>
+
+    <aol-layer-vector
+      [opacity]="layerOpacity()"
+      [visible]="layerVisible()"
+      [zIndex]="layerZIndex()"
+      [minZoom]="layerMinZoom()"
+      [maxZoom]="layerMaxZoom()"
+      [extent]="layerExtent()"
+    >
+      <aol-source-vector [features]="features()"></aol-source-vector>
+      <aol-style>
+        <aol-style-circle [radius]="7">
+          <aol-style-stroke color="#0f172a" [width]="2"></aol-style-stroke>
+          <aol-style-fill color="#f8fafc"></aol-style-fill>
+        </aol-style-circle>
+      </aol-style>
+    </aol-layer-vector>
+
+    <aol-layer-heatmap
+      [opacity]="heatmapOpacity()"
+      [visible]="heatmapVisible()"
+      [blur]="heatmapBlur()"
+      [radius]="heatmapRadius()"
+    >
+      <aol-source-vector [features]="features()"></aol-source-vector>
+    </aol-layer-heatmap>
+
+    <aol-interaction-default></aol-interaction-default>
+    <aol-control-scaleline></aol-control-scaleline>
+    <aol-control-zoom></aol-control-zoom>
+    <aol-control-attribution></aol-control-attribution>
+  </aol-map>
+
+  <aside class="panel demo-panel">
+    <h2>Reactive layers</h2>
+    <p>Use this page to change view constraints and layer properties without recreating layers.</p>
+
+    <fieldset>
+      <legend>View</legend>
+      <label for="reactive-view-zoom">Zoom: {{ zoom() }}</label>
+      <input
+        id="reactive-view-zoom"
+        type="range"
+        min="3"
+        max="12"
+        step="0.25"
+        [value]="zoom()"
+        (input)="setZoom($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-view-rotation">Rotation: {{ rotation() }}</label>
+      <input
+        id="reactive-view-rotation"
+        type="range"
+        min="-3.14"
+        max="3.14"
+        step="0.05"
+        [value]="rotation()"
+        (input)="setRotation($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-view-min-zoom">Min zoom: {{ minZoom() }}</label>
+      <input
+        id="reactive-view-min-zoom"
+        type="range"
+        min="1"
+        max="6"
+        [value]="minZoom()"
+        (input)="setMinZoom($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-view-max-zoom">Max zoom: {{ maxZoom() }}</label>
+      <input
+        id="reactive-view-max-zoom"
+        type="range"
+        min="8"
+        max="18"
+        [value]="maxZoom()"
+        (input)="setMaxZoom($any($event.target).valueAsNumber)"
+      />
+    </fieldset>
+
+    <fieldset>
+      <legend>Vector layer</legend>
+      <label>
+        <input
+          type="checkbox"
+          [checked]="layerVisible()"
+          (change)="setLayerVisible($any($event.target).checked)"
+        />
+        Visible
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          [checked]="layerExtentEnabled()"
+          (change)="toggleLayerExtent()"
+        />
+        Restrict to extent
+      </label>
+
+      <label for="reactive-layer-opacity">Opacity: {{ layerOpacity() }}</label>
+      <input
+        id="reactive-layer-opacity"
+        type="range"
+        min="0"
+        max="1"
+        step="0.05"
+        [value]="layerOpacity()"
+        (input)="setLayerOpacity($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-layer-z">Z index: {{ layerZIndex() }}</label>
+      <input
+        id="reactive-layer-z"
+        type="range"
+        min="0"
+        max="5"
+        [value]="layerZIndex()"
+        (input)="setLayerZIndex($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-layer-min-zoom">Min zoom: {{ layerMinZoom() }}</label>
+      <input
+        id="reactive-layer-min-zoom"
+        type="range"
+        min="1"
+        max="8"
+        [value]="layerMinZoom()"
+        (input)="setLayerMinZoom($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-layer-max-zoom">Max zoom: {{ layerMaxZoom() }}</label>
+      <input
+        id="reactive-layer-max-zoom"
+        type="range"
+        min="8"
+        max="18"
+        [value]="layerMaxZoom()"
+        (input)="setLayerMaxZoom($any($event.target).valueAsNumber)"
+      />
+    </fieldset>
+
+    <fieldset>
+      <legend>Heatmap layer</legend>
+      <label>
+        <input
+          type="checkbox"
+          [checked]="heatmapVisible()"
+          (change)="setHeatmapVisible($any($event.target).checked)"
+        />
+        Visible
+      </label>
+
+      <label for="reactive-heatmap-opacity">Opacity: {{ heatmapOpacity() }}</label>
+      <input
+        id="reactive-heatmap-opacity"
+        type="range"
+        min="0"
+        max="1"
+        step="0.05"
+        [value]="heatmapOpacity()"
+        (input)="setHeatmapOpacity($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-heatmap-blur">Blur: {{ heatmapBlur() }}</label>
+      <input
+        id="reactive-heatmap-blur"
+        type="range"
+        min="1"
+        max="40"
+        [value]="heatmapBlur()"
+        (input)="setHeatmapBlur($any($event.target).valueAsNumber)"
+      />
+
+      <label for="reactive-heatmap-radius">Radius: {{ heatmapRadius() }}</label>
+      <input
+        id="reactive-heatmap-radius"
+        type="range"
+        min="2"
+        max="30"
+        [value]="heatmapRadius()"
+        (input)="setHeatmapRadius($any($event.target).valueAsNumber)"
+      />
+    </fieldset>
+  </aside>
+</div>

--- a/src/app/reactive-view-layers/reactive-view-layers.less
+++ b/src/app/reactive-view-layers/reactive-view-layers.less
@@ -1,0 +1,37 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.panel {
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
+}
+
+.panel h2,
+.panel p,
+.panel fieldset,
+.panel label {
+  margin: 0;
+}
+
+.panel fieldset {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.panel label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.panel fieldset label:has(input[type='checkbox']) {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.panel button {
+  min-height: 2rem;
+}

--- a/src/app/reactive-view-layers/reactive-view-layers.spec.ts
+++ b/src/app/reactive-view-layers/reactive-view-layers.spec.ts
@@ -1,0 +1,24 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReactiveViewLayers } from './reactive-view-layers';
+
+describe('ReactiveViewLayers', () => {
+  let component: ReactiveViewLayers;
+  let fixture: ComponentFixture<ReactiveViewLayers>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveViewLayers],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReactiveViewLayers);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/reactive-view-layers/reactive-view-layers.ts
+++ b/src/app/reactive-view-layers/reactive-view-layers.ts
@@ -1,0 +1,118 @@
+import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
+import { AngularOpenlayersModule } from 'ngx-ol';
+import Feature from 'ol/Feature';
+import type { Coordinate } from 'ol/coordinate';
+import type { Extent } from 'ol/extent';
+import Point from 'ol/geom/Point';
+import { transform } from 'ol/proj';
+
+const POINTS: readonly [number, number, number][] = [
+  [-5.9, 53.3, 0.4],
+  [-4.2, 54.6, 0.7],
+  [-2.1, 53.9, 0.9],
+  [-1.2, 55.4, 0.6],
+  [-6.7, 55.1, 1],
+  [-3.4, 52.7, 0.5],
+];
+
+@Component({
+  selector: 'app-reactive-view-layers',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AngularOpenlayersModule],
+  templateUrl: './reactive-view-layers.html',
+  styleUrl: './reactive-view-layers.less',
+})
+export class ReactiveViewLayers {
+  readonly center = signal<Coordinate>(transform([-3.8, 54.3], 'EPSG:4326', 'EPSG:3857'));
+  readonly zoom = signal(6);
+  readonly rotation = signal(0);
+  readonly minZoom = signal(3);
+  readonly maxZoom = signal(12);
+  readonly layerOpacity = signal(0.85);
+  readonly layerVisible = signal(true);
+  readonly layerZIndex = signal(2);
+  readonly layerMinZoom = signal(3);
+  readonly layerMaxZoom = signal(13);
+  readonly layerExtentEnabled = signal(false);
+  readonly heatmapBlur = signal(18);
+  readonly heatmapRadius = signal(12);
+  readonly heatmapOpacity = signal(0.75);
+  readonly heatmapVisible = signal(true);
+
+  readonly layerExtent = computed<Extent | undefined>(() =>
+    this.layerExtentEnabled() ? transformExtent([-8, 52, 0, 56.4]) : undefined,
+  );
+  readonly features = computed(() =>
+    POINTS.map(([longitude, latitude, weight]) => {
+      const feature = new Feature({
+        geometry: new Point(transform([longitude, latitude], 'EPSG:4326', 'EPSG:3857')),
+      });
+
+      feature.set('weight', weight);
+      return feature;
+    }),
+  );
+
+  protected setZoom(zoom: number): void {
+    this.zoom.set(zoom);
+  }
+
+  protected setRotation(rotation: number): void {
+    this.rotation.set(rotation);
+  }
+
+  protected setMinZoom(minZoom: number): void {
+    this.minZoom.set(minZoom);
+  }
+
+  protected setMaxZoom(maxZoom: number): void {
+    this.maxZoom.set(maxZoom);
+  }
+
+  protected setLayerOpacity(opacity: number): void {
+    this.layerOpacity.set(opacity);
+  }
+
+  protected setLayerVisible(visible: boolean): void {
+    this.layerVisible.set(visible);
+  }
+
+  protected setLayerZIndex(zIndex: number): void {
+    this.layerZIndex.set(zIndex);
+  }
+
+  protected setLayerMinZoom(minZoom: number): void {
+    this.layerMinZoom.set(minZoom);
+  }
+
+  protected setLayerMaxZoom(maxZoom: number): void {
+    this.layerMaxZoom.set(maxZoom);
+  }
+
+  protected toggleLayerExtent(): void {
+    this.layerExtentEnabled.update((enabled) => !enabled);
+  }
+
+  protected setHeatmapBlur(blur: number): void {
+    this.heatmapBlur.set(blur);
+  }
+
+  protected setHeatmapRadius(radius: number): void {
+    this.heatmapRadius.set(radius);
+  }
+
+  protected setHeatmapOpacity(opacity: number): void {
+    this.heatmapOpacity.set(opacity);
+  }
+
+  protected setHeatmapVisible(visible: boolean): void {
+    this.heatmapVisible.set(visible);
+  }
+}
+
+function transformExtent(extent: Extent): Extent {
+  const bottomLeft = transform([extent[0], extent[1]], 'EPSG:4326', 'EPSG:3857');
+  const topRight = transform([extent[2], extent[3]], 'EPSG:4326', 'EPSG:3857');
+
+  return [bottomLeft[0], bottomLeft[1], topRight[0], topRight[1]];
+}

--- a/src/styles.less
+++ b/src/styles.less
@@ -139,6 +139,7 @@ body {
   min-width: 0;
   height: 100%;
   min-height: 24rem;
+  position: relative;
 }
 
 .demo-panel {

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -27,3 +27,17 @@ class WorkerStub {
 globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
 globalThis.PointerEvent ??= MouseEvent as unknown as typeof PointerEvent;
 globalThis.Worker ??= WorkerStub as unknown as typeof Worker;
+
+HTMLCanvasElement.prototype.getContext = (() =>
+  ({
+    canvas: document.createElement('canvas'),
+    createLinearGradient: () => ({
+      addColorStop(): void {},
+    }),
+    fillRect(): void {},
+    clearRect(): void {},
+    drawImage(): void {},
+    getImageData: () => ({
+      data: new Uint8ClampedArray(4),
+    }),
+  }) as unknown as RenderingContext) as typeof HTMLCanvasElement.prototype.getContext;


### PR DESCRIPTION
Modernizes the library with signal-based APIs while keeping OpenLayers instance behavior predictable.

This PR converts Angular inputs, outputs, and queries to signal APIs, adds instanceSignal alongside the existing instance property, and tightens input change handling so supported OpenLayers setters are used instead of unnecessary instance replacement. It also adds reactive demo coverage, documents init-only inputs, and fixes some redraw/update issues.